### PR TITLE
refactor(list): use consistent naming for creating new lists

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "За още списъци"
     },
-    "button_text_add_list": {
-      "default": "Добави списък"
+    "button_text_create_list": {
+      "default": "Списък"
     },
-    "button_label_add_list": {
-      "default": "Добави списък"
+    "button_label_create_list": {
+      "default": "Създай списък"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Въведете име за вашия списък"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "For flere lister"
     },
-    "button_text_add_list": {
-      "default": "Tilføj liste"
+    "button_text_create_list": {
+      "default": "Liste"
     },
-    "button_label_add_list": {
-      "default": "Tilføj liste"
+    "button_label_create_list": {
+      "default": "Opret liste"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Indtast et navn til din liste"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Für mehr Listen"
     },
-    "button_text_add_list": {
-      "default": "Liste hinzufügen"
+    "button_text_create_list": {
+      "default": "Liste"
     },
-    "button_label_add_list": {
-      "default": "Liste hinzufügen"
+    "button_label_create_list": {
+      "default": "Liste erstellen"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Gib einen Namen für deine Liste ein"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2357,17 +2357,17 @@
       "default": "to add more lists",
       "description": "Text for the link that takes users to the VIP upsell page. This should be as short as possible and be translated as if it starts with 'get vip'."
     },
-    "button_text_add_list": {
-      "default": "Add list",
-      "description": "Text for the button that allows users to add a new list."
+    "button_text_create_list": {
+      "default": "List",
+      "description": "Text for the button that allows users to create a new list. The text is shown before a 'plus' icon."
     },
-    "button_label_add_list": {
-      "default": "Add list",
-      "description": "Aria-label for the button that allows users to add a new list."
+    "button_label_create_list": {
+      "default": "Create list",
+      "description": "Aria-label for the button that allows users to create a new list."
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Enter a name for your list",
-      "description": "Message for the prompt that is shown when a user is adding a new list."
+      "description": "Message for the prompt that is shown when a user is creating a new list."
     },
     "list_placeholder_personal_list_empty": {
       "default": "There is nothing in this list yet.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Para más listas"
     },
-    "button_text_add_list": {
-      "default": "Añadir lista"
+    "button_text_create_list": {
+      "default": "Lista"
     },
-    "button_label_add_list": {
-      "default": "Añadir lista"
+    "button_label_create_list": {
+      "default": "Crear lista"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Introduce un nombre para tu lista"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Para más listas"
     },
-    "button_text_add_list": {
-      "default": "Agregar lista"
+    "button_text_create_list": {
+      "default": "Lista"
     },
-    "button_label_add_list": {
-      "default": "Agregar lista"
+    "button_label_create_list": {
+      "default": "Crear lista"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Ingresa un nombre para tu lista"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1868,14 +1868,14 @@
     "link_text_vip_list_upsell": {
       "default": "Pour plus de listes"
     },
-    "button_text_add_list": {
-      "default": "Ajouter une liste"
+    "button_text_create_list": {
+      "default": "Liste"
     },
-    "button_label_add_list": {
-      "default": "Ajouter une liste"
+    "button_label_create_list": {
+      "default": "Créer une liste"
     },
-    "input_prompt_add_list": {
-      "default": "Entrez le nom de votre liste"
+    "input_prompt_create_list": {
+      "default": "Entrez un nom pour votre liste"
     },
     "list_placeholder_personal_list_empty": {
       "default": "Y'a rien dans cette liste pour l'instant."

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Pour plus de listes"
     },
-    "button_text_add_list": {
-      "default": "Ajouter une liste"
+    "button_text_create_list": {
+      "default": "Liste"
     },
-    "button_label_add_list": {
-      "default": "Ajouter une liste"
+    "button_label_create_list": {
+      "default": "Créer une liste"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Entrez un nom pour votre liste"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Per più liste"
     },
-    "button_text_add_list": {
-      "default": "Aggiungi lista"
+    "button_text_create_list": {
+      "default": "Lista"
     },
-    "button_label_add_list": {
-      "default": "Aggiungi lista"
+    "button_label_create_list": {
+      "default": "Crea lista"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Inserisci un nome per la tua lista"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1868,14 +1868,14 @@
     "link_text_vip_list_upsell": {
       "default": "リスト追加"
     },
-    "button_text_add_list": {
-      "default": "リスト追加"
+    "button_text_create_list": {
+      "default": "リスト"
     },
-    "button_label_add_list": {
-      "default": "リストを追加"
+    "button_label_create_list": {
+      "default": "リストを作成"
     },
-    "input_prompt_add_list": {
-      "default": "リスト名を入力してください"
+    "input_prompt_create_list": {
+      "default": "リストの名前を入力"
     },
     "list_placeholder_personal_list_empty": {
       "default": "このリストにはまだ何もありません。"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "For flere lister"
     },
-    "button_text_add_list": {
-      "default": "Legg til liste"
+    "button_text_create_list": {
+      "default": "Liste"
     },
-    "button_label_add_list": {
-      "default": "Legg til liste"
+    "button_label_create_list": {
+      "default": "Opprett liste"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Skriv inn et navn for listen din"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Voor meer lijsten"
     },
-    "button_text_add_list": {
-      "default": "Lijst toevoegen"
+    "button_text_create_list": {
+      "default": "Lijst"
     },
-    "button_label_add_list": {
-      "default": "Lijst toevoegen"
+    "button_label_create_list": {
+      "default": "Lijst aanmaken"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Voer een naam in voor je lijst"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1868,14 +1868,14 @@
     "link_text_vip_list_upsell": {
       "default": "Po więcej list"
     },
-    "button_text_add_list": {
-      "default": "Dodaj listę"
+    "button_text_create_list": {
+      "default": "Lista"
     },
-    "button_label_add_list": {
-      "default": "Dodaj listę"
+    "button_label_create_list": {
+      "default": "Utwórz listę"
     },
-    "input_prompt_add_list": {
-      "default": "Wpisz nazwę swojej listy"
+    "input_prompt_create_list": {
+      "default": "Wprowadź nazwę dla swojej listy"
     },
     "list_placeholder_personal_list_empty": {
       "default": "W tej liście jeszcze nic nie ma."

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "Mais listas"
     },
-    "button_text_add_list": {
-      "default": "Adicionar lista"
+    "button_text_create_list": {
+      "default": "Lista"
     },
-    "button_label_add_list": {
-      "default": "Adicionar lista"
+    "button_label_create_list": {
+      "default": "Criar lista"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Digite um nome para sua lista"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1868,14 +1868,14 @@
     "link_text_vip_list_upsell": {
       "default": "Pentru mai multe liste"
     },
-    "button_text_add_list": {
-      "default": "Adaugă listă"
+    "button_text_create_list": {
+      "default": "Listă"
     },
-    "button_label_add_list": {
-      "default": "Adaugă listă"
+    "button_label_create_list": {
+      "default": "Crează listă"
     },
-    "input_prompt_add_list": {
-      "default": "Introdu un nume pentru lista ta"
+    "input_prompt_create_list": {
+      "default": "Introduce un nume pentru lista ta"
     },
     "list_placeholder_personal_list_empty": {
       "default": "Nu este nimic în această listă încă."

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1868,13 +1868,13 @@
     "link_text_vip_list_upsell": {
       "default": "För fler listor"
     },
-    "button_text_add_list": {
-      "default": "Lägg till lista"
+    "button_text_create_list": {
+      "default": "Lista"
     },
-    "button_label_add_list": {
-      "default": "Lägg till lista"
+    "button_label_create_list": {
+      "default": "Skapa lista"
     },
-    "input_prompt_add_list": {
+    "input_prompt_create_list": {
       "default": "Ange ett namn för din lista"
     },
     "list_placeholder_personal_list_empty": {

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1868,14 +1868,14 @@
     "link_text_vip_list_upsell": {
       "default": "Для більше списків"
     },
-    "button_text_add_list": {
-      "default": "Додати список"
+    "button_text_create_list": {
+      "default": "Список"
     },
-    "button_label_add_list": {
-      "default": "Додати список"
+    "button_label_create_list": {
+      "default": "Створити список"
     },
-    "input_prompt_add_list": {
-      "default": "Введіть назву вашого списку"
+    "input_prompt_create_list": {
+      "default": "Введіть назву для вашого списку"
     },
     "list_placeholder_personal_list_empty": {
       "default": "У цьому списку поки що нічого немає."

--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -6,8 +6,8 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia.ts";
   import ListSummaryItem from "../components/list-summary/ListSummaryItem.svelte";
-  import AddListAction from "./_internal/AddListAction.svelte";
-  import AddNewListHeader from "./_internal/AddNewListHeader.svelte";
+  import CreateListAction from "./_internal/CreateListAction.svelte";
+  import CreateListHeader from "./_internal/CreateListHeader.svelte";
   import type { PersonalListType } from "./models/PersonalListType.ts";
   import { usePersonalListsSummary } from "./usePersonalListsSummary.ts";
   import UserList from "./UserList.svelte";
@@ -58,7 +58,7 @@
   {#if variant === "preview"}
     {#if isMine}
       <RenderFor audience="authenticated" navigation="default">
-        <AddNewListHeader />
+        <CreateListHeader />
       </RenderFor>
     {/if}
 
@@ -81,7 +81,7 @@
 
       {#snippet dynamicActions()}
         {#if isMine}
-          <AddListAction />
+          <CreateListAction />
         {/if}
       {/snippet}
     </SectionList>

--- a/projects/client/src/lib/sections/lists/user/_internal/CreateListAction.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/CreateListAction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { usePersonalListsSummary } from "../usePersonalListsSummary";
-  import AddNewListButton from "./AddNewListButton.svelte";
+  import AddNewListButton from "./CreateListButton.svelte";
   import ListUpsellLink from "./ListUpsellLink.svelte";
 
   const { user } = useUser();

--- a/projects/client/src/lib/sections/lists/user/_internal/CreateListButton.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/CreateListButton.svelte
@@ -11,7 +11,7 @@
   const { createList, isCreating } = useCreateList();
 
   const commonProps: Omit<ButtonProps, "children"> = $derived({
-    label: m.button_label_add_list(),
+    label: m.button_label_create_list(),
     color: "purple",
     variant: "secondary",
     onclick: createList,
@@ -21,7 +21,7 @@
 
 <RenderFor audience="authenticated" device={["mobile", "tablet-lg", "desktop"]}>
   <Button size="small" {...commonProps}>
-    {m.button_text_add_list()}
+    {m.button_text_create_list()}
     {#snippet icon()}
       <PlusIcon />
     {/snippet}

--- a/projects/client/src/lib/sections/lists/user/_internal/CreateListHeader.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/CreateListHeader.svelte
@@ -1,9 +1,9 @@
 <script>
-  import AddListAction from "./AddListAction.svelte";
+  import CreateListAction from "./CreateListAction.svelte";
 </script>
 
 <div class="trakt-add-new-list-header">
-  <AddListAction />
+  <CreateListAction />
 </div>
 
 <style lang="scss">

--- a/projects/client/src/lib/sections/lists/user/_internal/useCreateList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useCreateList.ts
@@ -13,7 +13,7 @@ export function useCreateList() {
 
   const createList = async () => {
     // skipcq: JS-0052
-    const enteredName = prompt(m.input_prompt_add_list());
+    const enteredName = prompt(m.input_prompt_create_list());
     const newName = enteredName?.trim();
 
     if (!newName) {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Prefers `create` over `add` when creating new lists.
- The button now display `List +` instead of `Add list +`.

## 👀 Examples 👀
Before:
<img width="1064" height="333" alt="Screenshot 2025-07-22 at 10 39 20" src="https://github.com/user-attachments/assets/96a5dfdf-9363-4f79-973c-012141674cd7" />

After:
<img width="1064" height="333" alt="Screenshot 2025-07-22 at 10 39 04" src="https://github.com/user-attachments/assets/d20ffabe-a425-47ac-8ffd-09ee15799db0" />
