### PR TITLE
Refactors i18n labels for clarity

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -285,7 +285,7 @@
       "default": "Препоръчано"
     },
     "list_title_most_anticipated": {
-      "default": "Най-очаквани"
+      "default": "Очаквани"
     },
     "button_text_get_vip": {
       "default": "Вземи"
@@ -303,7 +303,7 @@
       "default": "Потребителски профил"
     },
     "list_title_most_popular": {
-      "default": "Най-популярни"
+      "default": "Популярни"
     },
     "button_text_browse_movies": {
       "default": "Филми"
@@ -988,7 +988,7 @@
       "default": "Гледай в"
     },
     "header_streaming": {
-      "default": "Стрийминг"
+      "default": "Къде да гледате"
     },
     "header_on_demand": {
       "default": "При поискване"

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -285,7 +285,7 @@
       "default": "Anbefalet"
     },
     "list_title_most_anticipated": {
-      "default": "Mest ventede"
+      "default": "Forventet"
     },
     "button_text_get_vip": {
       "default": "Hent"
@@ -303,7 +303,7 @@
       "default": "Brugerprofil"
     },
     "list_title_most_popular": {
-      "default": "Mest populære"
+      "default": "Populære"
     },
     "button_text_browse_movies": {
       "default": "Film"
@@ -988,7 +988,7 @@
       "default": "Stream på"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Hvor man kan se"
     },
     "header_on_demand": {
       "default": "On Demand"

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -285,7 +285,7 @@
       "default": "Empfohlen"
     },
     "list_title_most_anticipated": {
-      "default": "Am meisten erwartet"
+      "default": "Erwartet"
     },
     "button_text_get_vip": {
       "default": "Holen"
@@ -303,7 +303,7 @@
       "default": "Profil"
     },
     "list_title_most_popular": {
-      "default": "Meist beliebt"
+      "default": "Beliebt"
     },
     "button_text_browse_movies": {
       "default": "Filme"
@@ -988,7 +988,7 @@
       "default": "Streamen auf"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Wo schauen"
     },
     "header_on_demand": {
       "default": "Auf Abruf"

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -285,7 +285,7 @@
       "default": "Reckon You'd Like"
     },
     "list_title_most_anticipated": {
-      "default": "Most Anticipated"
+      "default": "Anticipated"
     },
     "button_text_get_vip": {
       "default": "Get"
@@ -303,7 +303,7 @@
       "default": "User Profile"
     },
     "list_title_most_popular": {
-      "default": "Most Popular"
+      "default": "Popular"
     },
     "button_text_browse_movies": {
       "default": "Movies"
@@ -988,7 +988,7 @@
       "default": "Stream on"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Availability"
     },
     "header_on_demand": {
       "default": "On Demand"

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -3,7 +3,7 @@
   "meta": {
     "locale": "en-au",
     "direction": "ltr",
-    "guidance": "Embrace Australian culture a little, but not too much.",
+    "guidance": "Stay as close to the original English version as possible, except for Australian specific spelling changes. For example, favorite becomes favourite, and references to Movies and Shows should stay the same.",
     "generator": {
       "inlang": {
         "enabled": true,
@@ -404,7 +404,7 @@
       "default": "A personalised message: If you have any information about the user (e.g., their watch history), you could use it to generate a more personalised placeholder, like 'This user loves horror movies but hates writing bios. (Maybe they're too busy hiding from zombies?)'"
     },
     "list_placeholder_watchlist": {
-      "default": "Your watchlist is looking a bit bare. Time to add some flicks or telly to get things started!"
+      "default": "Your watchlist is empty. Add movies or shows to create your cinematic masterpiece."
     },
     "list_placeholder_watchlist_movies": {
       "default": "Your watchlist is empty, mate. Chuck in a few movies!"
@@ -1899,7 +1899,7 @@
       }
     },
     "text_share_top_list": {
-      "default": "Have a gander at {name} on Trakt! 🔥",
+      "default": "Check out {name} on Trakt! 🔥",
       "variables": {
         "name": {
           "type": "string"
@@ -1907,25 +1907,25 @@
       }
     },
     "page_title_watchlist": {
-      "default": "To Watch"
+      "default": "Watchlist"
     },
     "list_title_watchlist": {
-      "default": "To Watch"
+      "default": "Watchlist"
     },
     "button_label_view_all_watchlist_items": {
-      "default": "View all to-watch items"
+      "default": "View all watchlist items"
     },
     "button_text_shows": {
-      "default": "Series"
+      "default": "Shows"
     },
     "button_label_shows": {
-      "default": "Series"
+      "default": "Shows"
     },
     "button_text_movies": {
-      "default": "Films"
+      "default": "Movies"
     },
     "button_label_movies": {
-      "default": "Films"
+      "default": "Movies"
     },
     "episode_footer_season_episode": {
       "default": "S{seasonNumber} · E{episodeNumber}",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -360,8 +360,8 @@
       "description": "Title for lists containing recommended movies or shows. This title should be as short and concise as possible."
     },
     "list_title_most_anticipated": {
-      "default": "Most Anticipated",
-      "description": "Title for lists containing most anticipated movies or shows. This title should be as short and concise as possible."
+      "default": "Anticipated",
+      "description": "Title for lists containing anticipated movies or shows. This title should be as short and concise as possible."
     },
     "button_text_get_vip": {
       "default": "Get",
@@ -384,8 +384,8 @@
       "description": "Aria-label for the button that opens the user profile page."
     },
     "list_title_most_popular": {
-      "default": "Most Popular",
-      "description": "Title for lists containing most popular movies or shows. This title should be as short and concise as possible."
+      "default": "Popular",
+      "description": "Title for lists containing popular movies or shows. This title should be as short and concise as possible."
     },
     "button_text_browse_movies": {
       "default": "Movies",
@@ -1263,8 +1263,8 @@
       "description": "Header for the section that shows streaming services for a movie or show."
     },
     "header_streaming": {
-      "default": "Streaming",
-      "description": "Header for the section that shows streaming services for a movie, show, or episode."
+      "default": "Availability",
+      "description": "Header for the section that shows streaming service availability for a movie, show, or episode."
     },
     "header_on_demand": {
       "default": "On Demand",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -285,7 +285,7 @@
       "default": "Recomendado"
     },
     "list_title_most_anticipated": {
-      "default": "Los más esperados"
+      "default": "Más esperadas"
     },
     "button_text_get_vip": {
       "default": "Hazte"
@@ -303,7 +303,7 @@
       "default": "Perfil de usuario"
     },
     "list_title_most_popular": {
-      "default": "Más popular"
+      "default": "Populares"
     },
     "button_text_browse_movies": {
       "default": "Películas"
@@ -988,7 +988,7 @@
       "default": "Ver en"
     },
     "header_streaming": {
-      "default": "En streaming"
+      "default": "Dónde ver"
     },
     "header_on_demand": {
       "default": "A la carta"

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -285,7 +285,7 @@
       "default": "Recomendaciones"
     },
     "list_title_most_anticipated": {
-      "default": "Los más esperados"
+      "default": "Más esperadas"
     },
     "button_text_get_vip": {
       "default": "Obtener"
@@ -303,7 +303,7 @@
       "default": "Perfil de usuario"
     },
     "list_title_most_popular": {
-      "default": "Lo más popular"
+      "default": "Populares"
     },
     "button_text_browse_movies": {
       "default": "Películas"
@@ -988,7 +988,7 @@
       "default": "Ver en"
     },
     "header_streaming": {
-      "default": "En línea"
+      "default": "Dónde ver"
     },
     "header_on_demand": {
       "default": "A la carta"

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -303,7 +303,7 @@
       "default": "Profil utilisateur"
     },
     "list_title_most_popular": {
-      "default": "Les plus populaires"
+      "default": "Populaires"
     },
     "button_text_browse_movies": {
       "default": "Films"
@@ -988,7 +988,7 @@
       "default": "Écouter sur"
     },
     "header_streaming": {
-      "default": "Diffusion"
+      "default": "Où regarder"
     },
     "header_on_demand": {
       "default": "Sur demande"

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -285,7 +285,7 @@
       "default": "Recommandé"
     },
     "list_title_most_anticipated": {
-      "default": "Les plus attendus"
+      "default": "Attendus"
     },
     "button_text_get_vip": {
       "default": "Obtenir"
@@ -303,7 +303,7 @@
       "default": "Profil utilisateur"
     },
     "list_title_most_popular": {
-      "default": "Les plus populaires"
+      "default": "Populaires"
     },
     "button_text_browse_movies": {
       "default": "Films"
@@ -988,7 +988,7 @@
       "default": "Regarder sur"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Où regarder"
     },
     "header_on_demand": {
       "default": "À la demande"

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -285,7 +285,7 @@
       "default": "Consigliati"
     },
     "list_title_most_anticipated": {
-      "default": "I più attesi"
+      "default": "Più attesi"
     },
     "button_text_get_vip": {
       "default": "Ottieni"
@@ -303,7 +303,7 @@
       "default": "Profilo utente"
     },
     "list_title_most_popular": {
-      "default": "I più popolari"
+      "default": "Popolari"
     },
     "button_text_browse_movies": {
       "default": "Film"
@@ -988,7 +988,7 @@
       "default": "Guarda su"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Dove guardare"
     },
     "header_on_demand": {
       "default": "On Demand"

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -285,7 +285,7 @@
       "default": "おすすめ"
     },
     "list_title_most_anticipated": {
-      "default": "最も期待されている作品"
+      "default": "期待"
     },
     "button_text_get_vip": {
       "default": "取得"
@@ -303,7 +303,7 @@
       "default": "ユーザー情報"
     },
     "list_title_most_popular": {
-      "default": "最も人気のある作品"
+      "default": "人気"
     },
     "button_text_browse_movies": {
       "default": "映画"
@@ -988,7 +988,7 @@
       "default": "ストリーミング"
     },
     "header_streaming": {
-      "default": "ストリーミング"
+      "default": "視聴可能"
     },
     "header_on_demand": {
       "default": "オンデマンド"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -285,7 +285,7 @@
       "default": "Anbefalt"
     },
     "list_title_most_anticipated": {
-      "default": "Mest Forventet"
+      "default": "Forventet"
     },
     "button_text_get_vip": {
       "default": "Få"
@@ -303,7 +303,7 @@
       "default": "Brukerprofil"
     },
     "list_title_most_popular": {
-      "default": "Mest Populære"
+      "default": "Populære"
     },
     "button_text_browse_movies": {
       "default": "Filmer"
@@ -988,7 +988,7 @@
       "default": "Strøm på"
     },
     "header_streaming": {
-      "default": "Strømming"
+      "default": "Hvor du kan se"
     },
     "header_on_demand": {
       "default": "On Demand"

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -285,7 +285,7 @@
       "default": "Aanbevolen"
     },
     "list_title_most_anticipated": {
-      "default": "Meest verwacht"
+      "default": "Verwacht"
     },
     "button_text_get_vip": {
       "default": "Word"
@@ -303,7 +303,7 @@
       "default": "Gebruikersprofiel"
     },
     "list_title_most_popular": {
-      "default": "Meest populair"
+      "default": "Populair"
     },
     "button_text_browse_movies": {
       "default": "Films"
@@ -988,7 +988,7 @@
       "default": "Streamen op"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Waar te kijken"
     },
     "header_on_demand": {
       "default": "Op aanvraag"

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -285,7 +285,7 @@
       "default": "Polecane"
     },
     "list_title_most_anticipated": {
-      "default": "Najbardziej wyczekiwane"
+      "default": "Oczekiwane"
     },
     "button_text_get_vip": {
       "default": "Zdobądź"
@@ -303,7 +303,7 @@
       "default": "Profil użytkownika"
     },
     "list_title_most_popular": {
-      "default": "Najpopularniejsze"
+      "default": "Popularne"
     },
     "button_text_browse_movies": {
       "default": "Filmy"
@@ -988,7 +988,7 @@
       "default": "Oglądaj na"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Gdzie oglądać"
     },
     "header_on_demand": {
       "default": "Na życzenie"

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -303,7 +303,7 @@
       "default": "Perfil do Usuário"
     },
     "list_title_most_popular": {
-      "default": "Mais Populares"
+      "default": "Populares"
     },
     "button_text_browse_movies": {
       "default": "Filmes"
@@ -988,7 +988,7 @@
       "default": "Assistir em"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Onde Assistir"
     },
     "header_on_demand": {
       "default": "Sob Demanda"

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -285,7 +285,7 @@
       "default": "Recomandate"
     },
     "list_title_most_anticipated": {
-      "default": "Cele mai așteptate"
+      "default": "Așteptate"
     },
     "button_text_get_vip": {
       "default": "Obține"
@@ -303,7 +303,7 @@
       "default": "Profil de utilizator"
     },
     "list_title_most_popular": {
-      "default": "Cele mai populare"
+      "default": "Populare"
     },
     "button_text_browse_movies": {
       "default": "Filme"
@@ -988,7 +988,7 @@
       "default": "Redă pe"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Unde poți viziona"
     },
     "header_on_demand": {
       "default": "La cerere"

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -285,7 +285,7 @@
       "default": "Rekommenderat"
     },
     "list_title_most_anticipated": {
-      "default": "Mest efterlängtade"
+      "default": "Förväntade"
     },
     "button_text_get_vip": {
       "default": "Hämta"
@@ -303,7 +303,7 @@
       "default": "Användarprofil"
     },
     "list_title_most_popular": {
-      "default": "Mest populära"
+      "default": "Populära"
     },
     "button_text_browse_movies": {
       "default": "Filmer"
@@ -988,7 +988,7 @@
       "default": "Streama på"
     },
     "header_streaming": {
-      "default": "Streaming"
+      "default": "Var du kan se"
     },
     "header_on_demand": {
       "default": "On Demand"

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -303,7 +303,7 @@
       "default": "Профіль користувача"
     },
     "list_title_most_popular": {
-      "default": "Найпопулярніші"
+      "default": "Популярні"
     },
     "button_text_browse_movies": {
       "default": "Фільми"
@@ -988,7 +988,7 @@
       "default": "Дивитися на"
     },
     "header_streaming": {
-      "default": "Онлайн"
+      "default": "Де дивитися"
     },
     "header_on_demand": {
       "default": "На вимогу"


### PR DESCRIPTION
Refines several i18n labels across multiple languages:

- Shortens "Most Anticipated" and "Most Popular" to "Anticipated" and "Popular" respectively, improving conciseness.
- Replaces "Streaming" with "Availability" or similar phrases in different languages, enhancing user understanding of the feature.