### PR TITLE
Feat/more settings

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@12.1.0": "12.1.0_@cucumber+gherkin@32.2.0_@cucumber+message-streams@4.0.1__@cucumber+messages@27.2.0_@cucumber+messages@27.2.0",
     "npm:@google/generative-ai@0.24.1": "0.24.1",
     "npm:@inlang/paraglide-js@^2.2.0": "2.2.0",
-    "npm:@jsr/trakt__api@~0.2.10": "0.2.10_zod@3.25.76",
+    "npm:@jsr/trakt__api@~0.2.11": "0.2.11_zod@3.25.76",
     "npm:@playwright/test@1.52.0": "1.52.0",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.33.14__acorn@8.15.0",
     "npm:@svelte-put/qr@^2.1.0": "2.1.0_svelte@5.33.14__acorn@8.15.0",
@@ -2203,14 +2203,14 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.2.10_zod@3.25.76": {
-      "integrity": "sha512-RzXVoErn0l4lSsbkXaWgMlvtbcQL4Uqvnta6U3SLgDMVwkQt29mkJwl7mrDvh6OXXht5sLIiaGBQ3oMRzmMKhQ==",
+    "@jsr/trakt__api@0.2.11_zod@3.25.76": {
+      "integrity": "sha512-hrqQLP65zSQUe30tZneQ2vCsbv1nrUsflGLUsrowyzij3nBLrrewWyEX+iNfKinHJfqFVEsiZaO0bEtqnr5N9Q==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod@3.25.76"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.2.10.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.2.11.tgz"
     },
     "@lix-js/sdk@0.4.7_kysely@0.27.6": {
       "integrity": "sha512-pRbW+joG12L0ULfMiWYosIW0plmW4AsUdiPCp+Z8rAsElJ+wJ6in58zhD3UwUcd4BNcpldEGjg6PdA7e0RgsDQ==",
@@ -6849,7 +6849,7 @@
             "npm:@cucumber/cucumber@12.1.0",
             "npm:@google/generative-ai@0.24.1",
             "npm:@inlang/paraglide-js@^2.2.0",
-            "npm:@jsr/trakt__api@~0.2.10",
+            "npm:@jsr/trakt__api@~0.2.11",
             "npm:@playwright/test@1.52.0",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@svelte-put/qr@^2.1.0",

--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Профилът е личен?"
+    },
+    "text_display_name": {
+      "default": "Показвано име"
+    },
+    "button_label_change_display_name": {
+      "default": "Промяна на показваното име"
+    },
+    "text_location": {
+      "default": "Местоположение"
+    },
+    "button_label_change_location": {
+      "default": "Промени местоположението"
+    },
+    "text_about": {
+      "default": "За мен"
+    },
+    "button_label_change_about": {
+      "default": "Промени за мен"
+    },
+    "input_prompt_display_name": {
+      "default": "Как искате да се показвате?"
+    },
+    "input_prompt_location": {
+      "default": "Къде се намирате?"
+    },
+    "input_prompt_about": {
+      "default": "Разкажете ни малко за себе си."
     }
   }
 }

--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Разкажете ни малко за себе си."
+    },
+    "header_favorite_genres": {
+      "default": "Любими жанрове"
+    },
+    "button_label_toggle_genre": {
+      "default": "Превключване на жанр {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Er profilen privat?"
+    },
+    "text_display_name": {
+      "default": "Visningsnavn"
+    },
+    "button_label_change_display_name": {
+      "default": "Skift visningsnavn"
+    },
+    "text_location": {
+      "default": "Placering"
+    },
+    "button_label_change_location": {
+      "default": "Skift placering"
+    },
+    "text_about": {
+      "default": "Om"
+    },
+    "button_label_change_about": {
+      "default": "Skift om"
+    },
+    "input_prompt_display_name": {
+      "default": "Hvad skal dit visningsnavn være?"
+    },
+    "input_prompt_location": {
+      "default": "Hvor er du placeret?"
+    },
+    "input_prompt_about": {
+      "default": "Fortæl os lidt om dig selv."
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Fortæl os lidt om dig selv."
+    },
+    "header_favorite_genres": {
+      "default": "Yndlingsgenrer"
+    },
+    "button_label_toggle_genre": {
+      "default": "Slå genren {genre} til/fra",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Erzähl uns etwas über dich."
+    },
+    "header_favorite_genres": {
+      "default": "Lieblingsgenres"
+    },
+    "button_label_toggle_genre": {
+      "default": "Genre {genre} umschalten",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Ist das Profil privat?"
+    },
+    "text_display_name": {
+      "default": "Anzeigename"
+    },
+    "button_label_change_display_name": {
+      "default": "Anzeigename ändern"
+    },
+    "text_location": {
+      "default": "Standort"
+    },
+    "button_label_change_location": {
+      "default": "Standort ändern"
+    },
+    "text_about": {
+      "default": "Über mich"
+    },
+    "button_label_change_about": {
+      "default": "Über mich ändern"
+    },
+    "input_prompt_display_name": {
+      "default": "Wie soll dein Name angezeigt werden?"
+    },
+    "input_prompt_location": {
+      "default": "Wo bist du?"
+    },
+    "input_prompt_about": {
+      "default": "Erzähl uns etwas über dich."
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2388,6 +2388,42 @@
     "switch_label_private": {
       "default": "Is profile private",
       "description": "Aria-label for the switch that allows users to toggle privacy on or off."
+    },
+    "text_display_name": {
+      "default": "Display name",
+      "description": "Text for the section that allows users to change their display name."
+    },
+    "button_label_change_display_name": {
+      "default": "Change display name",
+      "description": "Aria-label for the button that allows users to change their display name."
+    },
+    "text_location": {
+      "default": "Location",
+      "description": "Text for the section that allows users to change their location."
+    },
+    "button_label_change_location": {
+      "default": "Change location",
+      "description": "Aria-label for the button that allows users to change their location."
+    },
+    "text_about": {
+      "default": "About",
+      "description": "Text for the section that allows users to change their 'about me' description."
+    },
+    "button_label_change_about": {
+      "default": "Change about",
+      "description": "Aria-label for the button that allows users to change their 'about me' description."
+    },
+    "input_prompt_display_name": {
+      "default": "What should your display name be?",
+      "description": "Message for the prompt that allows users to specify their display name."
+    },
+    "input_prompt_location": {
+      "default": "Where are you located?",
+      "description": "Message for the prompt that allows users to specify their location."
+    },
+    "input_prompt_about": {
+      "default": "Tell us a bit about yourself.",
+      "description": "Message for the prompt that allows users to specify their 'about me' description."
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2424,6 +2424,19 @@
     "input_prompt_about": {
       "default": "Tell us a bit about yourself.",
       "description": "Message for the prompt that allows users to specify their 'about me' description."
+    },
+    "header_favorite_genres": {
+      "default": "Favorite genres",
+      "description": "Header for the section that allows users to change their favorite genres."
+    },
+    "button_label_toggle_genre": {
+      "default": "Toggle the {genre} genre",
+      "description": "Aria-label for the button that allows users to toggle a genre, for example as a favorite.",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "¿Es el perfil privado?"
+    },
+    "text_display_name": {
+      "default": "Nombre mostrado"
+    },
+    "button_label_change_display_name": {
+      "default": "Cambiar nombre visible"
+    },
+    "text_location": {
+      "default": "Ubicación"
+    },
+    "button_label_change_location": {
+      "default": "Cambiar ubicación"
+    },
+    "text_about": {
+      "default": "Acerca de"
+    },
+    "button_label_change_about": {
+      "default": "Cambiar acerca de"
+    },
+    "input_prompt_display_name": {
+      "default": "¿Cómo quieres que te llamen?"
+    },
+    "input_prompt_location": {
+      "default": "¿Dónde estás?"
+    },
+    "input_prompt_about": {
+      "default": "Cuéntanos un poco sobre ti."
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Cuéntanos un poco sobre ti."
+    },
+    "header_favorite_genres": {
+      "default": "Géneros favoritos"
+    },
+    "button_label_toggle_genre": {
+      "default": "Activar/Desactivar el género {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Cuéntanos un poco de ti."
+    },
+    "header_favorite_genres": {
+      "default": "Géneros favoritos"
+    },
+    "button_label_toggle_genre": {
+      "default": "Activar/Desactivar el género {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "¿Perfil privado?"
+    },
+    "text_display_name": {
+      "default": "Nombre para mostrar"
+    },
+    "button_label_change_display_name": {
+      "default": "Cambiar nombre para mostrar"
+    },
+    "text_location": {
+      "default": "Ubicación"
+    },
+    "button_label_change_location": {
+      "default": "Cambiar ubicación"
+    },
+    "text_about": {
+      "default": "Acerca de"
+    },
+    "button_label_change_about": {
+      "default": "Cambiar acerca de"
+    },
+    "input_prompt_display_name": {
+      "default": "¿Cómo quieres que te digan?"
+    },
+    "input_prompt_location": {
+      "default": "¿Dónde te encuentras?"
+    },
+    "input_prompt_about": {
+      "default": "Cuéntanos un poco de ti."
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Raconte-nous un peu ta vie."
+    },
+    "header_favorite_genres": {
+      "default": "Vos genres préférés"
+    },
+    "button_label_toggle_genre": {
+      "default": "Activer/Désactiver le genre {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Profil privé?"
+    },
+    "text_display_name": {
+      "default": "Nom d'affichage"
+    },
+    "button_label_change_display_name": {
+      "default": "Changer le nom d'affichage"
+    },
+    "text_location": {
+      "default": "Lieu"
+    },
+    "button_label_change_location": {
+      "default": "Changer de lieu"
+    },
+    "text_about": {
+      "default": "À propos"
+    },
+    "button_label_change_about": {
+      "default": "Modifier à propos"
+    },
+    "input_prompt_display_name": {
+      "default": "Comment tu veux t'appeler ?"
+    },
+    "input_prompt_location": {
+      "default": "Où es-tu situé(e) ?"
+    },
+    "input_prompt_about": {
+      "default": "Raconte-nous un peu ta vie."
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Votre profil est-il privé ?"
+    },
+    "text_display_name": {
+      "default": "Nom d'affichage"
+    },
+    "button_label_change_display_name": {
+      "default": "Modifier le nom d'affichage"
+    },
+    "text_location": {
+      "default": "Lieu"
+    },
+    "button_label_change_location": {
+      "default": "Modifier le lieu"
+    },
+    "text_about": {
+      "default": "À propos"
+    },
+    "button_label_change_about": {
+      "default": "Modifier à propos"
+    },
+    "input_prompt_display_name": {
+      "default": "Quel doit être votre nom d'affichage ?"
+    },
+    "input_prompt_location": {
+      "default": "Où êtes-vous situé(e) ?"
+    },
+    "input_prompt_about": {
+      "default": "Dites-nous en un peu plus sur vous."
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Dites-nous en un peu plus sur vous."
+    },
+    "header_favorite_genres": {
+      "default": "Vos genres favoris"
+    },
+    "button_label_toggle_genre": {
+      "default": "Activer/Désactiver le genre {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Raccontaci un po' di te."
+    },
+    "header_favorite_genres": {
+      "default": "Generi preferiti"
+    },
+    "button_label_toggle_genre": {
+      "default": "Attiva/Disattiva il genere {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Il profilo è privato?"
+    },
+    "text_display_name": {
+      "default": "Nome visualizzato"
+    },
+    "button_label_change_display_name": {
+      "default": "Cambia nome visualizzato"
+    },
+    "text_location": {
+      "default": "Posizione"
+    },
+    "button_label_change_location": {
+      "default": "Cambia posizione"
+    },
+    "text_about": {
+      "default": "Informazioni"
+    },
+    "button_label_change_about": {
+      "default": "Cambia informazioni"
+    },
+    "input_prompt_display_name": {
+      "default": "Come vuoi essere chiamato?"
+    },
+    "input_prompt_location": {
+      "default": "Dove ti trovi?"
+    },
+    "input_prompt_about": {
+      "default": "Raccontaci un po' di te."
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "プロフィールを非公開にしますか？"
+    },
+    "text_display_name": {
+      "default": "表示名"
+    },
+    "button_label_change_display_name": {
+      "default": "表示名を変更"
+    },
+    "text_location": {
+      "default": "場所"
+    },
+    "button_label_change_location": {
+      "default": "場所を変更"
+    },
+    "text_about": {
+      "default": "自己紹介"
+    },
+    "button_label_change_about": {
+      "default": "自己紹介を変更"
+    },
+    "input_prompt_display_name": {
+      "default": "表示名は？"
+    },
+    "input_prompt_location": {
+      "default": "どこにいますか？"
+    },
+    "input_prompt_about": {
+      "default": "自己紹介をお願いします。"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "自己紹介をお願いします。"
+    },
+    "header_favorite_genres": {
+      "default": "お気に入りのジャンル"
+    },
+    "button_label_toggle_genre": {
+      "default": "{genre}のジャンルを切り替える",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Fortell oss litt om deg selv."
+    },
+    "header_favorite_genres": {
+      "default": "Favorittjangre"
+    },
+    "button_label_toggle_genre": {
+      "default": "Veksle sjanger {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Er profilen privat?"
+    },
+    "text_display_name": {
+      "default": "Visningsnavn"
+    },
+    "button_label_change_display_name": {
+      "default": "Endre visningsnavn"
+    },
+    "text_location": {
+      "default": "Sted"
+    },
+    "button_label_change_location": {
+      "default": "Endre sted"
+    },
+    "text_about": {
+      "default": "Om"
+    },
+    "button_label_change_about": {
+      "default": "Endre om"
+    },
+    "input_prompt_display_name": {
+      "default": "Hva skal visningsnavnet ditt være?"
+    },
+    "input_prompt_location": {
+      "default": "Hvor er du?"
+    },
+    "input_prompt_about": {
+      "default": "Fortell oss litt om deg selv."
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Vertel iets over jezelf."
+    },
+    "header_favorite_genres": {
+      "default": "Favoriete genres"
+    },
+    "button_label_toggle_genre": {
+      "default": "Genre {genre} in-/uitschakelen",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Is profiel privé?"
+    },
+    "text_display_name": {
+      "default": "Weergavenaam"
+    },
+    "button_label_change_display_name": {
+      "default": "Weergavenaam wijzigen"
+    },
+    "text_location": {
+      "default": "Locatie"
+    },
+    "button_label_change_location": {
+      "default": "Locatie wijzigen"
+    },
+    "text_about": {
+      "default": "Over mij"
+    },
+    "button_label_change_about": {
+      "default": "Wijzig 'over mij'"
+    },
+    "input_prompt_display_name": {
+      "default": "Hoe wil je heten?"
+    },
+    "input_prompt_location": {
+      "default": "Waar ben je?"
+    },
+    "input_prompt_about": {
+      "default": "Vertel iets over jezelf."
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Czy profil jest prywatny?"
+    },
+    "text_display_name": {
+      "default": "Nazwa wyświetlana"
+    },
+    "button_label_change_display_name": {
+      "default": "Zmień nazwę wyświetlaną"
+    },
+    "text_location": {
+      "default": "Lokalizacja"
+    },
+    "button_label_change_location": {
+      "default": "Zmień lokalizację"
+    },
+    "text_about": {
+      "default": "O mnie"
+    },
+    "button_label_change_about": {
+      "default": "Zmień o mnie"
+    },
+    "input_prompt_display_name": {
+      "default": "Jak chcesz być wyświetlany?"
+    },
+    "input_prompt_location": {
+      "default": "Gdzie się znajdujesz?"
+    },
+    "input_prompt_about": {
+      "default": "Opowiedz nam coś o sobie."
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Opowiedz nam coś o sobie."
+    },
+    "header_favorite_genres": {
+      "default": "Ulubione gatunki"
+    },
+    "button_label_toggle_genre": {
+      "default": "Przełącz gatunek {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Conte-nos um pouco sobre você."
+    },
+    "header_favorite_genres": {
+      "default": "Gêneros favoritos"
+    },
+    "button_label_toggle_genre": {
+      "default": "Alternar o gênero {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Perfil é privado?"
+    },
+    "text_display_name": {
+      "default": "Nome de exibição"
+    },
+    "button_label_change_display_name": {
+      "default": "Alterar nome de exibição"
+    },
+    "text_location": {
+      "default": "Localização"
+    },
+    "button_label_change_location": {
+      "default": "Mudar local"
+    },
+    "text_about": {
+      "default": "Sobre"
+    },
+    "button_label_change_about": {
+      "default": "Mudar sobre"
+    },
+    "input_prompt_display_name": {
+      "default": "Qual deve ser seu nome de exibição?"
+    },
+    "input_prompt_location": {
+      "default": "Onde você está?"
+    },
+    "input_prompt_about": {
+      "default": "Conte-nos um pouco sobre você."
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Profil privat?"
+    },
+    "text_display_name": {
+      "default": "Nume afișat"
+    },
+    "button_label_change_display_name": {
+      "default": "Schimbă numele afișat"
+    },
+    "text_location": {
+      "default": "Locație"
+    },
+    "button_label_change_location": {
+      "default": "Schimbă locația"
+    },
+    "text_about": {
+      "default": "Despre"
+    },
+    "button_label_change_about": {
+      "default": "Schimbă despre"
+    },
+    "input_prompt_display_name": {
+      "default": "Cum vrei să fii afișat?"
+    },
+    "input_prompt_location": {
+      "default": "Unde te afli?"
+    },
+    "input_prompt_about": {
+      "default": "Spune-ne câteva cuvinte despre tine."
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Spune-ne câteva cuvinte despre tine."
+    },
+    "header_favorite_genres": {
+      "default": "Genurile favorite"
+    },
+    "button_label_toggle_genre": {
+      "default": "Comută genul {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Berätta lite om dig själv."
+    },
+    "header_favorite_genres": {
+      "default": "Favoritgenrer"
+    },
+    "button_label_toggle_genre": {
+      "default": "Växla genren {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Är profilen privat?"
+    },
+    "text_display_name": {
+      "default": "Visningsnamn"
+    },
+    "button_label_change_display_name": {
+      "default": "Ändra visningsnamn"
+    },
+    "text_location": {
+      "default": "Plats"
+    },
+    "button_label_change_location": {
+      "default": "Ändra plats"
+    },
+    "text_about": {
+      "default": "Om mig"
+    },
+    "button_label_change_about": {
+      "default": "Ändra om mig"
+    },
+    "input_prompt_display_name": {
+      "default": "Vad ska ditt visningsnamn vara?"
+    },
+    "input_prompt_location": {
+      "default": "Var befinner du dig?"
+    },
+    "input_prompt_about": {
+      "default": "Berätta lite om dig själv."
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1918,6 +1918,17 @@
     },
     "input_prompt_about": {
       "default": "Розкажіть трохи про себе."
+    },
+    "header_favorite_genres": {
+      "default": "Улюблені жанри"
+    },
+    "button_label_toggle_genre": {
+      "default": "Перемкнути жанр {genre}",
+      "variables": {
+        "genre": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1891,6 +1891,33 @@
     },
     "switch_label_private": {
       "default": "Чи профіль приватний?"
+    },
+    "text_display_name": {
+      "default": "Відображуване ім'я"
+    },
+    "button_label_change_display_name": {
+      "default": "Змінити ім'я для відображення"
+    },
+    "text_location": {
+      "default": "Місцезнаходження"
+    },
+    "button_label_change_location": {
+      "default": "Змінити місцезнаходження"
+    },
+    "text_about": {
+      "default": "Про себе"
+    },
+    "button_label_change_about": {
+      "default": "Змінити про себе"
+    },
+    "input_prompt_display_name": {
+      "default": "Як вас відображати?"
+    },
+    "input_prompt_location": {
+      "default": "Де ви знаходитесь?"
+    },
+    "input_prompt_about": {
+      "default": "Розкажіть трохи про себе."
     }
   }
 }

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -73,7 +73,7 @@
     "@tanstack/svelte-query": "^5.83.0",
     "@tanstack/svelte-query-devtools": "^5.83.0",
     "@tanstack/svelte-query-persist-client": "^5.83.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.2.10",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.2.11",
     "@ts-rest/core": "^3.52.1",
     "@use-gesture/vanilla": "^10.3.1",
     "date-fns": "^4.1.0",

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -154,6 +154,7 @@ declare global {
   export type ButtonProps =
     & {
       label: string;
+      'aria-pressed'?: 'true' | 'false' | 'mixed';
     }
     & HTMLElementProps
     & ChildrenProps;

--- a/projects/client/src/lib/sections/settings/Settings.svelte
+++ b/projects/client/src/lib/sections/settings/Settings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import Genres from "./_internal/Genres.svelte";
   import LogoutButton from "./_internal/LogoutButton.svelte";
   import Profile from "./_internal/Profile.svelte";
   import Spoilers from "./_internal/Spoilers.svelte";
@@ -19,6 +20,7 @@
     <div class="trakt-settings-content">
       <Profile />
       <Spoilers />
+      <Genres />
     </div>
   </div>
 </RenderFor>
@@ -40,6 +42,7 @@
       flex-direction: column;
       gap: var(--gap-xxl);
 
+      max-width: var(--ni-640);
       min-width: 0;
       padding: var(--ni-8);
     }

--- a/projects/client/src/lib/sections/settings/Settings.svelte
+++ b/projects/client/src/lib/sections/settings/Settings.svelte
@@ -38,8 +38,9 @@
     .trakt-settings-content {
       display: flex;
       flex-direction: column;
-      gap: var(--gap-xl);
+      gap: var(--gap-xxl);
 
+      min-width: 0;
       padding: var(--ni-8);
     }
 

--- a/projects/client/src/lib/sections/settings/_internal/Genres.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/Genres.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { GENRES } from "$lib/features/filters/_internal/genres";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue.ts";
+  import SettingsBlock from "./SettingsBlock.svelte";
+  import ToggleTag from "./ToggleTag.svelte";
+  import { useSettings } from "./useSettings";
+
+  const { genres, isSavingSettings } = useSettings();
+
+  // FIXME: use local writable and allow for faster clicks without disabling
+  const favorites = $derived($genres.favorites);
+
+  const toggleFavoriteGenre = (genre: string) => {
+    if (favorites.includes(genre)) {
+      $genres.set(favorites.filter((g) => g !== genre));
+      return;
+    }
+
+    $genres.set([...favorites, genre]);
+  };
+</script>
+
+<SettingsBlock title={m.header_favorite_genres()}>
+  <div class="trakt-genres" role="group">
+    {#each GENRES as genre}
+      <ToggleTag
+        disabled={$isSavingSettings}
+        label={m.button_label_toggle_genre({
+          genre: toTranslatedValue("genre", genre),
+        })}
+        onclick={() => toggleFavoriteGenre(genre)}
+        isPressed={favorites.includes(genre)}
+      >
+        {genre}
+      </ToggleTag>
+    {/each}
+  </div>
+</SettingsBlock>
+
+<style>
+  .trakt-genres {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+    padding: var(--ni-8);
+
+    gap: var(--gap-xs);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/Profile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/Profile.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import RenameIcon from "$lib/components/icons/RenameIcon.svelte";
+  import { lineClamp } from "$lib/components/text/lineClamp";
   import Switch from "$lib/components/toggles/Switch.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -8,11 +11,57 @@
   import SettingsRow from "./SettingsRow.svelte";
   import { useSettings } from "./useSettings";
 
-  const { user } = useUser();
-  const { privacy, isSavingSettings } = useSettings();
+  const ABOUT_LINE_CLAMP = 3;
 
-  const innerText = $derived(getSwitchInnerText($privacy.isPrivate, "yes-no"));
+  const { user } = useUser();
+  const { profile, isSavingSettings } = useSettings();
+
+  const innerText = $derived(getSwitchInnerText($profile.isPrivate, "yes-no"));
+
+  const promptMap = $derived({
+    name: {
+      prompt: m.input_prompt_display_name(),
+      label: m.button_label_change_display_name(),
+      currentValue: $profile.displayName,
+    },
+    location: {
+      prompt: m.input_prompt_location(),
+      label: m.button_label_change_location(),
+      currentValue: $profile.location,
+    },
+    about: {
+      prompt: m.input_prompt_about(),
+      label: m.button_label_change_about(),
+      currentValue: $profile.about,
+    },
+  });
+
+  // FIXME: change to input/text area elements
+  const handleFieldChange = (field: keyof typeof promptMap) => {
+    // skipcq: JS-0052
+    const enteredValue = prompt(
+      promptMap[field].prompt,
+      promptMap[field].currentValue,
+    );
+
+    if (!enteredValue || enteredValue.trim() === "") {
+      return;
+    }
+
+    $profile.set({ [field]: enteredValue.trim() });
+  };
 </script>
+
+{#snippet renameField(field: keyof typeof promptMap)}
+  <ActionButton
+    style="ghost"
+    label={promptMap[field].label}
+    onclick={() => handleFieldChange(field)}
+    disabled={$isSavingSettings}
+  >
+    <RenameIcon />
+  </ActionButton>
+{/snippet}
 
 <SettingsBlock title={m.header_profile()}>
   <SettingsRow title={m.text_avatar()}>
@@ -30,9 +79,39 @@
       {innerText}
       color="purple"
       label={m.switch_label_private()}
-      checked={$privacy.isPrivate}
-      onclick={() => $privacy.set(!$privacy.isPrivate)}
+      checked={$profile.isPrivate}
+      onclick={() => $profile.set({ private: !$profile.isPrivate })}
       disabled={$isSavingSettings}
     />
   </SettingsRow>
+  <SettingsRow title={m.text_display_name()}>
+    <p class="ellipsis bold">{$profile.displayName}</p>
+    {@render renameField("name")}
+  </SettingsRow>
+  <SettingsRow title={m.text_location()}>
+    <p class="ellipsis bold">{$profile.location}</p>
+    {@render renameField("location")}
+  </SettingsRow>
+  <SettingsRow title={m.text_about()}>
+    <p
+      class="bold trakt-about-text"
+      style="--line-clamp-lines: {ABOUT_LINE_CLAMP}"
+      use:lineClamp={{ lines: ABOUT_LINE_CLAMP }}
+    >
+      {$profile.about}
+    </p>
+    {@render renameField("about")}
+  </SettingsRow>
 </SettingsBlock>
+
+<style>
+  /* FIXME: find out why the initial values set in lineClamp are not applied */
+  .trakt-about-text {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--line-clamp-lines);
+
+    display: -webkit-box;
+    overflow: hidden;
+    line-clamp: var(--line-clamp-lines);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/SettingsRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsRow.svelte
@@ -16,15 +16,17 @@
     gap: var(--gap-s);
 
     .trakt-settings-row-title {
-      width: var(--ni-200);
+      max-width: var(--ni-200);
+      flex: 1;
     }
+  }
 
-    @include for-tablet-sm-and-below {
-      .trakt-settings-row-title,
-      .trakt-settings-row-content {
-        width: auto;
-        flex: 1;
-      }
-    }
+  .trakt-settings-row-content {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    min-width: 0;
+    flex: 1;
   }
 </style>

--- a/projects/client/src/lib/sections/settings/_internal/ToggleTag.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/ToggleTag.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import { type TraktButtonProps } from "$lib/components/buttons/TraktButtonProps";
+
+  type ToggleTagProps = Pick<
+    TraktButtonProps,
+    "disabled" | "label" | "onclick"
+  > & {
+    isPressed: boolean;
+  };
+
+  const {
+    children,
+    disabled,
+    label,
+    onclick,
+    isPressed,
+  }: ToggleTagProps & ChildrenProps = $props();
+
+  const pressedState = $derived(isPressed ? "true" : "false");
+</script>
+
+<Button
+  {disabled}
+  {label}
+  {onclick}
+  variant="primary"
+  color="purple"
+  size="tag"
+  style={isPressed ? "flat" : "ghost"}
+  aria-pressed={pressedState}
+>
+  {@render children()}
+</Button>

--- a/projects/client/src/lib/sections/settings/_internal/useSettings.ts
+++ b/projects/client/src/lib/sections/settings/_internal/useSettings.ts
@@ -72,5 +72,19 @@ export function useSettings() {
         await handleSettingsChange({ payload, action: 'profile' });
       },
     })),
+    genres: derived(user, ($user) => ({
+      favorites: $user.genres ?? [],
+      set: async (genres: string[]) => {
+        const payload = {
+          browsing: {
+            genres: {
+              favorites: genres,
+            },
+          },
+        };
+
+        await handleSettingsChange({ payload, action: 'genres' });
+      },
+    })),
   };
 }

--- a/projects/client/src/style/numeric-increments/index.css
+++ b/projects/client/src/style/numeric-increments/index.css
@@ -90,6 +90,7 @@
   --ni-320: 20rem;
   --ni-380: 25rem;
   --ni-480: 30rem;
+  --ni-640: 40rem;
 
   /**
    * Negative spacing and sizing variables
@@ -172,4 +173,5 @@
   --ni-neg-316: -19.75rem;
   --ni-neg-320: -20rem;
   --ni-neg-480: -30rem;
+  --ni-neg-640: -40rem;
 }

--- a/projects/client/src/style/sizing/index.css
+++ b/projects/client/src/style/sizing/index.css
@@ -13,6 +13,7 @@
   --border-thickness-l: var(--ni-12);
   --border-thickness-xl: var(--ni-16);
 
+  --gap-xxl: var(--ni-44);
   --gap-xl: var(--ni-32);
   --gap-l: var(--ni-24);
   --gap-m: var(--ni-16);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds support for changing some more profile settings: display name, location, about.
  - For now follows the UX we have for renaming lists. But ideally these should be come inline editables.
  - Birthday setting to follow.
- Adds support for changing favorite genres.
  - Note: these are not all genres, but match what can be selected in the filter.

## 👀 Examples 👀
<img width="1033" height="587" alt="Screenshot 2025-07-23 at 21 01 28" src="https://github.com/user-attachments/assets/46f8c233-5882-4d08-be1b-32c06f420379" />

<img width="426" height="731" alt="Screenshot 2025-07-23 at 21 14 31" src="https://github.com/user-attachments/assets/d65d3023-0e97-4305-95a4-7f55eeaada16" />
