### PR TITLE
fix(list): keep grid lists stable

### DIFF
--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -36,7 +36,7 @@
 
   {#if items.length > 0}
     <div class="trakt-list-item-container trakt-list-items" use:customAction>
-      {#each items as i (`${items.length}_${i.id}`)}
+      {#each items as i (i.id)}
         {@render item(i)}
       {/each}
     </div>


### PR DESCRIPTION
## ♪ Note ♪

- Grid lists should actually support varying item counts to accommodate lazy loading 🤦

## 👀 Examples 👀

Before:

https://github.com/user-attachments/assets/b6e966d1-38f7-451c-b1cd-0cd238c5ad10

After:

https://github.com/user-attachments/assets/5114a231-4054-43e2-acda-4c1c343b1974

