### PR TITLE
Fix/relative date formatting

### DIFF
--- a/projects/client/src/lib/utils/formatting/date/toHumanDate.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDate.spec.ts
@@ -88,4 +88,14 @@ describe('toHumanDate', () => {
       'December 13th, 2023 at 8:00 PM',
     );
   });
+
+  it('will display the date in the past if is more than 2 months ago', () => {
+    const wednesday = stripTime(new Date('2023-12-20'));
+
+    const twoMonthAgo = addDays(wednesday, -60);
+
+    expect(toHumanDate(wednesday, twoMonthAgo, 'en')).toBe(
+      'October 21st, 2023 at 12:00 AM',
+    );
+  });
 });

--- a/projects/client/src/lib/utils/formatting/date/toHumanDate.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDate.ts
@@ -15,12 +15,14 @@ export function toHumanDate(
 ): string {
   const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
 
-  const { days = 0 } = intervalToDuration({
+  const { days = 0, months = 0, years = 0 } = intervalToDuration({
     start: stripTime(today),
     end: stripTime(date),
   });
 
-  const isInRelativeRange = days >= -6 && days <= 6;
+  const isInMonthRange = years === 0 && months === 0;
+  const isInDaysRange = days >= -6 && days <= 6;
+  const isInRelativeRange = isInMonthRange && isInDaysRange;
 
   if (isInRelativeRange) {
     return formatRelative(date, today, {


### PR DESCRIPTION
## ♪ Note ♪

- Fixes displaying relative dates that are more than a month ago. After a difference of a month, the days counter started at 0 again...

## 👀 Examples 👀
Before:
<img width="1310" height="529" alt="Screenshot 2025-07-23 at 10 58 01" src="https://github.com/user-attachments/assets/b6fa31fd-c28c-4a83-bc99-9c578c80046d" />

After:
<img width="1310" height="529" alt="Screenshot 2025-07-23 at 10 58 11" src="https://github.com/user-attachments/assets/a7bbb1b1-4716-4008-9117-33acdd3ca2ee" />
