### PR TITLE
feat(list): adds tags to other watchlist based lists

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4558,6 +4558,30 @@
         "android",
         "ios"
       ]
+    },
+    "tag_text_movies": {
+      "default": "Movies",
+      "description": "Text for the tag that indicates a movie.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "tag_text_released": {
+      "default": "Released",
+      "description": "Text for the tag that indicates a movie or show has been released.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "tag_text_unreleased": {
+      "default": "Unreleased",
+      "description": "Text for the tag that indicates a movie or show has not been released yet.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
     }
   }
 }

--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -110,7 +110,7 @@
     }
 
     .trakt-list-title-container {
-      gap: var(--gap-s);
+      gap: var(--gap-xs);
 
       @include for-mobile {
         gap: var(--gap-xs);

--- a/projects/client/src/lib/sections/lists/watchlist/ReleasedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/ReleasedList.svelte
@@ -5,7 +5,6 @@
 </script>
 
 <WatchList
-  title={m.list_title_available_now()}
   drilldownLabel={m.button_label_view_all_released_movies()}
   defaultType="movie"
   status="released"

--- a/projects/client/src/lib/sections/lists/watchlist/UnreleasedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/UnreleasedList.svelte
@@ -5,7 +5,6 @@
 </script>
 
 <WatchList
-  title={m.list_title_coming_soon()}
   drilldownLabel={m.button_label_view_all_unreleased_movies()}
   defaultType="movie"
   status="unreleased"

--- a/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { assertDefined } from "$lib/utils/assert/assertDefined";
@@ -7,20 +9,19 @@
   import { writable } from "svelte/store";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import TypeToggles from "./_internal/TypeToggles.svelte";
+  import WatchlistTag from "./_internal/WatchlistTag.svelte";
   import EmptyWatchlist from "./EmptyWatchlist.svelte";
   import { statusToStore } from "./statusToStore";
   import WatchlistItem from "./WatchlistItem.svelte";
 
   type WatchListProps = {
-    title: string;
     defaultType?: MediaType;
     drilldownLabel: string;
     empty?: Snippet;
     status: "all" | "released" | "unreleased";
   };
 
-  const { title, defaultType, status, drilldownLabel }: WatchListProps =
-    $props();
+  const { defaultType, status, drilldownLabel }: WatchListProps = $props();
   const { filterMap } = useFilter();
 
   const useList = $derived.by(() => statusToStore(status));
@@ -36,7 +37,7 @@
 
 <DrillableMediaList
   id="watch-list-{type}-{status}"
-  {title}
+  title={m.list_title_watchlist()}
   {drilldownLabel}
   {type}
   filter={$filterMap}
@@ -67,6 +68,10 @@
   {#snippet badge()}
     {#if status === "all"}
       <TypeToggles types={selectedTypes} />
+    {/if}
+
+    {#if status === "unreleased" || status === "released"}
+      <WatchlistTag {status} />
     {/if}
   {/snippet}
 </DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -6,6 +6,7 @@
   import { writable } from "svelte/store";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import TypeToggles from "./_internal/TypeToggles.svelte";
+  import WatchlistTag from "./_internal/WatchlistTag.svelte";
   import EmptyWatchlist from "./EmptyWatchlist.svelte";
   import { statusToStore } from "./statusToStore";
   import WatchlistItem from "./WatchlistItem.svelte";
@@ -59,6 +60,10 @@
   {#snippet badge()}
     {#if status === "all" && onTypeChange}
       <TypeToggles types={selectedTypes} />
+    {/if}
+
+    {#if status === "unreleased" || status === "released"}
+      <WatchlistTag {status} />
     {/if}
   {/snippet}
 </DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/WatchlistTag.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/WatchlistTag.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+
+  import InfoTag from "$lib/components/media/tags/InfoTag.svelte";
+
+  type WatchListProps = {
+    status: "released" | "unreleased";
+  };
+
+  const { status }: WatchListProps = $props();
+</script>
+
+<div class="watchlist-tag">
+  <InfoTag>
+    {m.tag_text_movies()}
+  </InfoTag>
+  <InfoTag>
+    {#if status === "released"}
+      {m.tag_text_released()}
+    {:else}
+      {m.tag_text_unreleased()}
+    {/if}
+  </InfoTag>
+</div>
+
+<style>
+  .watchlist-tag {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-4);
+  }
+</style>

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -18,7 +18,6 @@
   <TraktPageCoverSetter />
 
   <WatchList
-    title={m.list_title_watchlist()}
     drilldownLabel={m.button_label_view_all_watchlist_items()}
     status="all"
   />


### PR DESCRIPTION
## ♪ Note ♪

- All watchlist based lists are now tagged. For the released/unreleased ones, only a read-only tag for informational purposes.

## 👀 Example 👀
<img width="376" height="664" alt="Screenshot 2025-07-30 at 21 33 00" src="https://github.com/user-attachments/assets/b794cb72-557d-470c-ae92-8cae3595664a" />
