### PR TITLE
Updates "Keep Watching" to "Continue Watching"

### DIFF
--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -51,7 +51,7 @@
       }
     },
     "list_title_up_next": {
-      "default": "Keep Watching"
+      "default": "Continue Watching"
     },
     "tag_text_remaining_episodes": {
       "default": "{count} remaining",


### PR DESCRIPTION
Updates the "Keep Watching" text to "Continue Watching" in the Australian English translation.

This aligns the Australian English translation with the intended terminology used in the application.