### PR TITLE
ci: remove gemini auto review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@vladjerca @seferturan


### PR DESCRIPTION
## ♪ Note ♪

- Added a codeowners file & change the branch rules to require an approval by an owner.
- ~~Removing the auto gemini pr-review for now.~~ Even though it's instructed to `Don't Approve The Pull Request`, it beautifully ignores it: `I see no issues, so I'll approve the PR with a brief summary comment`.

## 👀 Example 👀
Enabled rule:
<img width="617" height="66" alt="Screenshot 2025-08-11 at 11 45 45" src="https://github.com/user-attachments/assets/e3c04955-dd61-4d32-a92c-5078d135095e" />

