### PR TITLE
fix(cover): use more clear cover images on small devices

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -94,7 +94,7 @@
       filter: grayscale(0.5);
 
       transition: var(--transition-increment) ease-in-out;
-      transition-property: opacity, width, left;
+      transition-property: filter, opacity, width, left;
 
       @include for-tablet-sm-and-below {
         width: 150%;
@@ -169,11 +169,45 @@
     }
 
     &:not([data-cover-type="main"]) {
+      :global(img) {
+        @include for-tablet-sm-and-below {
+          filter: none;
+        }
+      }
+
       &::after {
         @include backdrop-filter-blur(var(--ni-2));
 
         @include for-tablet-sm-and-below {
           backdrop-filter: unset;
+
+          background: linear-gradient(
+            180deg,
+            var(--color-background) 0%,
+            color-mix(in srgb, var(--color-background) 48%, transparent) 10%,
+            transparent 25%,
+            color-mix(in srgb, var(--color-background) 25%, transparent) 45%,
+            color-mix(in srgb, var(--color-background) 88%, transparent) 60%,
+            var(--color-background) 90%
+          );
+        }
+      }
+
+      &::before {
+        @include for-tablet-sm-and-below {
+          background: none;
+        }
+      }
+
+      &.trakt-background-has-mirror {
+        &::after {
+          background: linear-gradient(
+            180deg,
+            transparent 0%,
+            color-mix(in srgb, var(--color-background) 25%, transparent) 45%,
+            color-mix(in srgb, var(--color-background) 88%, transparent) 60%,
+            var(--color-background) 90%
+          );
         }
       }
     }

--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -55,7 +55,7 @@
   </RenderFor>
 
   {#if first}
-    <CoverImageSetter src={first.cover.url.medium} type={first.type} />
+    <CoverImageSetter src={first.cover.url.medium} type="main" />
   {:else}
     <TraktPageCoverSetter />
   {/if}


### PR DESCRIPTION
## ♪ Note ♪

- Uses more clear cover images on small devices

## 👀 Examples 👀

Before/after:
<img width="373" height="667" alt="Screenshot 2025-07-31 at 13 12 04" src="https://github.com/user-attachments/assets/bba6cef0-aa55-40bd-beab-a14ba4d25e3b" /> <img width="373" height="667" alt="Screenshot 2025-07-31 at 13 18 03" src="https://github.com/user-attachments/assets/b2f69aff-a409-421c-99f2-9db47a8454f3" />


Before/after:
<img width="373" height="667" alt="Screenshot 2025-07-31 at 13 12 16" src="https://github.com/user-attachments/assets/20e4ba08-0c3d-43c4-95a9-e7b7ebaffade" /> <img width="373" height="667" alt="Screenshot 2025-07-31 at 13 18 08" src="https://github.com/user-attachments/assets/89eab6b3-ba43-4ad7-8a1e-4d6e8907e878" />
