### PR TITLE
feat(footer): add year chip to all movies

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -48,6 +48,13 @@
       text-decoration: none;
     }
 
+    .trakt-card-footer-tag {
+      width: 100%;
+
+      display: flex;
+      gap: var(--gap-micro);
+    }
+
     .trakt-card-footer-information {
       width: 100%;
       overflow: hidden;

--- a/projects/client/src/lib/components/media/tags/DurationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/DurationTag.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
@@ -13,9 +12,6 @@
 </script>
 
 <StemTag>
-  {#snippet icon()}
-    <ClockIcon />
-  {/snippet}
   <p class="meta-info capitalize no-wrap">
     {i18n.toDuration(runtime)}
   </p>

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -22,16 +22,17 @@
 </script>
 
 {#snippet tag()}
-  {#if media.airDate > new Date()}
+  {#if "episode" in media}
+    <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
+  {:else if type === "movie" && variant !== "activity"}
     <AirDateTag
       i18n={TagIntlProvider}
       year={media.year}
       airDate={media.airDate}
     />
-  {:else if "episode" in media}
-    <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
-  {:else if type === "movie" && variant !== "activity"}
-    <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
+    {#if media.airDate < new Date()}
+      <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
+    {/if}
   {/if}
 {/snippet}
 


### PR DESCRIPTION
## ♪ Note ♪

- Adds year chip to movie card footers.

## 👀 Example 👀
<img width="1017" height="950" alt="Screenshot 2025-07-31 at 12 15 52" src="https://github.com/user-attachments/assets/cf57f813-ca6d-4065-aaed-9c83ad7d87f8" />
