### PR TITLE
fix(summary): display TBA for unknown dates

### DIFF
--- a/projects/client/src/lib/components/media/tags/AirDateTag.spec.ts
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_DATE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { render, screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
@@ -5,11 +6,10 @@ import AirDateTag from './AirDateTag.svelte';
 import { TagIntlProvider } from './TagIntlProvider.ts';
 
 describe('AirDateTag', () => {
-  it('should display TBA when year is null', () => {
+  it('should display TBA when date is MAX_DATE', () => {
     render(AirDateTag, {
       props: {
-        year: null,
-        airDate: new Date(),
+        airDate: new Date(MAX_DATE),
         i18n: TagIntlProvider,
       },
     });
@@ -23,7 +23,6 @@ describe('AirDateTag', () => {
 
     render(AirDateTag, {
       props: {
-        year: airDate.getFullYear(),
         airDate,
         i18n: TagIntlProvider,
       },
@@ -37,7 +36,6 @@ describe('AirDateTag', () => {
 
     render(AirDateTag, {
       props: {
-        year: airDate.getFullYear(),
         airDate,
         i18n: TagIntlProvider,
       },
@@ -51,7 +49,6 @@ describe('AirDateTag', () => {
 
     render(AirDateTag, {
       props: {
-        year: airDate.getFullYear(),
         airDate,
         i18n: TagIntlProvider,
       },
@@ -65,7 +62,6 @@ describe('AirDateTag', () => {
 
     render(AirDateTag, {
       props: {
-        year: airDate.getFullYear(),
         airDate,
         i18n: TagIntlProvider,
       },
@@ -79,7 +75,6 @@ describe('AirDateTag', () => {
 
     render(AirDateTag, {
       props: {
-        year: airDate.getFullYear(),
         airDate,
         i18n: TagIntlProvider,
       },
@@ -94,7 +89,6 @@ describe('AirDateTag', () => {
 
     render(AirDateTag, {
       props: {
-        year: airDate.getFullYear(),
         airDate,
         i18n: TagIntlProvider,
       },

--- a/projects/client/src/lib/components/media/tags/AirDateTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import { isMaxDate } from "$lib/utils/date/isMaxDate";
   import type { TagIntl } from "./TagIntl";
 
   const {
-    year,
     airDate,
     i18n,
   }: {
-    year: number | Nil;
     airDate: Date;
     i18n: TagIntl;
   } = $props();
@@ -15,8 +14,7 @@
 
 <StemTag>
   <p class="meta-info capitalize no-wrap">
-    {#if year == null}
-      <!-- TODO: investigate if we can determine using airDate -->
+    {#if isMaxDate(airDate)}
       {i18n.tbaLabel()}
     {:else}
       {i18n.toReleaseEstimate(airDate)}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -25,11 +25,7 @@
   {#if "episode" in media}
     <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
   {:else if type === "movie" && variant !== "activity"}
-    <AirDateTag
-      i18n={TagIntlProvider}
-      year={media.year}
-      airDate={media.airDate}
-    />
+    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
     {#if media.airDate < new Date()}
       <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
     {/if}

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -57,11 +57,7 @@
     {/if}
 
     {#if props.variant === "upcoming"}
-      <AirDateTag
-        i18n={TagIntlProvider}
-        airDate={props.episode.airDate}
-        year={props.episode.year}
-      />
+      <AirDateTag i18n={TagIntlProvider} airDate={props.episode.airDate} />
     {/if}
   </div>
 {/snippet}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -10,6 +10,7 @@ import type {
 import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
 import type { MediaStudio } from '$lib/requests/models/MediaStudio.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { isMaxDate } from '$lib/utils/date/isMaxDate.ts';
 import { toHumanDay } from '$lib/utils/formatting/date/toHumanDay.ts';
 import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 import { toCountryName } from '$lib/utils/formatting/intl/toCountryName.ts';
@@ -27,6 +28,13 @@ function originalTitle(media: MediaEntry) {
 }
 
 function mediaAirDate(media: MediaEntry) {
+  if (isMaxDate(media.airDate)) {
+    return {
+      title: m.header_expected_premiere(),
+      values: [m.tag_text_tba()],
+    };
+  }
+
   const isUpcomingItem = media.airDate > new Date();
   return {
     title: isUpcomingItem ? m.header_expected_premiere() : m.header_premiered(),

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -40,11 +40,7 @@
       {/if}
 
       {#if media.year}
-        <AirDate
-          i18n={TagIntlProvider}
-          year={media.year}
-          airDate={media.airDate}
-        />
+        <AirDate i18n={TagIntlProvider} airDate={media.airDate} />
       {/if}
 
       <!-- FIXME: re-enable watchers once we have better watching stats -->

--- a/projects/client/src/lib/utils/date/isMaxDate.ts
+++ b/projects/client/src/lib/utils/date/isMaxDate.ts
@@ -1,0 +1,9 @@
+import { MAX_DATE } from '../constants.ts';
+
+export function isMaxDate(date: Date | Nil): boolean {
+  if (!date) {
+    return false;
+  }
+
+  return date.getTime() === MAX_DATE.getTime();
+}


### PR DESCRIPTION
Refactors the AirDate tag to rely solely on the `airDate` property and introduces a utility function to determine if a date represents an unknown or TBA state. This removes the need for a separate `year` property and centralizes the logic for displaying "TBA" status.

- Uses `isMaxDate` to check if the airDate represents a "To Be Announced" state.
- Simplifies components using the AirDate tag by removing the year prop.