### PR TITLE
feat(settings): adds minor profile settings

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Все още няма нищо в този списък."
+    },
+    "header_profile": {
+      "default": "Профил"
+    },
+    "text_avatar": {
+      "default": "Аватар"
+    },
+    "text_private": {
+      "default": "Лично"
+    },
+    "switch_label_private": {
+      "default": "Профилът е личен?"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Der er ikke noget i denne liste endnu."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privat"
+    },
+    "switch_label_private": {
+      "default": "Er profilen privat?"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "In dieser Liste gibt es noch nichts."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privat"
+    },
+    "switch_label_private": {
+      "default": "Ist das Profil privat?"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2372,6 +2372,22 @@
     "list_placeholder_personal_list_empty": {
       "default": "There is nothing in this list yet.",
       "description": "Placeholder text shown when there are no shows or movies in a user's personal list."
+    },
+    "header_profile": {
+      "default": "Profile",
+      "description": "Header for the section that allows users to change their profile settings."
+    },
+    "text_avatar": {
+      "default": "Avatar",
+      "description": "Text for the section that allows users to change their avatar."
+    },
+    "text_private": {
+      "default": "Private",
+      "description": "Text for the section that allows users to toggle privacy."
+    },
+    "switch_label_private": {
+      "default": "Is profile private",
+      "description": "Aria-label for the switch that allows users to toggle privacy on or off."
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Aún no hay nada en esta lista."
+    },
+    "header_profile": {
+      "default": "Perfil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privado"
+    },
+    "switch_label_private": {
+      "default": "¿Es el perfil privado?"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "¿No hay nada en esta lista, chavo?"
+    },
+    "header_profile": {
+      "default": "Perfil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privado"
+    },
+    "switch_label_private": {
+      "default": "¿Perfil privado?"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Y'a rien dans cette liste pour l'instant."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privé"
+    },
+    "switch_label_private": {
+      "default": "Profil privé?"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Rien pour le moment dans cette liste."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privé"
+    },
+    "switch_label_private": {
+      "default": "Votre profil est-il privé ?"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Non c'è ancora nulla in questa lista."
+    },
+    "header_profile": {
+      "default": "Profilo"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privato"
+    },
+    "switch_label_private": {
+      "default": "Il profilo è privato?"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "このリストにはまだ何もありません。"
+    },
+    "header_profile": {
+      "default": "プロフィール"
+    },
+    "text_avatar": {
+      "default": "アバター"
+    },
+    "text_private": {
+      "default": "非公開"
+    },
+    "switch_label_private": {
+      "default": "プロフィールを非公開にしますか？"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Det er ingenting i denne listen ennå."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privat"
+    },
+    "switch_label_private": {
+      "default": "Er profilen privat?"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Er staat nog niets in deze lijst."
+    },
+    "header_profile": {
+      "default": "Profiel"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privé"
+    },
+    "switch_label_private": {
+      "default": "Is profiel privé?"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "W tej liście jeszcze nic nie ma."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Awatar"
+    },
+    "text_private": {
+      "default": "Prywatne"
+    },
+    "switch_label_private": {
+      "default": "Czy profil jest prywatny?"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Não há nada nesta lista ainda."
+    },
+    "header_profile": {
+      "default": "Perfil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privado"
+    },
+    "switch_label_private": {
+      "default": "Perfil é privado?"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Nu este nimic în această listă încă."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privat"
+    },
+    "switch_label_private": {
+      "default": "Profil privat?"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "Det finns inget i den här listan än."
+    },
+    "header_profile": {
+      "default": "Profil"
+    },
+    "text_avatar": {
+      "default": "Avatar"
+    },
+    "text_private": {
+      "default": "Privat"
+    },
+    "switch_label_private": {
+      "default": "Är profilen privat?"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1879,6 +1879,18 @@
     },
     "list_placeholder_personal_list_empty": {
       "default": "У цьому списку поки що нічого немає."
+    },
+    "header_profile": {
+      "default": "Профіль"
+    },
+    "text_avatar": {
+      "default": "Аватар"
+    },
+    "text_private": {
+      "default": "Приватне"
+    },
+    "switch_label_private": {
+      "default": "Чи профіль приватний?"
     }
   }
 }

--- a/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
@@ -33,6 +33,7 @@ export const UserSettingsSchema = z.object({
   }),
   isVip: z.boolean(),
   isDirector: z.boolean(),
+  isPrivate: z.boolean(),
   preferences: z.object({
     progress: z.object({
       sort: z.object({
@@ -98,6 +99,7 @@ function mapUserSettingsResponse(response: SettingsResponse): UserSettings {
     },
     isVip: user.vip || user.vip_ep,
     isDirector: user.director,
+    isPrivate: user.private,
     preferences: {
       watch: {
         action: browsing?.watch_popup_action === 'ask'

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -46,6 +46,7 @@ const ANONYMOUS_USER: UserSettings = {
   },
   isVip: false,
   isDirector: false,
+  isPrivate: false,
   preferences: {
     progress: {
       sort: {

--- a/projects/client/src/lib/sections/settings/Settings.svelte
+++ b/projects/client/src/lib/sections/settings/Settings.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import LogoutButton from "./_internal/LogoutButton.svelte";
+  import Profile from "./_internal/Profile.svelte";
   import Spoilers from "./_internal/Spoilers.svelte";
 </script>
 
@@ -16,6 +17,7 @@
       </div>
     </div>
     <div class="trakt-settings-content">
+      <Profile />
       <Spoilers />
     </div>
   </div>
@@ -34,6 +36,10 @@
     min-height: var(--ni-120);
 
     .trakt-settings-content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-xl);
+
       padding: var(--ni-8);
     }
 

--- a/projects/client/src/lib/sections/settings/_internal/Profile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/Profile.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import Switch from "$lib/components/toggles/Switch.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import ProfileImage from "$lib/sections/profile-banner/ProfileImage.svelte";
+  import { getSwitchInnerText } from "./getSwitchInnerText";
+  import SettingsBlock from "./SettingsBlock.svelte";
+  import SettingsRow from "./SettingsRow.svelte";
+  import { useSettings } from "./useSettings";
+
+  const { user } = useUser();
+  const { privacy, isSavingSettings } = useSettings();
+
+  const innerText = $derived(getSwitchInnerText($privacy.isPrivate, "yes-no"));
+</script>
+
+<SettingsBlock title={m.header_profile()}>
+  <SettingsRow title={m.text_avatar()}>
+    <ProfileImage
+      isEditable
+      --width="var(--ni-32)"
+      --height="var(--ni-32)"
+      --border-width="var(--border-thickness-xs)"
+      name={$user.name.first}
+      src={$user.avatar.url}
+    />
+  </SettingsRow>
+  <SettingsRow title={m.text_private()}>
+    <Switch
+      {innerText}
+      color="purple"
+      label={m.switch_label_private()}
+      checked={$privacy.isPrivate}
+      onclick={() => $privacy.set(!$privacy.isPrivate)}
+      disabled={$isSavingSettings}
+    />
+  </SettingsRow>
+</SettingsBlock>

--- a/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
@@ -21,6 +21,6 @@
   .trakt-settings-block-content {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-xl);
+    gap: var(--gap-m);
   }
 </style>

--- a/projects/client/src/lib/sections/settings/_internal/constants.ts
+++ b/projects/client/src/lib/sections/settings/_internal/constants.ts
@@ -1,2 +1,5 @@
 export const SWITCH_ON_LABEL = 'On';
 export const SWITCH_OFF_LABEL = 'Off';
+
+export const SWITCH_YES_LABEL = 'Yes';
+export const SWITCH_NO_LABEL = 'No';

--- a/projects/client/src/lib/sections/settings/_internal/getSwitchInnerText.ts
+++ b/projects/client/src/lib/sections/settings/_internal/getSwitchInnerText.ts
@@ -1,9 +1,22 @@
-import { SWITCH_OFF_LABEL, SWITCH_ON_LABEL } from './constants.ts';
+import {
+  SWITCH_NO_LABEL,
+  SWITCH_OFF_LABEL,
+  SWITCH_ON_LABEL,
+  SWITCH_YES_LABEL,
+} from './constants.ts';
 
 /*
   These labels are not translated to make sure they always
   fit in the switch toggle
 */
-export function getSwitchInnerText(isEnabled: boolean) {
+type Mode = 'on-off' | 'yes-no';
+export function getSwitchInnerText(
+  isEnabled: boolean,
+  mode: Mode = 'on-off',
+): string {
+  if (mode === 'yes-no') {
+    return isEnabled ? SWITCH_YES_LABEL : SWITCH_NO_LABEL;
+  }
+
   return isEnabled ? SWITCH_ON_LABEL : SWITCH_OFF_LABEL;
 }

--- a/projects/client/src/lib/sections/settings/_internal/useSettings.ts
+++ b/projects/client/src/lib/sections/settings/_internal/useSettings.ts
@@ -65,5 +65,21 @@ export function useSettings() {
         });
       },
     })),
+    privacy: derived(user, ($user) => ({
+      isPrivate: Boolean($user.isPrivate),
+      set: async (isPrivate: boolean) => {
+        const payload = {
+          user: {
+            private: isPrivate,
+          },
+        };
+
+        await handleSettingsChange({
+          payload,
+          action: 'privacy',
+          invalidateAction: InvalidateAction.User.Settings,
+        });
+      },
+    })),
   };
 }

--- a/projects/client/src/mocks/data/users/mapped/ExtendedUserSettingsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/ExtendedUserSettingsMappedMock.ts
@@ -14,6 +14,7 @@ export const ExtendedUserMappedMock: UserSettings = {
   'about': "Sorry about the amnesia. I'm actually a superstar detective.",
   'isVip': true,
   'isDirector': false,
+  'isPrivate': false,
   'location': 'Martinaise, Revachol West',
   'name': {
     'first': 'Harry',


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds initial profile settings.
- More to follow (like name/about me/etc).

## 👀 Examples 👀
<img width="1368" height="343" alt="Screenshot 2025-07-22 at 19 06 06" src="https://github.com/user-attachments/assets/f4bb607e-2a1e-47ef-b3d1-1d983ac23c74" />

<img width="373" height="665" alt="Screenshot 2025-07-22 at 19 06 24" src="https://github.com/user-attachments/assets/cbf4c41a-54fd-4621-941d-6a8e5b5b5224" />
