### PR TITLE
fix(search): place on page search in page component

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Търсене"
+    },
     "dropdown_label_extras": {
       "default": "Екстри"
     },

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Søg"
+    },
     "dropdown_label_extras": {
       "default": "Ekstramateriale"
     },

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Suche"
+    },
     "dropdown_label_extras": {
       "default": "Extras"
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2276,6 +2276,10 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Search",
+      "description": "Title for the search page."
+    },
     "dropdown_label_extras": {
       "default": "Extras",
       "description": "Aria-label for the dropdown that allows users to filter extras by type, such as trailers, featurettes, etc."

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Buscar"
+    },
     "dropdown_label_extras": {
       "default": "Extras"
     },

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Buscar"
+    },
     "dropdown_label_extras": {
       "default": "Extras"
     },

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Recherche"
+    },
     "dropdown_label_extras": {
       "default": "Suppléments"
     },

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Recherche"
+    },
     "dropdown_label_extras": {
       "default": "Suppléments"
     },

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Cerca"
+    },
     "dropdown_label_extras": {
       "default": "Extra"
     },

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "検索"
+    },
     "dropdown_label_extras": {
       "default": "エクストラ"
     },

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Søk"
+    },
     "dropdown_label_extras": {
       "default": "Ekstra"
     },

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Zoeken"
+    },
     "dropdown_label_extras": {
       "default": "Extra's"
     },

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Szukaj"
+    },
     "dropdown_label_extras": {
       "default": "Dodatki"
     },

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Busca"
+    },
     "dropdown_label_extras": {
       "default": "Extras"
     },

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Căutare"
+    },
     "dropdown_label_extras": {
       "default": "Extra"
     },

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Sök"
+    },
     "dropdown_label_extras": {
       "default": "Extramaterial"
     },

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1801,6 +1801,9 @@
         }
       }
     },
+    "page_title_search": {
+      "default": "Пошук"
+    },
     "dropdown_label_extras": {
       "default": "Додаткові матеріали"
     },

--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -42,26 +42,25 @@
   });
 
   const first = $derived($shows.at(0) ?? $movies.at(0));
+  const pageTitle = $derived(
+    query ? m.page_title_search_results({ query }) : m.page_title_search(),
+  );
 </script>
 
-<RenderFor audience="all" device={NAVBAR_CONFIG.side.device}>
-  <div class="trakt-search">
-    <SearchInput isInline={false} />
-  </div>
-</RenderFor>
+<TraktPage audience="all" image={DEFAULT_SHARE_COVER} title={pageTitle}>
+  <RenderFor audience="all" device={NAVBAR_CONFIG.side.device}>
+    <div class="trakt-search-container">
+      <SearchInput isInline={false} />
+    </div>
+  </RenderFor>
 
-{#if query}
-  <TraktPage
-    audience="all"
-    image={DEFAULT_SHARE_COVER}
-    title={m.page_title_search_results({ query })}
-  >
-    {#if first}
-      <CoverImageSetter src={first.cover.url.medium} type={first.type} />
-    {:else}
-      <TraktPageCoverSetter />
-    {/if}
+  {#if first}
+    <CoverImageSetter src={first.cover.url.medium} type={first.type} />
+  {:else}
+    <TraktPageCoverSetter />
+  {/if}
 
+  {#if query}
     <SectionList
       id="search-grid-list-movies"
       title={m.text_search_results_for({
@@ -93,12 +92,12 @@
         </DefaultMediaItem>
       {/snippet}
     </SectionList>
-  </TraktPage>
-{/if}
+  {/if}
+</TraktPage>
 
 <style>
-  .trakt-search {
-    margin: var(--gap-xl) var(--layout-distance-side);
+  .trakt-search-container {
+    margin-left: var(--layout-distance-side);
 
     :global(.trakt-search-icon) {
       z-index: calc(var(--layer-overlay) - 1);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes the alignment of the search input on the search page. It is now within the TraktPage component
- Auto focus still has an issue on iPad; will investigate later, see examples for issue.

## 👀 Examples 👀
Before:
<img width="1230" height="737" alt="Screenshot 2025-07-18 at 14 19 31" src="https://github.com/user-attachments/assets/05630310-917d-432f-9f93-536a29337bd6" />

After:
<img width="1230" height="737" alt="Screenshot 2025-07-18 at 14 19 20" src="https://github.com/user-attachments/assets/6c0b9a90-7a2d-4743-b9f9-a45981c84e2f" />

Focus issue on iPad: seems like there's some lifecycle weirdness going on (only on iPad os...). onMount never seems to be triggered when it's in a render guard. Test case: the searchinput only has some header elements with some states. The search page uses it in varying ways (on the root of the page; with and without render guards. And in the traktpage component; with and without render guards).

On Safari on macOS:

https://github.com/user-attachments/assets/1397e3e1-130a-4402-87c7-96a46443bfb9

On iPad:

https://github.com/user-attachments/assets/0a3238a6-c69b-478f-a1fd-87b28451bfca
