### PR TITLE
fix(filter): properly load saved filters

### DIFF
--- a/projects/client/src/lib/features/filters/useStoredFilters.ts
+++ b/projects/client/src/lib/features/filters/useStoredFilters.ts
@@ -1,3 +1,4 @@
+import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { get } from 'svelte/store';
@@ -41,7 +42,7 @@ export function useStoredFilters() {
       },
     );
 
-    globalThis.window.history.replaceState({}, '', page.url);
+    goto(page.url, { replaceState: true });
   };
 
   return {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Saved filters are now properly loaded.
- Root cause: the effect in the `GlobalParameterProvider` was never triggered on initial load 😅

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/2f3aa4d1-9eff-4bb0-b7e7-8e410df142d5

After:

https://github.com/user-attachments/assets/c6cd7fc0-c396-4ca8-a7ce-05fda4cfbac3

