### PR TITLE
feat(navbar): adds search icon to mobile navbar

### DIFF
--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -5,6 +5,7 @@
   import { clickOutside } from "$lib/utils/actions/clickOutside";
   import { buildParamString } from "$lib/utils/url/buildParamString";
   import { onMount } from "svelte";
+  import { SEARCH_INPUT_FOCUS_EVENT } from "./constants";
   import SearchIcon from "./SearchIcon.svelte";
   import { useSearch } from "./useSearch";
 
@@ -64,11 +65,7 @@
     };
   }
 
-  onMount(() => {
-    if (isInline) {
-      return;
-    }
-
+  const focusSearchInput = () => {
     const length = inputElement.value.length;
     inputElement.setSelectionRange(length, length);
     inputElement.focus();
@@ -76,6 +73,22 @@
     if (length > 0) {
       inputElement.click();
     }
+  };
+
+  onMount(() => {
+    globalThis.window.addEventListener(
+      SEARCH_INPUT_FOCUS_EVENT,
+      focusSearchInput,
+    );
+
+    !isInline && focusSearchInput();
+
+    return () => {
+      globalThis.window.removeEventListener(
+        SEARCH_INPUT_FOCUS_EVENT,
+        focusSearchInput,
+      );
+    };
   });
 </script>
 
@@ -113,6 +126,15 @@
     100% {
       background-position: -200% 0;
     }
+  }
+
+  @mixin visible-background {
+    background: color-mix(
+      in srgb,
+      var(--color-background) 75%,
+      transparent 25%
+    );
+    @include backdrop-filter-blur(var(--ni-8));
   }
 
   :global(.trakt-navbar-scroll:not(.trakt-navbar-pwa)) {
@@ -177,18 +199,18 @@
       box-sizing: border-box;
 
       border-radius: var(--border-radius-s);
-      background: color-mix(
-        in srgb,
-        var(--color-background) 75%,
-        transparent 25%
-      );
+      background: transparent;
 
       transition: var(--transition-increment) ease-in-out;
       transition-property:
         border-color, background-color, padding, width, top, left, opacity;
 
-      @include backdrop-filter-blur(var(--ni-8));
+      @include visible-background;
+
       @include for-mobile {
+        background: transparent;
+        backdrop-filter: none;
+
         width: var(--search-icon-size);
         position: absolute;
         top: 0;
@@ -214,6 +236,8 @@
           top: 0;
           width: var(--mobile-search-focus-width);
           z-index: var(--layer-top);
+
+          @include visible-background;
         }
       }
 

--- a/projects/client/src/lib/features/search/constants.ts
+++ b/projects/client/src/lib/features/search/constants.ts
@@ -1,0 +1,1 @@
+export const SEARCH_INPUT_FOCUS_EVENT = 'trakt-focus-search-input';

--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import HomeIcon from "$lib/components/icons/mobile/HomeIcon.svelte";
   import WatchlistIcon from "$lib/components/icons/mobile/WatchlistIcon.svelte";
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import { SEARCH_INPUT_FOCUS_EVENT } from "$lib/features/search/constants";
+  import SearchIcon from "$lib/features/search/SearchIcon.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  const searchTrigger = () => {
+    globalThis.window.dispatchEvent(new CustomEvent(SEARCH_INPUT_FOCUS_EVENT));
+  };
 </script>
 
 <div class="trakt-mobile-navbar">
@@ -33,6 +41,14 @@
         <WatchlistIcon />
       </div>
     </Link>
+
+    <ActionButton
+      label={m.button_label_search()}
+      style="ghost"
+      onclick={searchTrigger}
+    >
+      <SearchIcon />
+    </ActionButton>
   </RenderFor>
 </div>
 
@@ -40,6 +56,16 @@
 
 <style lang="scss">
   @use "$style/scss/mixins/index.scss" as *;
+
+  @mixin base-button-style {
+    width: var(--ni-60);
+    height: var(--ni-32);
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
 
   .trakt-mobile-navbar-spacer,
   .trakt-mobile-navbar {
@@ -64,17 +90,22 @@
     justify-content: center;
     gap: var(--gap-m);
 
+    :global(.trakt-action-button) {
+      padding: 0;
+
+      backdrop-filter: none;
+      background-color: transparent;
+
+      @include base-button-style;
+    }
+
     @include backdrop-filter-blur(8px);
   }
 
   .trakt-mobile-navbar-link {
-    width: var(--ni-80);
     transition: color var(--transition-increment) ease-in-out;
 
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+    @include base-button-style;
   }
 
   :global(.trakt-link.trakt-link-active) {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a search icon to the mobile navbar.
  - This triggers the search input in the top navbar.
- De-emphasizes the top navbar search button (until it's focused).
- Aligns the icons in the center.

## 👀 Examples 👀

Before:
<img width="445" height="101" alt="Screenshot 2025-07-30 at 22 26 29" src="https://github.com/user-attachments/assets/41565c76-82e7-495b-ac66-b88c22af8621" />

After:
<img width="445" height="101" alt="Screenshot 2025-07-30 at 22 26 21" src="https://github.com/user-attachments/assets/a61b1095-2fbc-48a7-a124-47d8de0bf5e2" />

Search example:

https://github.com/user-attachments/assets/cd97f4d2-65ef-4e1e-88fc-8068ec1857b1


