### PR TITLE
Fix/i18n multi key

### DIFF
--- a/projects/client/.scripts/_internal/mapToTranslations.spec.ts
+++ b/projects/client/.scripts/_internal/mapToTranslations.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MetaMessageDefinition } from '../../i18n/generator/model/MetaMessageDefinition.ts';
+import { mapToTranslations } from './mapToTranslations.ts';
+
+describe('mapToTranslations', () => {
+  const messages: Record<string, MetaMessageDefinition> = {
+    'hello': { default: 'Hello' },
+    'goodbye': { default: 'Goodbye' },
+    'welcome': { default: 'Welcome' },
+  };
+
+  const locales = ['es', 'fr'];
+
+  it('should map translations correctly for multiple locales', () => {
+    const response: Array<Record<string, Record<string, string>>> = [
+      {
+        'es': { 'hello': 'Hola', 'goodbye': 'Adiós', 'welcome': 'Bienvenido' },
+        'fr': {
+          'hello': 'Salut',
+          'goodbye': 'Au revoir',
+          'welcome': 'Bienvenue',
+        },
+      },
+    ];
+
+    const result = mapToTranslations({ messages, locales, response });
+
+    expect(result).toEqual({
+      'es': {
+        'hello': 'Hola',
+        'goodbye': 'Adiós',
+        'welcome': 'Bienvenido',
+      },
+      'fr': {
+        'hello': 'Salut',
+        'goodbye': 'Au revoir',
+        'welcome': 'Bienvenue',
+      },
+    });
+  });
+
+  it('should aggregate translations for multiple locales', () => {
+    const response: Array<Record<string, Record<string, string>>> = [
+      {
+        'es': { 'hello': 'Hola' },
+        'fr': { 'hello': 'Salut' },
+      },
+      {
+        'es': { 'goodbye': 'Adiós' },
+        'fr': { 'goodbye': 'Au revoir' },
+      },
+      {
+        'es': { 'welcome': 'Bienvenido' },
+        'fr': { 'welcome': 'Bienvenue' },
+      },
+    ];
+
+    const result = mapToTranslations({ messages, locales, response });
+
+    expect(result).toEqual({
+      'es': {
+        'hello': 'Hola',
+        'goodbye': 'Adiós',
+        'welcome': 'Bienvenido',
+      },
+      'fr': {
+        'hello': 'Salut',
+        'goodbye': 'Au revoir',
+        'welcome': 'Bienvenue',
+      },
+    });
+  });
+
+  it('should map translations correctly for single key', () => {
+    const singleKeyMessages: Record<string, MetaMessageDefinition> = {
+      'hello': { default: 'Hello' },
+    };
+    const response: Array<Record<string, Record<string, string>>> = [
+      {
+        'es': { 'hello': 'Hola' },
+        'fr': { 'hello': 'Salut' },
+      },
+    ];
+
+    const result = mapToTranslations({
+      messages: singleKeyMessages,
+      locales,
+      response,
+    });
+
+    expect(result).toEqual({
+      'es': {
+        'hello': 'Hola',
+      },
+      'fr': {
+        'hello': 'Salut',
+      },
+    });
+  });
+
+  it('should handle missing translations by using default values', () => {
+    const response: Array<Record<string, Record<string, string>>> = [
+      {
+        'es': { 'hello': 'Hola' },
+        'fr': { 'hello': 'Bonjour' },
+      },
+      {
+        'es': { 'goodbye': 'Adiós' },
+        'fr': {},
+      },
+      {
+        'es': { 'welcome': 'Bienvenido' },
+        'fr': {},
+      },
+    ];
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = mapToTranslations({
+      messages,
+      locales,
+      response,
+    });
+
+    expect(result).toEqual({
+      'es': {
+        'hello': 'Hola',
+        'goodbye': 'Adiós',
+        'welcome': 'Bienvenido',
+      },
+      'fr': {
+        'hello': 'Bonjour',
+        'goodbye': 'Goodbye',
+        'welcome': 'Welcome',
+      },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '⚠️ Missing 2 keys for fr: goodbye, welcome',
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle missing locale in response', () => {
+    const response: Array<Record<string, Record<string, string>>> = [
+      {
+        'es': { 'hello': 'Hola' },
+      },
+      {
+        'es': { 'goodbye': 'Adiós' },
+      },
+      {
+        'es': { 'welcome': 'Bienvenido' },
+      },
+    ];
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = mapToTranslations({
+      messages,
+      locales,
+      response,
+    });
+
+    expect(result).toEqual({
+      'es': {
+        'hello': 'Hola',
+        'goodbye': 'Adiós',
+        'welcome': 'Bienvenido',
+      },
+      'fr': {
+        'hello': 'Hello',
+        'goodbye': 'Goodbye',
+        'welcome': 'Welcome',
+      },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '⚠️ Missing translations for locale: fr',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '⚠️ Missing 3 keys for fr: hello, goodbye, welcome',
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/projects/client/.scripts/_internal/mapToTranslations.ts
+++ b/projects/client/.scripts/_internal/mapToTranslations.ts
@@ -1,0 +1,76 @@
+import type { MetaMessageDefinition } from '../../i18n/generator/model/MetaMessageDefinition.ts';
+import type { TranslationMap } from './loadMetaFile.ts';
+
+type MapToTranslationsType = {
+  messages: Record<string, MetaMessageDefinition>;
+  locales: string[];
+  response: Array<Record<string, Record<string, string>>>;
+};
+
+export function mapToTranslations({
+  messages,
+  locales,
+  response,
+}: MapToTranslationsType) {
+  // Since responses can contain multiple translation keys we aggregate them per locale
+  const translations: Record<string, TranslationMap> = {};
+  for (const locale of locales) {
+    translations[locale] = {};
+  }
+
+  const addToTranslations = (
+    locale: string,
+    key: string,
+    translation?: string,
+  ) => {
+    if (!translation) {
+      return;
+    }
+
+    if (translations[locale]) {
+      translations[locale][key] = translation;
+      return;
+    }
+
+    translations[locale] = { [key]: translation };
+  };
+
+  response.forEach(
+    (localeResponse: Record<string, TranslationMap>) => {
+      for (const locale of locales) {
+        const localeTranslations = localeResponse[locale];
+        if (!localeTranslations) {
+          console.warn(`⚠️ Missing translations for locale: ${locale}`);
+          continue;
+        }
+
+        const translatedKeys = Object.keys(localeTranslations);
+        for (const key of translatedKeys) {
+          addToTranslations(locale, key, localeTranslations[key]);
+        }
+      }
+    },
+  );
+
+  const expectedKeys = Object.keys(messages);
+  for (const locale of locales) {
+    const translatedKeys = Object.keys(translations[locale] ?? {});
+    const missingKeys = expectedKeys.filter((key) =>
+      !translatedKeys.includes(key)
+    );
+
+    if (missingKeys.length > 0) {
+      console.warn(
+        `⚠️ Missing ${missingKeys.length} keys for ${locale}: ${
+          missingKeys.join(', ')
+        }`,
+      );
+      // Fill missing keys with original values
+      for (const key of missingKeys) {
+        addToTranslations(locale, key, messages[key]?.default || '');
+      }
+    }
+  }
+
+  return translations;
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes the cases where the translations aren't aggregated. For example, if instead of:
````
[
  "fr-fr": {
    link_text_vip_list_upsell: "Pour plus de listes",
    button_text_add_list: "Ajouter une liste",
    button_label_add_list: "Ajouter une liste"
   }
]
````
the response could be:
````
[
  "fr-fr": { link_text_vip_list_upsell: "Pour plus de listes" },
  "fr-fr": { button_text_add_list: "Ajouter une liste" },
  "fr-fr": { button_label_add_list: "Ajouter une liste" },
]
 ````

- Added tests to cover the multiple scenarios