### PR TITLE
Feat/feature flags

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -25,6 +25,7 @@ export const AnalyticsEvent = {
   Watchlist: buildEventKey(MEDIA_ACTION_PREFIX, 'watchlist'),
   List: buildEventKey(MEDIA_ACTION_PREFIX, 'list'),
   RemoveFromHistory: 'remove-from-history',
+  LikeComment: buildEventKey(MEDIA_ACTION_PREFIX, 'like-comment'),
   React: buildEventKey(ACTION_PREFIX, 'react'),
   AddComment: buildEventKey(MEDIA_ACTION_PREFIX, 'add-comment'),
   Rate: buildEventKey(MEDIA_ACTION_PREFIX, 'rate'),

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -25,6 +25,7 @@ export type AnalyticsEventDataMap = {
   [AnalyticsEvent.Watchlist]: ActionType;
   [AnalyticsEvent.List]: ActionType;
   [AnalyticsEvent.RemoveFromHistory]: never;
+  [AnalyticsEvent.LikeComment]: ActionType;
   [AnalyticsEvent.React]: ReactionType;
   [AnalyticsEvent.AddComment]: CommentType;
   [AnalyticsEvent.Rate]: RatingType;

--- a/projects/client/src/lib/features/auth/queries/currentUserCommentLikesQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserCommentLikesQuery.ts
@@ -1,0 +1,40 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import type { LikedCommentItemResponse } from '@trakt/api';
+import { z } from 'zod';
+import { api, type ApiParams } from '../../../requests/api.ts';
+
+const UserLikeSchema = z.object({
+  type: z.enum(['comment', 'list']),
+  id: z.number(),
+});
+
+export type UserLike = z.infer<typeof UserLikeSchema>;
+
+function mapRatedItemResponse(response: LikedCommentItemResponse): UserLike {
+  return {
+    type: response.type,
+    id: response.comment.id,
+  };
+}
+
+const currentUserCommentLikesRequest = ({ fetch }: ApiParams) =>
+  api({ fetch })
+    .users
+    .likes
+    .comments({
+      query: {
+        limit: 'all',
+        extended: 'min',
+      },
+    });
+
+export const currentUserCommentLikesQuery = defineQuery({
+  key: 'currentUserLikes',
+  request: () => currentUserCommentLikesRequest({ fetch }),
+  invalidations: [InvalidateAction.Like],
+  dependencies: [],
+  mapper: (response) => response.body.map(mapRatedItemResponse),
+  schema: UserLikeSchema.array(),
+  ttl: Infinity,
+});

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -1,5 +1,9 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { derived, get, readable } from 'svelte/store';
+import {
+  currentUserCommentLikesQuery,
+  type UserLike,
+} from '../queries/currentUserCommentLikesQuery.ts';
 import { currentUserFavoritesQuery } from '../queries/currentUserFavoritesQuery.ts';
 import {
   currentUserHistoryQuery,
@@ -93,6 +97,7 @@ export function useUser() {
         movies: new Map(),
         shows: new Map(),
       }),
+      likes: readable<UserLike[]>([]),
       favorites: readable({
         movies: new Map(),
         shows: new Map(),
@@ -107,6 +112,7 @@ export function useUser() {
   const historyQueryResponse = useQuery(currentUserHistoryQuery());
   const watchlistQueryResponse = useQuery(currentUserWatchlistQuery());
   const ratingsQueryResponse = useQuery(currentUserRatingsQuery());
+  const commentLikesQueryResponse = useQuery(currentUserCommentLikesQuery());
   const favoritesQueryResponse = useQuery(currentUserFavoritesQuery());
   const followingQueryResponse = useQuery(currentUserNetworkQuery());
 
@@ -126,6 +132,10 @@ export function useUser() {
     ratingsQueryResponse,
     ($ratings) => definedData($ratings.data),
   );
+  const likes = derived(
+    commentLikesQueryResponse,
+    ($likes) => definedData($likes.data),
+  );
   const favorites = derived(
     favoritesQueryResponse,
     ($favorites) => definedData($favorites.data),
@@ -140,6 +150,7 @@ export function useUser() {
     history,
     watchlist,
     ratings,
+    likes,
     favorites,
     network,
   };

--- a/projects/client/src/lib/features/feature-flag/FeatureFlagProvider.svelte
+++ b/projects/client/src/lib/features/feature-flag/FeatureFlagProvider.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { createFeatureFlagContext } from "./_internal/createFeatureFlagContext";
+
+  const { children }: ChildrenProps = $props();
+
+  createFeatureFlagContext();
+</script>
+
+{@render children()}

--- a/projects/client/src/lib/features/feature-flag/FeatureFlagTool.svelte
+++ b/projects/client/src/lib/features/feature-flag/FeatureFlagTool.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import CircularLogo from "$lib/components/icons/CircularLogo.svelte";
+  import Switch from "$lib/components/toggles/Switch.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import Sidebar from "$lib/sections/navbar/components/filter/_internal/Sidebar.svelte";
+  import { safeLocalStorage } from "$lib/utils/storage/safeStorage.ts";
+  import { writable } from "svelte/store";
+  import { FEATURE_FLAG_LOCAL_STORAGE_KEY } from "./_internal/createFeatureFlagContext.ts";
+  import { getFeatureFlagContext } from "./_internal/getFeatureFlagContext.ts";
+  import { FeatureFlag } from "./models/FeatureFlag.ts";
+
+  const { flags } = getFeatureFlagContext();
+
+  const setFlag = (flag: FeatureFlag, value: boolean) => {
+    flags.update((currentFlags) => {
+      const updatedFlags = { ...currentFlags, [flag]: value };
+      safeLocalStorage.setItem(
+        FEATURE_FLAG_LOCAL_STORAGE_KEY,
+        JSON.stringify(updatedFlags),
+      );
+      return updatedFlags;
+    });
+  };
+
+  const isOpen = writable(false);
+</script>
+
+<RenderFor audience="director">
+  <ActionButton
+    label="Feature flags"
+    onclick={() => isOpen.set(!$isOpen)}
+    style="ghost"
+  >
+    <CircularLogo variant="flat" />
+  </ActionButton>
+
+  <Sidebar {isOpen} title="Feature Flags">
+    {#each Object.entries($flags) as [key, value]}
+      <div class="feature-flag-item">
+        <span class="meta-info">{key}</span>
+        <Switch
+          color="orange"
+          label={key}
+          checked={value}
+          innerText={value ? "on" : "off"}
+          onclick={() => setFlag(key as FeatureFlag, !value)}
+        />
+      </div>
+    {/each}
+  </Sidebar>
+</RenderFor>
+
+<style>
+  .feature-flag-item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    gap: var(--gap-m);
+  }
+</style>

--- a/projects/client/src/lib/features/feature-flag/_internal/FeatureFlagContext.ts
+++ b/projects/client/src/lib/features/feature-flag/_internal/FeatureFlagContext.ts
@@ -1,0 +1,10 @@
+import type { Writable } from 'svelte/store';
+import type { FeatureFlag } from '../models/FeatureFlag.ts';
+
+type FeatureFlags = {
+  [key in FeatureFlag]: boolean;
+};
+
+export type FeatureFlagContext = {
+  flags: Writable<FeatureFlags>;
+};

--- a/projects/client/src/lib/features/feature-flag/_internal/FeatureFlagContextKey.ts
+++ b/projects/client/src/lib/features/feature-flag/_internal/FeatureFlagContextKey.ts
@@ -1,0 +1,1 @@
+export const FEATURE_FLAG_CONTEXT_KEY = Symbol('feature-flag-context');

--- a/projects/client/src/lib/features/feature-flag/_internal/createFeatureFlagContext.ts
+++ b/projects/client/src/lib/features/feature-flag/_internal/createFeatureFlagContext.ts
@@ -1,0 +1,30 @@
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+import { getContext, setContext } from 'svelte';
+import { writable } from 'svelte/store';
+import { FeatureFlag } from '../models/FeatureFlag.ts';
+import type { FeatureFlagContext } from './FeatureFlagContext.ts';
+import { FEATURE_FLAG_CONTEXT_KEY } from './FeatureFlagContextKey.ts';
+
+export const FEATURE_FLAG_LOCAL_STORAGE_KEY = 'trakt-feature-flags';
+
+function initializeFlags() {
+  const storedFlags = safeLocalStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_KEY);
+  const parsedFlags = storedFlags ? JSON.parse(storedFlags) : {};
+
+  return Object.values(FeatureFlag).reduce((acc, flag) => {
+    acc[flag] = parsedFlags[flag] ?? false;
+    return acc;
+  }, {} as Record<string, boolean>);
+}
+
+export function createFeatureFlagContext() {
+  const ctx = setContext(
+    FEATURE_FLAG_CONTEXT_KEY,
+    getContext<FeatureFlagContext>(FEATURE_FLAG_CONTEXT_KEY) ??
+      {
+        flags: writable(initializeFlags()),
+      },
+  );
+
+  return ctx;
+}

--- a/projects/client/src/lib/features/feature-flag/_internal/getFeatureFlagContext.ts
+++ b/projects/client/src/lib/features/feature-flag/_internal/getFeatureFlagContext.ts
@@ -1,0 +1,15 @@
+import { getContext } from 'svelte';
+import type { FeatureFlagContext } from './FeatureFlagContext.ts';
+import { FEATURE_FLAG_CONTEXT_KEY } from './FeatureFlagContextKey.ts';
+
+export function getFeatureFlagContext() {
+  const context = getContext<FeatureFlagContext>(FEATURE_FLAG_CONTEXT_KEY);
+
+  if (!context) {
+    throw new Error(
+      'Feature flag context not found. Make sure to call use this within the FeatureFlagProvider scope.',
+    );
+  }
+
+  return context;
+}

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -1,0 +1,3 @@
+export enum FeatureFlag {
+  Reactions = 'reactions',
+}

--- a/projects/client/src/lib/features/feature-flag/useFeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/useFeatureFlag.ts
@@ -1,0 +1,11 @@
+import { derived } from 'svelte/store';
+import { getFeatureFlagContext } from './_internal/getFeatureFlagContext.ts';
+import type { FeatureFlag } from './models/FeatureFlag.ts';
+
+export function useFeatureFlag(flag: FeatureFlag) {
+  const { flags } = getFeatureFlagContext();
+
+  return {
+    isEnabled: derived(flags, ($flags) => $flags[flag]),
+  };
+}

--- a/projects/client/src/lib/guards/RenderForFeature.svelte
+++ b/projects/client/src/lib/guards/RenderForFeature.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
+  import type { Snippet } from "svelte";
+
+  const {
+    flag,
+    enabled,
+    children,
+  }: { flag: FeatureFlag; enabled: Snippet } & ChildrenProps = $props();
+
+  const { isEnabled } = $derived(useFeatureFlag(flag));
+</script>
+
+{#if $isEnabled}
+  {@render enabled()}
+{:else}
+  {@render children()}
+{/if}

--- a/projects/client/src/lib/requests/models/InvalidateAction.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.ts
@@ -13,6 +13,7 @@ export type InvalidateActionOptions =
   | `${typeof INVALIDATION_ID}:watchlisted:${MediaType}`
   | `${typeof INVALIDATION_ID}:dropped:show`
   | `${typeof INVALIDATION_ID}:restored:show`
+  | `${typeof INVALIDATION_ID}:like:comment`
   | `${typeof INVALIDATION_ID}:comment:reply`
   | `${typeof INVALIDATION_ID}:listed:${MediaType}`
   | `${typeof INVALIDATION_ID}:user:${UserType}`
@@ -26,6 +27,7 @@ type TypeDataMap = {
   'watchlisted': MediaType;
   'dropped': 'show';
   'restored': 'show';
+  'like': 'comment';
   'react': 'comment';
   'comment': 'reply';
   'listed': MediaType;
@@ -69,6 +71,7 @@ export const InvalidateAction = {
 
   Restore: buildInvalidationKey('restored', 'show'),
 
+  Like: buildInvalidationKey('like', 'comment'),
   React: buildInvalidationKey('react', 'comment'),
 
   ReplyToComment: buildInvalidationKey('comment', 'reply'),

--- a/projects/client/src/lib/requests/queries/comments/likeCommentRequest.ts
+++ b/projects/client/src/lib/requests/queries/comments/likeCommentRequest.ts
@@ -1,0 +1,16 @@
+import { api, type ApiParams } from '$lib/requests/api.ts';
+
+type LikeCommentParams = { id: number } & ApiParams;
+
+export function likeCommentRequest(
+  { fetch, id }: LikeCommentParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .comments
+    .like({
+      params: {
+        id: `${id}`,
+      },
+    })
+    .then(({ status }) => status === 204);
+}

--- a/projects/client/src/lib/requests/queries/comments/unlikeCommentRequest.ts
+++ b/projects/client/src/lib/requests/queries/comments/unlikeCommentRequest.ts
@@ -1,0 +1,16 @@
+import { api, type ApiParams } from '$lib/requests/api.ts';
+
+type UnlikeCommentParams = { id: number } & ApiParams;
+
+export function unlikeCommentRequest(
+  { fetch, id }: UnlikeCommentParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .comments
+    .unlike({
+      params: {
+        id: `${id}`,
+      },
+    })
+    .then(({ status }) => status === 204);
+}

--- a/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
@@ -35,7 +35,7 @@ const showCommentsRequest = (
 
 export const episodeCommentsQuery = defineQuery({
   key: 'episodeComments',
-  invalidations: [InvalidateAction.Commented('episode')],
+  invalidations: [InvalidateAction.Like, InvalidateAction.Commented('episode')],
   dependencies: (
     params,
   ) => [params.slug, params.season, params.episode, params.limit],

--- a/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
@@ -28,7 +28,7 @@ const movieCommentsRequest = (
 
 export const movieCommentsQuery = defineQuery({
   key: 'movieComments',
-  invalidations: [InvalidateAction.Commented('movie')],
+  invalidations: [InvalidateAction.Like, InvalidateAction.Commented('movie')],
   dependencies: (params) => [params.slug, params.limit],
   request: movieCommentsRequest,
   mapper: (response) => response.body.map(mapToMediaComment),

--- a/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
@@ -28,7 +28,7 @@ const showCommentsRequest = (
 
 export const showCommentsQuery = defineQuery({
   key: 'showComments',
-  invalidations: [InvalidateAction.Commented('show')],
+  invalidations: [InvalidateAction.Like, InvalidateAction.Commented('show')],
   dependencies: (params) => [params.slug, params.limit],
   request: showCommentsRequest,
   mapper: (response) => response.body.map(mapToMediaComment),

--- a/projects/client/src/lib/sections/footer/components/FooterContent.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterContent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import FeatureFlagTool from "$lib/features/feature-flag/FeatureFlagTool.svelte";
   import LocalePicker from "$lib/features/i18n/components/LocalePicker.svelte";
   import ThemePicker from "$lib/features/theme/components/ThemePicker.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -33,6 +34,7 @@
       </RenderFor>
       <LocalePicker />
       <ThemePicker />
+      <FeatureFlagTool />
     </div>
     <div class="trakt-footer-right">
       <RenderFor audience="all" navigation="default">

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/LikeCommentAction.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/LikeCommentAction.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import LikeCommentButton from "$lib/components/buttons/like-comment/LikeCommentButton.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import type { MediaComment } from "$lib/requests/models/MediaComment";
+  import { useCommentLikes } from "./useCommentLikes";
+
+  type LikeCommentButtonProps = {
+    comment: MediaComment;
+  };
+
+  const { comment }: LikeCommentButtonProps = $props();
+
+  const { likes } = useUser();
+  const { like, unlike, isLiking } = $derived(
+    useCommentLikes({ id: comment.id }),
+  );
+
+  const isLiked = $derived(
+    !!$likes?.some((like) => like.type === "comment" && like.id === comment.id),
+  );
+</script>
+
+<LikeCommentButton
+  style="normal"
+  size="normal"
+  onLike={like}
+  onUnlike={unlike}
+  {isLiked}
+  isLiking={$isLiking}
+  likeCount={comment.likeCount}
+/>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactAction.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactAction.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { MediaComment } from "$lib/requests/models/MediaComment";
+  import LikeCommentAction from "./LikeCommentAction.svelte";
   import ReactionPopupMenu from "./ReactionPopupMenu.svelte";
   import ReactionsSummary from "./ReactionsSummary.svelte";
 
   const { comment }: { comment: MediaComment } = $props();
 </script>
 
-<RenderFor audience="public">
-  <ReactionsSummary {comment} />
-</RenderFor>
+<RenderForFeature flag={FeatureFlag.Reactions}>
+  {#snippet enabled()}
+    <RenderFor audience="public">
+      <ReactionsSummary {comment} />
+    </RenderFor>
 
-<RenderFor audience="authenticated">
-  <ReactionPopupMenu {comment} />
-</RenderFor>
+    <RenderFor audience="authenticated">
+      <ReactionPopupMenu {comment} />
+    </RenderFor>
+  {/snippet}
+
+  <LikeCommentAction {comment} />
+</RenderForFeature>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useCommentLikes.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useCommentLikes.ts
@@ -1,0 +1,43 @@
+import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
+import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { likeCommentRequest } from '$lib/requests/queries/comments/likeCommentRequest.ts';
+import { unlikeCommentRequest } from '$lib/requests/queries/comments/unlikeCommentRequest.ts';
+import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { writable } from 'svelte/store';
+
+type UseCommentLikesProps = {
+  id: number;
+};
+
+export function useCommentLikes({ id }: UseCommentLikesProps) {
+  const isLiking = writable(false);
+  const { invalidate } = useInvalidator();
+  const { track } = useTrack(AnalyticsEvent.LikeComment);
+
+  const like = async () => {
+    isLiking.set(true);
+    track({ action: 'add' });
+
+    await likeCommentRequest({ id });
+    await invalidate(InvalidateAction.Like);
+
+    isLiking.set(false);
+  };
+
+  const unlike = async () => {
+    isLiking.set(true);
+    track({ action: 'remove' });
+
+    await unlikeCommentRequest({ id });
+    await invalidate(InvalidateAction.Like);
+
+    isLiking.set(false);
+  };
+
+  return {
+    isLiking,
+    like,
+    unlike,
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -44,12 +44,13 @@
   .trakt-summary-container {
     display: grid;
     gap: var(--gap-xl);
+    grid-template-columns: minmax(var(--ni-320), 1fr) 2fr 1fr;
+    margin: 0 var(--layout-distance-side);
+
     @include for-mobile {
       /* Poster is hidden in mobile layout. */
       gap: initial;
     }
-    grid-template-columns: minmax(var(--ni-320), 1fr) 2fr 1fr;
-    margin: 0 var(--layout-distance-side);
 
     @include for-tablet-sm-and-below {
       grid-template-columns: 1fr;

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
   import CookieConsentProvider from "$lib/features/cookie-consent/CookieConsentProvider.svelte";
   import { DeploymentEndpoint } from "$lib/features/deployment/DeploymentEndpoint.js";
   import ErrorProvider from "$lib/features/errors/ErrorProvider.svelte";
+  import FeatureFlagProvider from "$lib/features/feature-flag/FeatureFlagProvider.svelte";
   import FilterProvider from "$lib/features/filters/FilterProvider.svelte";
   import LocaleProvider from "$lib/features/i18n/components/LocaleProvider.svelte";
   import NavigationProvider from "$lib/features/navigation/NavigationProvider.svelte";
@@ -129,46 +130,48 @@
                   <SearchProvider type="show">
                     <SearchProvider type="movie">
                       <FilterProvider>
-                        <CoverProvider>
-                          <NowPlayingProvider>
-                            <CoverImage />
+                        <FeatureFlagProvider>
+                          <CoverProvider>
+                            <NowPlayingProvider>
+                              <CoverImage />
 
-                            <ThemeProvider theme={data.theme}>
-                              <ListScrollHistoryProvider>
-                                <div class="trakt-layout-wrapper">
-                                  <Navbar />
-                                  <div class="trakt-layout-content">
-                                    {@render children()}
+                              <ThemeProvider theme={data.theme}>
+                                <ListScrollHistoryProvider>
+                                  <div class="trakt-layout-wrapper">
+                                    <Navbar />
+                                    <div class="trakt-layout-content">
+                                      {@render children()}
+                                    </div>
+                                    <RenderFor
+                                      audience="all"
+                                      navigation="default"
+                                    >
+                                      <Footer />
+                                    </RenderFor>
                                   </div>
                                   <RenderFor
                                     audience="all"
+                                    device={["mobile", "tablet-sm"]}
                                     navigation="default"
                                   >
-                                    <Footer />
+                                    <MobileNavbar />
                                   </RenderFor>
-                                </div>
-                                <RenderFor
-                                  audience="all"
-                                  device={["mobile", "tablet-sm"]}
-                                  navigation="default"
-                                >
-                                  <MobileNavbar />
-                                </RenderFor>
-                                <RenderFor
-                                  audience="authenticated"
-                                  navigation="default"
-                                >
-                                  <NowPlaying />
-                                </RenderFor>
-                                <SvelteQueryDevtools
-                                  buttonPosition="bottom-right"
-                                  styleNonce="opacity: 0.5"
-                                />
-                                <FirefoxBlurHack />
-                              </ListScrollHistoryProvider>
-                            </ThemeProvider>
-                          </NowPlayingProvider>
-                        </CoverProvider>
+                                  <RenderFor
+                                    audience="authenticated"
+                                    navigation="default"
+                                  >
+                                    <NowPlaying />
+                                  </RenderFor>
+                                  <SvelteQueryDevtools
+                                    buttonPosition="bottom-right"
+                                    styleNonce="opacity: 0.5"
+                                  />
+                                  <FirefoxBlurHack />
+                                </ListScrollHistoryProvider>
+                              </ThemeProvider>
+                            </NowPlayingProvider>
+                          </CoverProvider>
+                        </FeatureFlagProvider>
                       </FilterProvider>
                     </SearchProvider>
                   </SearchProvider>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds support for using feature flags.
  - 1 flag at the moment, for reactions.
  - Adding a feature flag: add an entry to the `FeatureFlag` enum, and use the `RenderForFeature` guard with that flag.
- Reverts the removal of the `like comment` code.
- Places the comment reactions under the feature flag.
  - By default likes are used, reactions are shown when the flag is enabled.
- The button is placed in the footer. Having a fixed position button in the UI quickly got annoying.

## 👀 Examples 👀
<img width="1406" height="1223" alt="Screenshot 2025-07-31 at 15 53 36" src="https://github.com/user-attachments/assets/ab05ca4c-7f07-4470-8ec5-7d722ce0c566" />

<img width="373" height="664" alt="Screenshot 2025-07-31 at 15 54 09" src="https://github.com/user-attachments/assets/9e7556e2-1024-4fe6-af7b-d7824f978389" />


https://github.com/user-attachments/assets/0371b81d-913d-4b0b-981f-efa4a06c4efe

