### PR TITLE
fix(summary): only show watch history list starting at 2 plays

### DIFF
--- a/projects/client/src/lib/sections/lists/history/MediaWatchHistoryList.svelte
+++ b/projects/client/src/lib/sections/lists/history/MediaWatchHistoryList.svelte
@@ -1,41 +1,49 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
-  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
-  import type { MediaType } from "$lib/requests/models/MediaType";
+  import {
+    useWatchCount,
+    type UseWatchCountProps,
+  } from "$lib/stores/useWatchCount";
   import MediaList from "../drilldown/MediaList.svelte";
   import { useRecentlyWatchedList } from "../stores/useRecentlyWatchedList";
   import RecentlyWatchedItem from "./RecentlyWatchedItem.svelte";
 
+  const MINIMUM_WATCH_COUNT = 2;
+
   type RecentlyWatchedListProps = {
     title: string;
-    type: MediaType | "episode";
-    media: MediaEntry | EpisodeEntry;
-  };
+  } & UseWatchCountProps;
 
-  const { title, type, media }: RecentlyWatchedListProps = $props();
+  const { title, ...target }: RecentlyWatchedListProps = $props();
+
+  const { watchCount } = $derived(useWatchCount(target));
+  const targetItem = $derived(
+    target.type === "episode" ? target.episode : target.media,
+  );
 </script>
 
 <RenderFor audience="authenticated">
-  <MediaList
-    id="media-watch-history-list-{type}-{media.id}"
-    {title}
-    type="episode"
-    useList={({ limit, page }) =>
-      useRecentlyWatchedList({
-        type,
-        limit,
-        page,
-        id: media.id,
-      })}
-  >
-    {#snippet item(media)}
-      <RecentlyWatchedItem {media} isActionable />
-    {/snippet}
+  {#if $watchCount >= MINIMUM_WATCH_COUNT}
+    <MediaList
+      id="media-watch-history-list-{target.type}-{targetItem.id}"
+      {title}
+      type="episode"
+      useList={({ limit, page }) =>
+        useRecentlyWatchedList({
+          type: target.type,
+          limit,
+          page,
+          id: targetItem.id,
+        })}
+    >
+      {#snippet item(media)}
+        <RecentlyWatchedItem {media} isActionable />
+      {/snippet}
 
-    {#snippet empty()}
-      <p>{m.list_placeholder_media_history({ title: media.title })}</p>
-    {/snippet}
-  </MediaList>
+      {#snippet empty()}
+        <p>{m.list_placeholder_media_history({ title: targetItem.title })}</p>
+      {/snippet}
+    </MediaList>
+  {/if}
 </RenderFor>

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -195,6 +195,7 @@
 
 <MediaWatchHistoryList
   title={m.list_title_recently_watched()}
-  media={episode}
+  {episode}
+  {show}
   type="episode"
 />

--- a/projects/client/src/lib/stores/useWatchCount.ts
+++ b/projects/client/src/lib/stores/useWatchCount.ts
@@ -5,7 +5,7 @@ import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 import { derived } from 'svelte/store';
 
-type UseWatchCountProps = {
+export type UseWatchCountProps = {
   type: MediaType;
   media: MediaEntry;
 } | {


### PR DESCRIPTION
## ♪ Note ♪

- On summary pages, only show the watch history if there are at least 2 plays.