### PR TITLE
feat(popular): implicitly filter on current year to keep things fresh

### DIFF
--- a/projects/client/src/lib/requests/models/FilterParams.ts
+++ b/projects/client/src/lib/requests/models/FilterParams.ts
@@ -6,6 +6,7 @@ export type FilterParams = DeepPartial<{
       -update defineQuery to deal with object dependencies
     */
     genres: string;
+    years: string;
     ignore_watched: boolean;
     ignore_watchlisted: boolean;
     watch_window: number;

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -24,6 +24,11 @@ type PopularListStoreProps =
 function typeToQuery(
   { type, ...params }: PopularListStoreProps,
 ) {
+  // FIXME: remove this when behavior is uplifted to the server
+  params.filter = params.filter ?? {};
+  params.filter.years = params.filter?.years ??
+    new Date().getFullYear().toString();
+
   switch (type) {
     case 'movie':
       return moviePopularQuery(params);


### PR DESCRIPTION
Ensures that the popular content lists are implicitly filtered to show content from the current year.

- Keeps the popular lists fresh and relevant by default.
- Adds `years` filter parameter to the `FilterParams` model.