### PR TITLE
Updates i18n translations for improved clarity

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Следва"
+      "default": "Продължете гледането"
     },
     "tag_text_remaining_episodes": {
       "default": "остават {count}",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Популярно в моменра"
     },
-    "list_title_recommendations": {
-      "default": "Препоръчано за теб"
+    "list_title_recommended": {
+      "default": "Препоръчано"
     },
     "list_title_most_anticipated": {
       "default": "Най-очаквани"
@@ -1453,10 +1453,10 @@
       "default": "Система"
     },
     "button_text_filters": {
-      "default": "Филтрирай"
+      "default": "Филтри"
     },
     "button_label_filters": {
-      "default": "Филтър"
+      "default": "Филтри"
     },
     "button_label_reset_filter": {
       "default": "Изчисти"
@@ -1715,7 +1715,7 @@
       "default": "Екстри"
     },
     "page_title_up_next": {
-      "default": "Предстоящи"
+      "default": "Продължете гледането"
     },
     "page_title_available_now": {
       "default": "Налично сега"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Филми"
+    },
+    "episode_footer_season_episode": {
+      "default": "C{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Næste"
+      "default": "Fortsæt visning"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} tilbage",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Populært"
     },
-    "list_title_recommendations": {
-      "default": "Anbefalinger"
+    "list_title_recommended": {
+      "default": "Anbefalet"
     },
     "list_title_most_anticipated": {
       "default": "Mest ventede"
@@ -1453,10 +1453,10 @@
       "default": "System"
     },
     "button_text_filters": {
-      "default": "Filter"
+      "default": "Filtre"
     },
     "button_label_filters": {
-      "default": "Filtrér"
+      "default": "Filtre"
     },
     "button_label_reset_filter": {
       "default": "Nulstil"
@@ -1715,7 +1715,7 @@
       "default": "Ekstra"
     },
     "page_title_up_next": {
-      "default": "Snart"
+      "default": "Fortsæt visning"
     },
     "page_title_available_now": {
       "default": "Tilgængelig nu"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Film"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Als Nächstes"
+      "default": "Weiter schauen"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} Ausstehende",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Angesagt"
     },
-    "list_title_recommendations": {
-      "default": "Empfehlungen"
+    "list_title_recommended": {
+      "default": "Empfohlen"
     },
     "list_title_most_anticipated": {
       "default": "Am meisten erwartet"
@@ -1453,10 +1453,10 @@
       "default": "System"
     },
     "button_text_filters": {
-      "default": "Filtern"
+      "default": "Filter"
     },
     "button_label_filters": {
-      "default": "Filtern"
+      "default": "Filter"
     },
     "button_label_reset_filter": {
       "default": "Zurücksetzen"
@@ -1715,7 +1715,7 @@
       "default": "Extras"
     },
     "page_title_up_next": {
-      "default": "Demnächst"
+      "default": "Weiter schauen"
     },
     "page_title_available_now": {
       "default": "Jetzt verfügbar"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Filme"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · F{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Up Next"
+      "default": "Keep Watching"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} remaining",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Trending"
     },
-    "list_title_recommendations": {
-      "default": "Recommendations"
+    "list_title_recommended": {
+      "default": "Reckon You'd Like"
     },
     "list_title_most_anticipated": {
       "default": "Most Anticipated"
@@ -1453,10 +1453,10 @@
       "default": "System"
     },
     "button_text_filters": {
-      "default": "Filter"
+      "default": "Filters"
     },
     "button_label_filters": {
-      "default": "Filter"
+      "default": "Filters"
     },
     "button_label_reset_filter": {
       "default": "Reset"
@@ -1715,7 +1715,7 @@
       "default": "Extras"
     },
     "page_title_up_next": {
-      "default": "Up Next"
+      "default": "Keep Watching"
     },
     "page_title_available_now": {
       "default": "Available Now"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Films"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -58,8 +58,8 @@
       }
     },
     "list_title_up_next": {
-      "default": "Up Next",
-      "description": "Title for lists containing the next episodes to watch of aired episodes. This title should be as short and concise as possible."
+      "default": "Continue Watching",
+      "description": "Title for lists containing the next episodes and in progress movies. This title should be as short and concise as possible."
     },
     "tag_text_remaining_episodes": {
       "default": "{count} remaining",
@@ -355,8 +355,8 @@
       "default": "Trending",
       "description": "Title for lists containing trending movies or shows. This title should be as short and concise as possible."
     },
-    "list_title_recommendations": {
-      "default": "Recommendations",
+    "list_title_recommended": {
+      "default": "Recommended",
       "description": "Title for lists containing recommended movies or shows. This title should be as short and concise as possible."
     },
     "list_title_most_anticipated": {
@@ -1830,11 +1830,11 @@
       "description": "Text for the system theme option in the theme selection dropdown."
     },
     "button_text_filters": {
-      "default": "Filter",
+      "default": "Filters",
       "description": "Text for the button that opens the filters panel."
     },
     "button_label_filters": {
-      "default": "Filter",
+      "default": "Filters",
       "description": "Aria-label for the button that opens the filters panel."
     },
     "button_label_reset_filter": {
@@ -2166,8 +2166,8 @@
       "description": "Title for lists containing extras (like trailers) for movies or shows. This title should be as short and concise as possible."
     },
     "page_title_up_next": {
-      "default": "Up Next",
-      "description": "Title for the up next page."
+      "default": "Continue Watching",
+      "description": "Title for the Up Next page, which shows the next movie or episode a user should watch."
     },
     "page_title_available_now": {
       "default": "Available Now",
@@ -2445,6 +2445,18 @@
     "button_label_movies": {
       "default": "Movies",
       "description": "Aria-label for the button that allows users to toggle movies in the watchlist."
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "description": "Footer text for an episode, showing the season and episode number. The text should be as short and concise as possible, wherever possible use only the first letter.",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "A continuación"
+      "default": "Continuar viendo"
     },
     "tag_text_remaining_episodes": {
       "default": "Quedan {count}",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Tendencias"
     },
-    "list_title_recommendations": {
-      "default": "Recomendaciones"
+    "list_title_recommended": {
+      "default": "Recomendado"
     },
     "list_title_most_anticipated": {
       "default": "Los más esperados"
@@ -1453,10 +1453,10 @@
       "default": "Sistema"
     },
     "button_text_filters": {
-      "default": "Filtrar"
+      "default": "Filtros"
     },
     "button_label_filters": {
-      "default": "Filtrar"
+      "default": "Filtros"
     },
     "button_label_reset_filter": {
       "default": "Restablecer"
@@ -1715,7 +1715,7 @@
       "default": "Extras"
     },
     "page_title_up_next": {
-      "default": "Próximamente"
+      "default": "Continuar viendo"
     },
     "page_title_available_now": {
       "default": "Disponible ahora"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Películas"
+    },
+    "episode_footer_season_episode": {
+      "default": "T{seasonNumber} · C{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "A continuación"
+      "default": "Continuar viendo"
     },
     "tag_text_remaining_episodes": {
       "default": "Quedan {count}",
@@ -281,7 +281,7 @@
     "list_title_trending": {
       "default": "Tendencias"
     },
-    "list_title_recommendations": {
+    "list_title_recommended": {
       "default": "Recomendaciones"
     },
     "list_title_most_anticipated": {
@@ -1453,10 +1453,10 @@
       "default": "Sistema"
     },
     "button_text_filters": {
-      "default": "Filtro"
+      "default": "Filtros"
     },
     "button_label_filters": {
-      "default": "Filtrar"
+      "default": "Filtros"
     },
     "button_label_reset_filter": {
       "default": "Restablecer"
@@ -1715,7 +1715,7 @@
       "default": "Extras"
     },
     "page_title_up_next": {
-      "default": "Próximamente"
+      "default": "Continuar viendo"
     },
     "page_title_available_now": {
       "default": "Disponible ya"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Películas"
+    },
+    "episode_footer_season_episode": {
+      "default": "T{seasonNumber} · C{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Ce qui vous attend"
+      "default": "À suivre"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} restant(s)",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Tendance"
     },
-    "list_title_recommendations": {
-      "default": "Recommandations"
+    "list_title_recommended": {
+      "default": "Recommandé"
     },
     "list_title_most_anticipated": {
       "default": "Les plus attendus"
@@ -1453,10 +1453,10 @@
       "default": "Système"
     },
     "button_text_filters": {
-      "default": "Filtrer"
+      "default": "Filtres"
     },
     "button_label_filters": {
-      "default": "Filtrer"
+      "default": "Filtres"
     },
     "button_label_reset_filter": {
       "default": "Réinitialiser"
@@ -1715,7 +1715,7 @@
       "default": "Extras"
     },
     "page_title_up_next": {
-      "default": "Prochainement"
+      "default": "À l'écoute"
     },
     "page_title_available_now": {
       "default": "Dispo maintenant"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Films"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · É{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "À suivre"
+      "default": "Continuez à regarder"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} restant(s)",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Tendances"
     },
-    "list_title_recommendations": {
-      "default": "Recommandations"
+    "list_title_recommended": {
+      "default": "Recommandé"
     },
     "list_title_most_anticipated": {
       "default": "Les plus attendus"
@@ -1453,10 +1453,10 @@
       "default": "Système"
     },
     "button_text_filters": {
-      "default": "Filtrer"
+      "default": "Filtres"
     },
     "button_label_filters": {
-      "default": "Filtrer"
+      "default": "Filtres"
     },
     "button_label_reset_filter": {
       "default": "Réinitialiser"
@@ -1715,7 +1715,7 @@
       "default": "Suppléments"
     },
     "page_title_up_next": {
-      "default": "Prochainement"
+      "default": "Continuer à regarder"
     },
     "page_title_available_now": {
       "default": "Disponible maintenant"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Films"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · É{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Prossimamente"
+      "default": "Continua a guardare"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} rimanenti",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Tendenze"
     },
-    "list_title_recommendations": {
-      "default": "Consigli"
+    "list_title_recommended": {
+      "default": "Consigliati"
     },
     "list_title_most_anticipated": {
       "default": "I più attesi"
@@ -1453,10 +1453,10 @@
       "default": "Sistema"
     },
     "button_text_filters": {
-      "default": "Filtra"
+      "default": "Filtri"
     },
     "button_label_filters": {
-      "default": "Filtra"
+      "default": "Filtri"
     },
     "button_label_reset_filter": {
       "default": "Azzera"
@@ -1715,7 +1715,7 @@
       "default": "Extra"
     },
     "page_title_up_next": {
-      "default": "Prossimamente"
+      "default": "Continua a guardare"
     },
     "page_title_available_now": {
       "default": "Disponibile ora"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Film"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "次に見る作品"
+      "default": "視聴を続ける"
     },
     "tag_text_remaining_episodes": {
       "default": "あと{count}話",
@@ -281,7 +281,7 @@
     "list_title_trending": {
       "default": "話題の作品"
     },
-    "list_title_recommendations": {
+    "list_title_recommended": {
       "default": "おすすめ"
     },
     "list_title_most_anticipated": {
@@ -1456,7 +1456,7 @@
       "default": "フィルター"
     },
     "button_label_filters": {
-      "default": "絞り込み"
+      "default": "フィルター"
     },
     "button_label_reset_filter": {
       "default": "リセット"
@@ -1715,7 +1715,7 @@
       "default": "エクストラ"
     },
     "page_title_up_next": {
-      "default": "近日公開"
+      "default": "視聴を続ける"
     },
     "page_title_available_now": {
       "default": "公開中"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "映画"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Neste"
+      "default": "Fortsett å se"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} igjen",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Populært"
     },
-    "list_title_recommendations": {
-      "default": "Anbefalinger"
+    "list_title_recommended": {
+      "default": "Anbefalt"
     },
     "list_title_most_anticipated": {
       "default": "Mest Forventet"
@@ -1453,10 +1453,10 @@
       "default": "System"
     },
     "button_text_filters": {
-      "default": "Filter"
+      "default": "Filtre"
     },
     "button_label_filters": {
-      "default": "Filter"
+      "default": "Filtre"
     },
     "button_label_reset_filter": {
       "default": "Nullstill"
@@ -1715,7 +1715,7 @@
       "default": "Ekstra"
     },
     "page_title_up_next": {
-      "default": "Snart"
+      "default": "Fortsett å se"
     },
     "page_title_available_now": {
       "default": "Tilgjengelig nå"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Filmer"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Volgende"
+      "default": "Verder kijken"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} resterend",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Trending"
     },
-    "list_title_recommendations": {
-      "default": "Aanbevelingen"
+    "list_title_recommended": {
+      "default": "Aanbevolen"
     },
     "list_title_most_anticipated": {
       "default": "Meest verwacht"
@@ -1453,10 +1453,10 @@
       "default": "Systeem"
     },
     "button_text_filters": {
-      "default": "Filter"
+      "default": "Filters"
     },
     "button_label_filters": {
-      "default": "Filter"
+      "default": "Filters"
     },
     "button_label_reset_filter": {
       "default": "Reset"
@@ -1715,7 +1715,7 @@
       "default": "Extra's"
     },
     "page_title_up_next": {
-      "default": "Binnenkort"
+      "default": "Verder kijken"
     },
     "page_title_available_now": {
       "default": "Nu beschikbaar"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Films"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · A{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Następne"
+      "default": "Kontynuuj oglądanie"
     },
     "tag_text_remaining_episodes": {
       "default": "Pozostało {count}",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Teraz popularne"
     },
-    "list_title_recommendations": {
-      "default": "Rekomendacje"
+    "list_title_recommended": {
+      "default": "Polecane"
     },
     "list_title_most_anticipated": {
       "default": "Najbardziej wyczekiwane"
@@ -1453,10 +1453,10 @@
       "default": "System"
     },
     "button_text_filters": {
-      "default": "Filtruj"
+      "default": "Filtry"
     },
     "button_label_filters": {
-      "default": "Filtruj"
+      "default": "Filtry"
     },
     "button_label_reset_filter": {
       "default": "Resetuj"
@@ -1715,7 +1715,7 @@
       "default": "Dodatki"
     },
     "page_title_up_next": {
-      "default": "Następne"
+      "default": "Kontynuuj oglądanie"
     },
     "page_title_available_now": {
       "default": "Dostępne teraz"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Filmy"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · O{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Próximo"
+      "default": "Continuar Assistindo"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} restantes",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Tendências"
     },
-    "list_title_recommendations": {
-      "default": "Recomendações"
+    "list_title_recommended": {
+      "default": "Recomendados"
     },
     "list_title_most_anticipated": {
       "default": "Mais Esperados"
@@ -1453,10 +1453,10 @@
       "default": "Sistema"
     },
     "button_text_filters": {
-      "default": "Filtrar"
+      "default": "Filtros"
     },
     "button_label_filters": {
-      "default": "Filtrar"
+      "default": "Filtros"
     },
     "button_label_reset_filter": {
       "default": "Redefinir"
@@ -1715,7 +1715,7 @@
       "default": "Extras"
     },
     "page_title_up_next": {
-      "default": "Próximos"
+      "default": "Continuar Assistindo"
     },
     "page_title_available_now": {
       "default": "Disponível agora"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Filmes"
+    },
+    "episode_footer_season_episode": {
+      "default": "T{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Următorul"
+      "default": "Continuă vizionarea"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} episoade",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Trending"
     },
-    "list_title_recommendations": {
-      "default": "Recomandări"
+    "list_title_recommended": {
+      "default": "Recomandate"
     },
     "list_title_most_anticipated": {
       "default": "Cele mai așteptate"
@@ -1456,7 +1456,7 @@
       "default": "Filtre"
     },
     "button_label_filters": {
-      "default": "Filtru"
+      "default": "Filtre"
     },
     "button_label_reset_filter": {
       "default": "Resetează"
@@ -1715,7 +1715,7 @@
       "default": "Extra"
     },
     "page_title_up_next": {
-      "default": "Urmează"
+      "default": "Continuă vizionarea"
     },
     "page_title_available_now": {
       "default": "Disponibil acum"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Filme"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · E{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Nästa"
+      "default": "Fortsätt titta"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} kvar",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Trendigt"
     },
-    "list_title_recommendations": {
-      "default": "Rekommendationer"
+    "list_title_recommended": {
+      "default": "Rekommenderat"
     },
     "list_title_most_anticipated": {
       "default": "Mest efterlängtade"
@@ -1456,7 +1456,7 @@
       "default": "Filter"
     },
     "button_label_filters": {
-      "default": "Filtrera"
+      "default": "Filter"
     },
     "button_label_reset_filter": {
       "default": "Återställ"
@@ -1715,7 +1715,7 @@
       "default": "Extramaterial"
     },
     "page_title_up_next": {
-      "default": "Kommande"
+      "default": "Fortsätt titta"
     },
     "page_title_available_now": {
       "default": "Tillgängligt nu"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Filmer"
+    },
+    "episode_footer_season_episode": {
+      "default": "S{seasonNumber} · A{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Наступне"
+      "default": "Продовжити перегляд"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} епізодів",
@@ -281,8 +281,8 @@
     "list_title_trending": {
       "default": "Тренди"
     },
-    "list_title_recommendations": {
-      "default": "Рекомендації"
+    "list_title_recommended": {
+      "default": "Рекомендовано"
     },
     "list_title_most_anticipated": {
       "default": "Найбільш очікувані"
@@ -1456,7 +1456,7 @@
       "default": "Фільтри"
     },
     "button_label_filters": {
-      "default": "Фільтр"
+      "default": "Фільтри"
     },
     "button_label_reset_filter": {
       "default": "Скинути"
@@ -1715,7 +1715,7 @@
       "default": "Додаткові матеріали"
     },
     "page_title_up_next": {
-      "default": "Найближчим часом"
+      "default": "Продовжити перегляд"
     },
     "page_title_available_now": {
       "default": "Доступно зараз"
@@ -1935,6 +1935,17 @@
     },
     "button_label_movies": {
       "default": "Фільми"
+    },
+    "episode_footer_season_episode": {
+      "default": "С{seasonNumber} · С{episodeNumber}",
+      "variables": {
+        "seasonNumber": {
+          "type": "number"
+        },
+        "episodeNumber": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
@@ -16,5 +16,8 @@
     &[data-style="secondary"] {
       color: var(--color-text-secondary);
     }
+
+    /** FIXME: remove when we have adaptive typography and updated sizes */
+    font-size: var(--font-size-18);
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -96,7 +96,10 @@
         {#if episode.type === EpisodeComputedType.full_season}
           {seasonLabel(episode.season)}
         {:else}
-          {episode.season}x{episode.number}
+          {m.episode_footer_season_episode({
+            seasonNumber: episode.season,
+            episodeNumber: episode.number,
+          })}
           <Spoiler media={episode} {show} type="episode">
             - {episode.title}
           </Spoiler>

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -33,7 +33,7 @@
   <RenderFor audience="authenticated">
     <RecommendedList
       drilldownLabel={m.button_label_view_all_recommended_movies()}
-      title={m.list_title_recommendations()}
+      title={m.list_title_recommended()}
       {type}
     />
   </RenderFor>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -33,7 +33,7 @@
   />
   <RenderFor audience="authenticated">
     <RecommendedList
-      title={m.list_title_recommendations()}
+      title={m.list_title_recommended()}
       drilldownLabel={m.button_label_view_all_recommended_shows()}
       {type}
     />


### PR DESCRIPTION
Refactors translations across multiple languages to enhance clarity and provide a better user experience.

- Updates the "Up Next" section to "Continue Watching" to align with its functionality, which now includes both episodes and movies.
- Renames "Recommendations" to "Recommended" for brevity and consistency.
- Generalizes "Filter" to "Filters" for better accuracy.
- Introduces a new translation key for episode footers, displaying season and episode numbers in a concise format.