### PR TITLE
Feat/call to action cards in empty-ish lists

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Календар"
+    },
+    "text_cta_up_next": {
+      "default": "Продължете да гледате любимите си сериали и да започнете от там, където сте спрели по всяко време. Кои сериали следите?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Добавете филми към списъка си и започнете да създавате списък с филми, които искате да гледате."
+    },
+    "text_cta_upcoming": {
+      "default": "Предстоящият ви график показва нови епизоди, които ще бъдат публикувани скоро за сериалите, които вече следите."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Добавете предстоящи филми към списъка си и вижте кои ще бъдат публикувани скоро."
+    },
+    "text_cta_activity": {
+      "default": "Започнете да създавате приятели бързо, като следвате екипа на Trakt и проучете какво гледат."
+    },
+    "link_text_browse_shows": {
+      "default": "Разгледайте сериали"
+    },
+    "link_text_browse_movies": {
+      "default": "Разгледайте филми"
+    },
+    "link_text_explore_shows": {
+      "default": "Разгледайте сериали"
+    },
+    "link_text_explore_movies": {
+      "default": "Разгледайте филми"
+    },
+    "link_label_browse_shows": {
+      "default": "Разгледайте сериали"
+    },
+    "link_label_browse_movies": {
+      "default": "Разгледайте филми"
+    },
+    "link_label_explore_shows": {
+      "default": "Разгледайте сериали"
+    },
+    "link_label_explore_movies": {
+      "default": "Разгледайте филми"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Kalender"
+    },
+    "text_cta_up_next": {
+      "default": "Fortsæt med at se dine yndlingsserier, og fortsæt hvor du slap når som helst. Hvilke serier følger du?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Tilføj film til din liste, og begynd at bygge en liste over film, du vil se."
+    },
+    "text_cta_upcoming": {
+      "default": "Din kommende tidsplan viser nye episoder, der snart udkommer for serier, du allerede følger."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Tilføj kommende film til din liste, og se hvilke der snart udkommer."
+    },
+    "text_cta_activity": {
+      "default": "Begynd at få venner hurtigt ved at følge Trakt-teamet, og udforsk hvad de ser."
+    },
+    "link_text_browse_shows": {
+      "default": "Gennemse serier"
+    },
+    "link_text_browse_movies": {
+      "default": "Gennemse film"
+    },
+    "link_text_explore_shows": {
+      "default": "Udforsk serier"
+    },
+    "link_text_explore_movies": {
+      "default": "Udforsk film"
+    },
+    "link_label_browse_shows": {
+      "default": "Gennemse serier"
+    },
+    "link_label_browse_movies": {
+      "default": "Gennemse film"
+    },
+    "link_label_explore_shows": {
+      "default": "Udforsk serier"
+    },
+    "link_label_explore_movies": {
+      "default": "Udforsk film"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Kalender"
+    },
+    "text_cta_up_next": {
+      "default": "Schau deine Lieblingsserien weiter und setze sie jederzeit dort fort, wo du aufgehört hast. Welche Serien verfolgst du gerade?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Füge Filme zu deiner Watchlist hinzu und beginne, eine Liste von Filmen zu erstellen, die du sehen möchtest."
+    },
+    "text_cta_upcoming": {
+      "default": "Dein kommender Zeitplan listet bald erscheinende neue Episoden für Serien auf, denen du bereits folgst."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Füge kommende Filme zu deiner Watchlist hinzu und sieh, welche bald erscheinen."
+    },
+    "text_cta_activity": {
+      "default": "Finde schnell Freunde, indem du dem Trakt Team folgst und entdeckst, was sie sich ansehen."
+    },
+    "link_text_browse_shows": {
+      "default": "Serien"
+    },
+    "link_text_browse_movies": {
+      "default": "Filme"
+    },
+    "link_text_explore_shows": {
+      "default": "Serien entdecken"
+    },
+    "link_text_explore_movies": {
+      "default": "Filme entdecken"
+    },
+    "link_label_browse_shows": {
+      "default": "Serien"
+    },
+    "link_label_browse_movies": {
+      "default": "Filme"
+    },
+    "link_label_explore_shows": {
+      "default": "Serien entdecken"
+    },
+    "link_label_explore_movies": {
+      "default": "Filme entdecken"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendar"
+    },
+    "text_cta_up_next": {
+      "default": "Continue watching your favourite shows and pick up where you left off anytime. Which shows are you currently following?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Add films to your watchlist and start building a list of films you want to watch."
+    },
+    "text_cta_upcoming": {
+      "default": "Your upcoming schedule lists new episodes releasing soon for shows you’re already following."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Add upcoming films to your watchlist and see which ones are releasing soon."
+    },
+    "text_cta_activity": {
+      "default": "Start making friends quickly by following the Trakt Team and explore what they are watching."
+    },
+    "link_text_browse_shows": {
+      "default": "Browse shows"
+    },
+    "link_text_browse_movies": {
+      "default": "Browse movies"
+    },
+    "link_text_explore_shows": {
+      "default": "Explore shows"
+    },
+    "link_text_explore_movies": {
+      "default": "Explore movies"
+    },
+    "link_label_browse_shows": {
+      "default": "Browse shows"
+    },
+    "link_label_browse_movies": {
+      "default": "Browse movies"
+    },
+    "link_label_explore_shows": {
+      "default": "Explore shows"
+    },
+    "link_label_explore_movies": {
+      "default": "Explore movies"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4819,6 +4819,110 @@
         "android",
         "ios"
       ]
+    },
+    "text_cta_up_next": {
+      "default": "Continue watching your favorite shows and pick up where you left off anytime. Which shows are you currently following?",
+      "description": "Call to action text shown in the Up Next list, encouraging users to add their favorite shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_cta_watchlist_released": {
+      "default": "Add movies to your watchlist and start building a list of movies you want to watch.",
+      "description": "Call to action text shown in the Watchlist Released list, encouraging users to add released movies to their watchlist.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_cta_upcoming": {
+      "default": "Your upcoming schedule lists new episodes releasing soon for shows you’re already following.",
+      "description": "Call to action text shown in the Upcoming list, encouraging users to follow shows for upcoming episodes.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Add upcoming movies to your watchlist and see which ones are releasing soon.",
+      "description": "Call to action text shown in the Watchlist Unreleased list, encouraging users to add unreleased movies to their watchlist.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_cta_activity": {
+      "default": "Start making friends quickly by following the Trakt Team and explore what they are watching.",
+      "description": "Call to action text shown in the social activity list, encouraging users to follow members of the Trakt Team.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_text_browse_shows": {
+      "default": "Browse shows",
+      "description": "Link text for browsing shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_text_browse_movies": {
+      "default": "Browse movies",
+      "description": "Link text for browsing movies.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_text_explore_shows": {
+      "default": "Explore shows",
+      "description": "Link text for exploring shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_text_explore_movies": {
+      "default": "Explore movies",
+      "description": "Link text for exploring movies.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_label_browse_shows": {
+      "default": "Browse shows",
+      "description": "Aria-label for the link that allows users to browse shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_label_browse_movies": {
+      "default": "Browse movies",
+      "description": "Aria-label for the link that allows users to browse movies.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_label_explore_shows": {
+      "default": "Explore shows",
+      "description": "Aria-label for the link that allows users to explore shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_label_explore_movies": {
+      "default": "Explore movies",
+      "description": "Aria-label for the link that allows users to explore movies.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendario"
+    },
+    "text_cta_up_next": {
+      "default": "Continúe viendo sus series favoritas y retome donde lo dejó en cualquier momento. ¿Qué series está siguiendo?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Añada películas a su lista de seguimiento y empiece a crear una lista de películas que quiere ver."
+    },
+    "text_cta_upcoming": {
+      "default": "Su calendario de estrenos muestra los nuevos episodios que se publicarán pronto de las series que ya sigue."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Añada películas próximas a su lista de seguimiento y vea cuáles se estrenan pronto."
+    },
+    "text_cta_activity": {
+      "default": "Empiece a hacer amigos rápidamente siguiendo al equipo de Trakt y explore lo que están viendo."
+    },
+    "link_text_browse_shows": {
+      "default": "Explorar series"
+    },
+    "link_text_browse_movies": {
+      "default": "Explorar películas"
+    },
+    "link_text_explore_shows": {
+      "default": "Descubrir series"
+    },
+    "link_text_explore_movies": {
+      "default": "Descubrir películas"
+    },
+    "link_label_browse_shows": {
+      "default": "Explorar series"
+    },
+    "link_label_browse_movies": {
+      "default": "Explorar películas"
+    },
+    "link_label_explore_shows": {
+      "default": "Descubrir series"
+    },
+    "link_label_explore_movies": {
+      "default": "Descubrir películas"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendario"
+    },
+    "text_cta_up_next": {
+      "default": "Sigue viendo tus series favoritas y retoma donde te quedaste en cualquier momento. ¿Qué series estás siguiendo?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Añade pelis a tu lista y empieza a armar una lista de pelis que quieres ver."
+    },
+    "text_cta_upcoming": {
+      "default": "Tu calendario de estrenos lista los nuevos episodios que salen pronto de las series que ya sigues."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Añade las pelis próximas a tu lista y checa cuáles se estrenan pronto."
+    },
+    "text_cta_activity": {
+      "default": "Empieza a hacer amigos rápido siguiendo al equipo Trakt y explora qué están viendo."
+    },
+    "link_text_browse_shows": {
+      "default": "Series"
+    },
+    "link_text_browse_movies": {
+      "default": "Películas"
+    },
+    "link_text_explore_shows": {
+      "default": "Explorar series"
+    },
+    "link_text_explore_movies": {
+      "default": "Explorar películas"
+    },
+    "link_label_browse_shows": {
+      "default": "Series"
+    },
+    "link_label_browse_movies": {
+      "default": "Películas"
+    },
+    "link_label_explore_shows": {
+      "default": "Explorar series"
+    },
+    "link_label_explore_movies": {
+      "default": "Explorar películas"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendrier"
+    },
+    "text_cta_up_next": {
+      "default": "Continuez à regarder vos séries préférées et reprenez où vous en étiez à tout moment. Quelles séries suivez-vous ?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Ajoutez des films à votre liste et commencez à créer une liste de films que vous voulez voir."
+    },
+    "text_cta_upcoming": {
+      "default": "Votre horaire à venir liste les nouveaux épisodes qui sortent bientôt pour les séries que vous suivez déjà."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Ajoutez des films à venir à votre liste et voyez lesquels sortent bientôt."
+    },
+    "text_cta_activity": {
+      "default": "Commencez à vous faire des amis rapidement en suivant l'équipe Trakt et explorez ce qu'ils regardent."
+    },
+    "link_text_browse_shows": {
+      "default": "Séries"
+    },
+    "link_text_browse_movies": {
+      "default": "Films"
+    },
+    "link_text_explore_shows": {
+      "default": "Explorez séries"
+    },
+    "link_text_explore_movies": {
+      "default": "Explorez films"
+    },
+    "link_label_browse_shows": {
+      "default": "Séries"
+    },
+    "link_label_browse_movies": {
+      "default": "Films"
+    },
+    "link_label_explore_shows": {
+      "default": "Explorez séries"
+    },
+    "link_label_explore_movies": {
+      "default": "Explorez films"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendrier"
+    },
+    "text_cta_up_next": {
+      "default": "Continuez à regarder vos séries favorites et reprenez là où vous en étiez à tout moment. Quelles séries suivez-vous ?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Ajoutez des films à votre liste de souhaits et commencez à constituer une liste de films à voir."
+    },
+    "text_cta_upcoming": {
+      "default": "Votre programme à venir liste les nouveaux épisodes diffusés prochainement pour les séries que vous suivez déjà."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Ajoutez des films à venir à votre liste de souhaits et découvrez lesquels sortent bientôt."
+    },
+    "text_cta_activity": {
+      "default": "Commencez à vous faire des amis rapidement en suivant l'équipe Trakt et explorez ce qu'ils regardent."
+    },
+    "link_text_browse_shows": {
+      "default": "Explorer séries"
+    },
+    "link_text_browse_movies": {
+      "default": "Explorer films"
+    },
+    "link_text_explore_shows": {
+      "default": "Découvrir séries"
+    },
+    "link_text_explore_movies": {
+      "default": "Découvrir films"
+    },
+    "link_label_browse_shows": {
+      "default": "Explorer séries"
+    },
+    "link_label_browse_movies": {
+      "default": "Explorer films"
+    },
+    "link_label_explore_shows": {
+      "default": "Découvrir séries"
+    },
+    "link_label_explore_movies": {
+      "default": "Découvrir films"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendario"
+    },
+    "text_cta_up_next": {
+      "default": "Continua a guardare le tue serie TV preferite e riprendi da dove eri rimasto in qualsiasi momento. Quali serie stai seguendo?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Aggiungi film alla tua lista e inizia a creare un elenco di film che vuoi guardare."
+    },
+    "text_cta_upcoming": {
+      "default": "Il tuo programma in arrivo elenca i nuovi episodi in uscita a breve per le serie TV che stai già seguendo."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Aggiungi i film in uscita alla tua lista e scopri quali usciranno presto."
+    },
+    "text_cta_activity": {
+      "default": "Inizia a fare amicizia velocemente seguendo il Team Trakt ed esplora cosa stanno guardando."
+    },
+    "link_text_browse_shows": {
+      "default": "Sfoglia serie TV"
+    },
+    "link_text_browse_movies": {
+      "default": "Sfoglia film"
+    },
+    "link_text_explore_shows": {
+      "default": "Esplora serie TV"
+    },
+    "link_text_explore_movies": {
+      "default": "Esplora film"
+    },
+    "link_label_browse_shows": {
+      "default": "Sfoglia serie TV"
+    },
+    "link_label_browse_movies": {
+      "default": "Sfoglia film"
+    },
+    "link_label_explore_shows": {
+      "default": "Esplora serie TV"
+    },
+    "link_label_explore_movies": {
+      "default": "Esplora film"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "カレンダー"
+    },
+    "text_cta_up_next": {
+      "default": "お気に入りのドラマの視聴を続けて、いつでも中断したところから再開できます。現在フォローしているドラマはどれですか？"
+    },
+    "text_cta_watchlist_released": {
+      "default": "ウォッチリストに映画を追加して、見たい映画のリストを作成しましょう。"
+    },
+    "text_cta_upcoming": {
+      "default": "今後のスケジュールでは、フォローしているドラマの新しいエピソードが間もなく公開されます。"
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "近日公開の映画をウォッチリストに追加して、まもなく公開される映画を確認しましょう。"
+    },
+    "text_cta_activity": {
+      "default": "Trakt チームをフォローして、彼らが何を見ているか調べて、すぐに友達を作りましょう。"
+    },
+    "link_text_browse_shows": {
+      "default": "ドラマを検索"
+    },
+    "link_text_browse_movies": {
+      "default": "映画を検索"
+    },
+    "link_text_explore_shows": {
+      "default": "ドラマを探す"
+    },
+    "link_text_explore_movies": {
+      "default": "映画を探す"
+    },
+    "link_label_browse_shows": {
+      "default": "ドラマを検索"
+    },
+    "link_label_browse_movies": {
+      "default": "映画を検索"
+    },
+    "link_label_explore_shows": {
+      "default": "ドラマを探す"
+    },
+    "link_label_explore_movies": {
+      "default": "映画を探す"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Kalender"
+    },
+    "text_cta_up_next": {
+      "default": "Fortsett å se favorittseriene dine og fortsett der du slapp når som helst. Hvilke serier følger du?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Legg til filmer på listen din og begynn å bygge en liste over filmer du vil se."
+    },
+    "text_cta_upcoming": {
+      "default": "Din kommende timeplan viser nye episoder som kommer snart for serier du allerede følger."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Legg til kommende filmer på listen din og se hvilke som kommer snart."
+    },
+    "text_cta_activity": {
+      "default": "Begynn å få venner raskt ved å følge Trakt-teamet og utforsk hva de ser på."
+    },
+    "link_text_browse_shows": {
+      "default": "Bla gjennom serier"
+    },
+    "link_text_browse_movies": {
+      "default": "Bla gjennom filmer"
+    },
+    "link_text_explore_shows": {
+      "default": "Utforsk serier"
+    },
+    "link_text_explore_movies": {
+      "default": "Utforsk filmer"
+    },
+    "link_label_browse_shows": {
+      "default": "Bla gjennom serier"
+    },
+    "link_label_browse_movies": {
+      "default": "Bla gjennom filmer"
+    },
+    "link_label_explore_shows": {
+      "default": "Utforsk serier"
+    },
+    "link_label_explore_movies": {
+      "default": "Utforsk filmer"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Kalender"
+    },
+    "text_cta_up_next": {
+      "default": "Bekijk je favoriete series verder en ga verder waar je gebleven was. Welke series volg je momenteel?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Voeg films toe aan je watchlist en begin met het bouwen van een lijst met films die je wilt bekijken."
+    },
+    "text_cta_upcoming": {
+      "default": "Je aankomende schema geeft nieuwe afleveringen weer die binnenkort uitkomen van series die je al volgt."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Voeg aankomende films toe aan je watchlist en bekijk welke binnenkort uitkomen."
+    },
+    "text_cta_activity": {
+      "default": "Maak snel vrienden door het Trakt Team te volgen en te ontdekken wat zij bekijken."
+    },
+    "link_text_browse_shows": {
+      "default": "Series"
+    },
+    "link_text_browse_movies": {
+      "default": "Films"
+    },
+    "link_text_explore_shows": {
+      "default": "Series verkennen"
+    },
+    "link_text_explore_movies": {
+      "default": "Films verkennen"
+    },
+    "link_label_browse_shows": {
+      "default": "Series"
+    },
+    "link_label_browse_movies": {
+      "default": "Films"
+    },
+    "link_label_explore_shows": {
+      "default": "Series verkennen"
+    },
+    "link_label_explore_movies": {
+      "default": "Films verkennen"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Kalendarz"
+    },
+    "text_cta_up_next": {
+      "default": "Kontynuuj oglądanie ulubionych seriali i wznów odtwarzanie w dowolnym momencie. Jakie seriale śledzisz?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Dodaj filmy do swojej listy i zacznij budować listę filmów, które chcesz obejrzeć."
+    },
+    "text_cta_upcoming": {
+      "default": "Nadchodzący harmonogram zawiera nowe odcinki, które wkrótce zostaną wydane dla seriali, które już śledzisz."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Dodaj nadchodzące filmy do swojej listy i zobacz, które wkrótce się ukażą."
+    },
+    "text_cta_activity": {
+      "default": "Zacznij szybko poznawać znajomych, śledząc zespół Trakt i odkrywaj, co oglądają."
+    },
+    "link_text_browse_shows": {
+      "default": "Przeglądaj seriale"
+    },
+    "link_text_browse_movies": {
+      "default": "Przeglądaj filmy"
+    },
+    "link_text_explore_shows": {
+      "default": "Odkrywaj seriale"
+    },
+    "link_text_explore_movies": {
+      "default": "Odkrywaj filmy"
+    },
+    "link_label_browse_shows": {
+      "default": "Przeglądaj seriale"
+    },
+    "link_label_browse_movies": {
+      "default": "Przeglądaj filmy"
+    },
+    "link_label_explore_shows": {
+      "default": "Odkrywaj seriale"
+    },
+    "link_label_explore_movies": {
+      "default": "Odkrywaj filmy"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendário"
+    },
+    "text_cta_up_next": {
+      "default": "Continue assistindo suas séries favoritas e retome de onde parou a qualquer momento. Quais séries você está seguindo?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Adicione filmes à sua lista e comece a montar uma lista dos filmes que você quer assistir."
+    },
+    "text_cta_upcoming": {
+      "default": "Seu cronograma mostra os novos episódios lançando em breve das séries que você já acompanha."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Adicione filmes em breve à sua lista e veja quais estão lançando em breve."
+    },
+    "text_cta_activity": {
+      "default": "Comece a fazer amigos rapidamente seguindo a Equipe Trakt e explore o que eles estão assistindo."
+    },
+    "link_text_browse_shows": {
+      "default": "Séries"
+    },
+    "link_text_browse_movies": {
+      "default": "Filmes"
+    },
+    "link_text_explore_shows": {
+      "default": "Explorar séries"
+    },
+    "link_text_explore_movies": {
+      "default": "Explorar filmes"
+    },
+    "link_label_browse_shows": {
+      "default": "Séries"
+    },
+    "link_label_browse_movies": {
+      "default": "Filmes"
+    },
+    "link_label_explore_shows": {
+      "default": "Explorar séries"
+    },
+    "link_label_explore_movies": {
+      "default": "Explorar filmes"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Calendar"
+    },
+    "text_cta_up_next": {
+      "default": "Continuați să urmăriți serialele preferate și reluați de unde ați rămas oricând. Ce seriale urmăriți?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Adăugați filme în lista de urmărire și începeți să creați o listă de filme pe care doriți să le vedeți."
+    },
+    "text_cta_upcoming": {
+      "default": "Programul dvs. viitor listează episoade noi care vor fi lansate în curând pentru serialele pe care le urmăriți deja."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Adăugați filme viitoare în lista de urmărire și vedeți care vor fi lansate în curând."
+    },
+    "text_cta_activity": {
+      "default": "Începeți să vă faceți prieteni rapid urmărind Echipa Trakt și explorați ce urmăresc."
+    },
+    "link_text_browse_shows": {
+      "default": "Răsfoiește seriale"
+    },
+    "link_text_browse_movies": {
+      "default": "Răsfoiește filme"
+    },
+    "link_text_explore_shows": {
+      "default": "Explorează seriale"
+    },
+    "link_text_explore_movies": {
+      "default": "Explorează filme"
+    },
+    "link_label_browse_shows": {
+      "default": "Răsfoiește seriale"
+    },
+    "link_label_browse_movies": {
+      "default": "Răsfoiește filme"
+    },
+    "link_label_explore_shows": {
+      "default": "Explorează seriale"
+    },
+    "link_label_explore_movies": {
+      "default": "Explorează filme"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Kalender"
+    },
+    "text_cta_up_next": {
+      "default": "Fortsätt titta på dina favoritserier och återuppta där du slutade när som helst. Vilka serier följer du?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Lägg till filmer i din lista och börja bygga en lista över filmer du vill se."
+    },
+    "text_cta_upcoming": {
+      "default": "Ditt kommande schema listar nya avsnitt som släpps snart för serier du redan följer."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Lägg till kommande filmer i din lista och se vilka som släpps snart."
+    },
+    "text_cta_activity": {
+      "default": "Börja få vänner snabbt genom att följa Trakt-teamet och utforska vad de tittar på."
+    },
+    "link_text_browse_shows": {
+      "default": "Bläddra serier"
+    },
+    "link_text_browse_movies": {
+      "default": "Bläddra filmer"
+    },
+    "link_text_explore_shows": {
+      "default": "Utforska serier"
+    },
+    "link_text_explore_movies": {
+      "default": "Utforska filmer"
+    },
+    "link_label_browse_shows": {
+      "default": "Bläddra serier"
+    },
+    "link_label_browse_movies": {
+      "default": "Bläddra filmer"
+    },
+    "link_label_explore_shows": {
+      "default": "Utforska serier"
+    },
+    "link_label_explore_movies": {
+      "default": "Utforska filmer"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1670,6 +1670,45 @@
     },
     "button_label_calendar": {
       "default": "Календар"
+    },
+    "text_cta_up_next": {
+      "default": "Продовжуйте перегляд улюблених серіалів і повертайтеся до перегляду у будь-який час. Які серіали ви зараз дивитеся?"
+    },
+    "text_cta_watchlist_released": {
+      "default": "Додайте фільми до свого списку і почніть складати список фільмів, які хочете переглянути."
+    },
+    "text_cta_upcoming": {
+      "default": "Ваш найближчий графік містить нові епізоди, які незабаром виходять для серіалів, які ви вже дивитеся."
+    },
+    "text_cta_watchlist_unreleased": {
+      "default": "Додайте майбутні фільми до свого списку і дізнайтеся, які з них вийдуть найближчим часом."
+    },
+    "text_cta_activity": {
+      "default": "Почніть швидко заводити друзів, підписавшись на команду Trakt, і дізнайтеся, що вони дивляться."
+    },
+    "link_text_browse_shows": {
+      "default": "Огляд серіалів"
+    },
+    "link_text_browse_movies": {
+      "default": "Огляд фільмів"
+    },
+    "link_text_explore_shows": {
+      "default": "Дослідити серіали"
+    },
+    "link_text_explore_movies": {
+      "default": "Дослідити фільми"
+    },
+    "link_label_browse_shows": {
+      "default": "Огляд серіалів"
+    },
+    "link_label_browse_movies": {
+      "default": "Огляд фільмів"
+    },
+    "link_label_explore_shows": {
+      "default": "Дослідити серіали"
+    },
+    "link_label_explore_movies": {
+      "default": "Дослідити фільми"
     }
   }
 }

--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -16,7 +16,7 @@
 
 <div
   use:whenInViewport={() => isVisible.set(true)}
-  use:dPadTrigger={".trakt-card-content > .trakt-link"}
+  use:dPadTrigger={".trakt-card-content > .trakt-link, .trakt-button-link"}
   class="trakt-card"
   data-navigation-type={$navigation}
   data-dpad-navigation={DpadNavigationType.Item}
@@ -42,7 +42,8 @@
   }
 
   .trakt-card[data-navigation-type="dpad"] {
-    &:has(:global(.trakt-link)) {
+    &:has(:global(.trakt-link)),
+    &:has(:global(.trakt-button-link)) {
       .trakt-card-content {
         transform: scale(0.95);
         /* To compensate that we're scaling a non 1:1 aspect ratio element */

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -87,7 +87,8 @@
     }
 
     .trakt-card-footer-action {
-      :global(.trakt-action-button[data-style="ghost"]) {
+      :global(.trakt-action-button[data-style="ghost"]),
+      :global(.trakt-button[data-style="ghost"]) {
         backdrop-filter: none;
       }
     }

--- a/projects/client/src/lib/components/lists/ListProps.ts
+++ b/projects/client/src/lib/components/lists/ListProps.ts
@@ -5,6 +5,7 @@ export type ListProps<T> = {
   title: string | Nil;
   items: T[];
   item: Snippet<[T]>;
+  ctaItem?: Snippet;
   actions?: Snippet;
   dynamicActions?: Snippet;
   badge?: Snippet;

--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -18,6 +18,7 @@
     items,
     title,
     item,
+    ctaItem,
     empty,
     dynamicActions,
     actions: externalActions,
@@ -63,6 +64,7 @@
   {title}
   {items}
   {item}
+  {ctaItem}
   {empty}
   {badge}
   {scrollX}

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -1,8 +1,10 @@
 <script lang="ts" generics="T extends { id: unknown }">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { useNavigation } from "$lib/features/navigation/useNavigation";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
   import { whenInViewport } from "$lib/utils/actions/whenInViewport";
   import { onMount, type Snippet } from "svelte";
@@ -17,6 +19,7 @@
   import { scrollTracking } from "./scrollTracking";
 
   const EMPTY_STATE_CLASS = "shadow-list-empty-state";
+  const CTA_CUT_OFF = 4;
 
   type SectionListProps<T> = ListProps<T> & {
     subtitle?: string;
@@ -35,6 +38,7 @@
     scrollX = writable({ left: 0, right: 0 }),
     scrollContainer = writable(),
     item,
+    ctaItem,
     actions,
     badge,
     empty,
@@ -127,6 +131,16 @@
           {#each items as i (`${items.length}_${i.id}`)}
             {@render item(i)}
           {/each}
+
+          {#if ctaItem && items.length <= CTA_CUT_OFF}
+            <RenderForFeature flag={FeatureFlag.Cta}>
+              {#snippet enabled()}
+                {#key `shadow-list-${id}_cta`}
+                  {@render ctaItem()}
+                {/key}
+              {/snippet}
+            </RenderForFeature>
+          {/if}
         </div>
       {:else if empty != null && $isMounted}
         <div class={EMPTY_STATE_CLASS}>

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -4,4 +4,5 @@ export enum FeatureFlag {
   Plex = 'plex',
   Search = 'search',
   Calendar = 'calendar',
+  Cta = 'cta',
 }

--- a/projects/client/src/lib/sections/lists/UpcomingList.svelte
+++ b/projects/client/src/lib/sections/lists/UpcomingList.svelte
@@ -2,6 +2,7 @@
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import CalendarButton from "./components/CalendarButton.svelte";
+  import CtaItem from "./components/cta/CtaItem.svelte";
   import DefaultMediaItem from "./components/DefaultMediaItem.svelte";
   import EpisodeItem from "./components/EpisodeItem.svelte";
   import FindShowsLink from "./components/FindShowsLink.svelte";
@@ -27,6 +28,10 @@
     {#if entry.type === "movie"}
       <DefaultMediaItem media={entry} type="movie" variant="landscape" />
     {/if}
+  {/snippet}
+
+  {#snippet ctaItem()}
+    <CtaItem cta="upcoming" />
   {/snippet}
 
   {#snippet empty()}

--- a/projects/client/src/lib/sections/lists/components/cta/CtaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/CtaItem.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import ActivityCtaCard from "./_internal/ActivityCtaCard.svelte";
+  import MediaCtaCard from "./_internal/MediaCtaCard.svelte";
+  import type { CtaItemIntl } from "./CtaItemIntl";
+  import { CtaItemIntlProvider } from "./CtaItemIntlProvider";
+  import type { Cta } from "./models/Cta";
+
+  const {
+    cta,
+    intl = CtaItemIntlProvider,
+  }: {
+    cta: Cta;
+    intl?: CtaItemIntl;
+  } = $props();
+</script>
+
+{#if cta === "activity"}
+  <ActivityCtaCard {intl} />
+{:else}
+  <MediaCtaCard {cta} {intl} />
+{/if}

--- a/projects/client/src/lib/sections/lists/components/cta/CtaItemIntl.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/CtaItemIntl.ts
@@ -1,0 +1,17 @@
+import type { Cta } from './models/Cta.ts';
+
+export type CtaItemMeta = {
+  cta: Cta;
+};
+
+export type CtaLinkMeta = {
+  cta: Exclude<Cta, 'activity'>;
+};
+
+export type CtaItemIntl = {
+  text: (meta: CtaItemMeta) => string;
+  cta: {
+    text: (meta: CtaLinkMeta) => string;
+    label: (meta: CtaLinkMeta) => string;
+  };
+};

--- a/projects/client/src/lib/sections/lists/components/cta/CtaItemIntlProvider.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/CtaItemIntlProvider.ts
@@ -1,0 +1,45 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { CtaItemIntl, CtaItemMeta, CtaLinkMeta } from './CtaItemIntl.ts';
+
+export const CtaItemIntlProvider: CtaItemIntl = {
+  text: ({ cta }: CtaItemMeta) => {
+    switch (cta) {
+      case 'up-next':
+        return m.text_cta_up_next();
+      case 'released':
+        return m.text_cta_watchlist_released();
+      case 'upcoming':
+        return m.text_cta_upcoming();
+      case 'unreleased':
+        return m.text_cta_watchlist_unreleased();
+      case 'activity':
+        return m.text_cta_activity();
+    }
+  },
+  cta: {
+    text: ({ cta }: CtaLinkMeta) => {
+      switch (cta) {
+        case 'up-next':
+          return m.link_text_browse_shows();
+        case 'released':
+          return m.link_text_browse_movies();
+        case 'upcoming':
+          return m.link_text_explore_shows();
+        case 'unreleased':
+          return m.link_text_explore_movies();
+      }
+    },
+    label: ({ cta }: CtaLinkMeta) => {
+      switch (cta) {
+        case 'up-next':
+          return m.link_label_browse_shows();
+        case 'released':
+          return m.link_label_browse_movies();
+        case 'upcoming':
+          return m.link_label_explore_shows();
+        case 'unreleased':
+          return m.link_label_explore_movies();
+      }
+    },
+  },
+};

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/ActivityCtaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/ActivityCtaCard.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import VipBadge from "$lib/sections/navbar/components/VIPBadge.svelte";
+  import UserAvatar from "../../UserAvatar.svelte";
+  import type { CtaItemIntl } from "../CtaItemIntl";
+  import CtaCard from "./CtaCard.svelte";
+  import { useTraktTeam } from "./useTraktTeam";
+
+  const { intl }: { intl: CtaItemIntl } = $props();
+
+  const { network } = useUser();
+  const { isLoading, team } = $derived(useTraktTeam($network?.following ?? []));
+</script>
+
+<CtaCard variant="activity">
+  <p class="smaller">
+    {intl.text({ cta: "activity" })}
+  </p>
+  <div class="trakt-team-list">
+    {#if !$isLoading}
+      {#each $team as member (member.username)}
+        <div class="trakt-team-member">
+          <UserAvatar user={member}>
+            {#snippet icon()}
+              <VipBadge style="inverted" />
+            {/snippet}
+          </UserAvatar>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</CtaCard>
+
+<style>
+  .trakt-team-list {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    gap: var(--gap-xs);
+  }
+
+  .trakt-team-member {
+    position: relative;
+
+    :global(svg) {
+      width: var(--ni-22);
+      height: var(--ni-22);
+
+      position: absolute;
+      top: var(--ni-neg-8);
+      right: var(--ni-neg-4);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/CtaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/CtaCard.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import Card from "$lib/components/card/Card.svelte";
+  import CardFooter from "$lib/components/card/CardFooter.svelte";
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+    action,
+    variant,
+  }: {
+    variant: "portrait" | "landscape" | "activity";
+    action?: Snippet;
+  } & ChildrenProps = $props();
+</script>
+
+{#snippet content()}
+  <div class="trakt-cta-content">
+    {@render children()}
+  </div>
+
+  {#if action}
+    <div class="trakt-cta-footer">
+      <CardFooter {action} />
+    </div>
+  {/if}
+{/snippet}
+
+{#if variant === "portrait"}
+  <Card
+    variant="transparent"
+    --width-card="var(--width-cta-portrait-card)"
+    --height-card="var(--height-cta-portrait-card)"
+    --height-card-cover="var(--height-cta-portrait-card-cover)"
+  >
+    {@render content()}
+  </Card>
+{/if}
+
+{#if variant === "landscape"}
+  <Card
+    variant="transparent"
+    --width-card="var(--width-cta-landscape-card)"
+    --height-card="var(--height-cta-landscape-card)"
+    --height-card-cover="var(--height-cta-landscape-card-cover)"
+  >
+    {@render content()}
+  </Card>
+{/if}
+
+{#if variant === "activity"}
+  <Card
+    variant="transparent"
+    --width-card="var(--width-cta-activity-card)"
+    --height-card="var(--height-cta-activity-card)"
+    --height-card-cover="var(--height-cta-activity-card)"
+  >
+    {@render content()}
+  </Card>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-cta-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--gap-xs);
+
+    width: var(--width-card);
+    height: var(--height-card-cover);
+
+    border-radius: var(--border-radius-m);
+
+    background: linear-gradient(
+      258.73deg,
+      var(--cm-gradient-stop-cta) 0%,
+      var(--shade-900) 53.05%
+    );
+
+    padding: var(--ni-16);
+    box-sizing: border-box;
+
+    box-shadow:
+      0px var(--ni-16) var(--ni-8) 0px var(--cm-shadow-2),
+      0px var(--ni-8) var(--ni-4) 0px var(--cm-shadow-4),
+      0px var(--ni-4) var(--ni-4) 0px var(--cm-shadow-8),
+      0px var(--ni-1) var(--ni-2) 0px var(--cm-shadow-8);
+
+    transition: padding var(--transition-increment) ease-in-out;
+
+    :global(p.smaller) {
+      color: var(--shade-10);
+    }
+
+    @include for-mobile() {
+      padding: var(--ni-10);
+    }
+  }
+
+  .trakt-cta-footer {
+    // To visually align the icon of the ghost button with the card
+    margin-right: var(--ni-neg-12);
+
+    :global(.trakt-card-footer) {
+      justify-content: flex-end;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/MediaCtaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/MediaCtaCard.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import SearchIcon from "$lib/features/search/SearchIcon.svelte";
+  import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import type { CtaItemIntl } from "../CtaItemIntl";
+  import type { Cta } from "../models/Cta";
+  import CtaCard from "./CtaCard.svelte";
+
+  const {
+    cta,
+    intl,
+  }: {
+    cta: Exclude<Cta, "activity">;
+    intl: CtaItemIntl;
+  } = $props();
+
+  const type = $derived(
+    cta === "up-next" || cta === "upcoming" ? "episode" : "movie",
+  );
+
+  const defaultVariant = $derived(useDefaultCardVariant(type));
+
+  const ctaHref = $derived.by(() => {
+    switch (cta) {
+      case "up-next":
+        return UrlBuilder.shows();
+      case "released":
+        return UrlBuilder.trending({ type: "movie" });
+      case "upcoming":
+        return UrlBuilder.shows();
+      case "unreleased":
+        return UrlBuilder.anticipated({ type: "movie" });
+    }
+  });
+</script>
+
+<CtaCard variant={$defaultVariant}>
+  <p class="smaller">{intl.text({ cta })}</p>
+
+  {#snippet action()}
+    <Button
+      href={ctaHref}
+      label={intl.cta.label({ cta })}
+      size="small"
+      color="purple"
+      style="ghost"
+    >
+      {intl.cta.text({ cta })}
+      {#snippet icon()}
+        <SearchIcon />
+      {/snippet}
+    </Button>
+  {/snippet}
+</CtaCard>

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/useTraktTeam.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/useTraktTeam.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { UserProfile } from '$lib/requests/models/UserProfile.ts';
+import { userProfileQuery } from '$lib/requests/queries/users/userProfileQuery.ts';
+import { shuffle } from '$lib/utils/array/shuffle.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { derived, type Readable } from 'svelte/store';
+
+const MAX_TEAM_MEMBERS = 5;
+
+// FIXME: move this to the server to have a single source of truth
+const TEAM_SLUGS = [
+  'andrei-l-magnea',
+  'justin',
+  'kcador',
+  'kristin',
+  'marius',
+  'mike-d-47b75e85-263f-4f74-bda4-d6347793fbba',
+  'ohifriend',
+  'sean',
+  'seftur',
+  'sonply',
+  'visualcortex',
+  'zandertrakt',
+];
+
+type TraktTeam = {
+  isLoading: Readable<boolean>;
+  team: Readable<Array<UserProfile>>;
+};
+
+export function useTraktTeam(following: UserProfile[]): TraktTeam {
+  const unfollowedMembers = TEAM_SLUGS.filter(
+    (slug) => !following.some((user) => user.username === slug),
+  );
+
+  const queries = shuffle(unfollowedMembers)
+    .slice(0, MAX_TEAM_MEMBERS)
+    .map((slug) => userProfileQuery({ slug }))
+    .map((query) => useQuery(query));
+
+  const isLoading = derived(
+    queries,
+    ($queries) => $queries.some(toLoadingState),
+  );
+
+  return {
+    isLoading,
+    team: derived(
+      queries,
+      ($queries) =>
+        $queries
+          .filter((query) => Boolean(query.data))
+          .map((query) => assertDefined(query.data)),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/lists/components/cta/models/Cta.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/models/Cta.ts
@@ -1,0 +1,6 @@
+export type Cta =
+  | 'up-next'
+  | 'released'
+  | 'upcoming'
+  | 'unreleased'
+  | 'activity';

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -13,6 +13,7 @@
     badge,
     type,
     item,
+    ctaItem,
     actions: externalActions,
     useList,
     filter,
@@ -36,6 +37,7 @@
   items={$list}
   {badge}
   {item}
+  {ctaItem}
   {title}
   actions={externalActions ? actions : undefined}
   --height-list={mediaListHeightResolver($defaultVariant)}

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -7,6 +7,7 @@ export type MediaListProps<T, M> = {
   title: string;
   type: M;
   item: Snippet<[T]>;
+  ctaItem?: Snippet;
   useList: PaginatableStore<T, M>;
   actions?: Snippet<[T[], M]>;
   empty?: Snippet;

--- a/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
@@ -4,6 +4,7 @@
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import CtaItem from "../components/cta/CtaItem.svelte";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import { useStablePaginated } from "../stores/useStablePaginated";
   import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
@@ -40,6 +41,11 @@
       status={$hidden.includes(episode.show.id) ? "hidden" : "watching"}
     />
   {/snippet}
+
+  {#snippet ctaItem()}
+    <CtaItem cta="up-next" />
+  {/snippet}
+
   {#snippet empty()}
     <p>{m.list_placeholder_up_next_empty()}</p>
   {/snippet}

--- a/projects/client/src/lib/sections/lists/social/SocialActivityList.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import CtaItem from "../components/cta/CtaItem.svelte";
 
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import SocialActivityItem from "./SocialActivityItem.svelte";
@@ -24,6 +25,10 @@
   >
     {#snippet item(activity)}
       <SocialActivityItem {activity} />
+    {/snippet}
+
+    {#snippet ctaItem()}
+      <CtaItem cta="activity" />
     {/snippet}
   </DrillableMediaList>
 {/if}

--- a/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
@@ -7,6 +7,7 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { Snippet } from "svelte";
   import { writable } from "svelte/store";
+  import CtaItem from "../components/cta/CtaItem.svelte";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import TypeToggles from "./_internal/TypeToggles.svelte";
   import WatchlistTag from "./_internal/WatchlistTag.svelte";
@@ -59,6 +60,12 @@
 >
   {#snippet item(media)}
     <WatchlistItem type={media.type} {media} />
+  {/snippet}
+
+  {#snippet ctaItem()}
+    {#if status !== "all"}
+      <CtaItem cta={status} />
+    {/if}
   {/snippet}
 
   {#snippet empty()}

--- a/projects/client/src/style/color-mix/index.scss
+++ b/projects/client/src/style/color-mix/index.scss
@@ -43,6 +43,10 @@ $cm-background-navbar-percentages: 80, 90;
       var(--color-background-navbar) 75%,
       transparent 25%);
 
+  --cm-gradient-stop-cta: color-mix(in srgb,
+      var(--purple-500) 80%,
+      transparent);
+
 
   @each $percent in $cm-foreground-percentages {
     --cm-foreground-#{$percent}: color-mix(in srgb,
@@ -79,6 +83,7 @@ $cm-background-navbar-percentages: 80, 90;
     --cm-background-official-list-summary: rgb(46, 27, 57);
     --cm-background-cookie-notice: rgba(32, 36, 38, 0.7);
     --cm-background-search-input: rgba(25, 27, 29, 0.6);
+    --cm-gradient-stop-cta: rgba(159, 66, 198, 0.8);
 
     @each $percent in $cm-foreground-percentages {
       --cm-foreground-#{$percent}: rgba(254, 254, 254, #{math.div($percent, 100)});

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -30,6 +30,17 @@
   --width-now-playing-card: var(--ni-104);
   --height-now-playing-card: var(--ni-80);
 
+  --width-cta-landscape-card: var(--ni-240);
+  --height-cta-landscape-card: var(--height-landscape-card);
+  --height-cta-landscape-card-cover: var(--height-landscape-card-cover);
+
+  --width-cta-portrait-card: var(--ni-196);
+  --height-cta-portrait-card: var(--height-portrait-card);
+  --height-cta-portrait-card-cover: var(--height-portrait-card-cover);
+
+  --width-cta-activity-card: var(--ni-340);
+  --height-cta-activity-card: var(--height-landscape-card-cover);
+
   /**
    * List dimensions
    */

--- a/projects/client/src/style/numeric-increments/index.css
+++ b/projects/client/src/style/numeric-increments/index.css
@@ -88,6 +88,7 @@
   --ni-312: 19.5rem;
   --ni-316: 19.75rem;
   --ni-320: 20rem;
+  --ni-340: 21.25rem;
   --ni-380: 25rem;
   --ni-480: 30rem;
   --ni-640: 40rem;
@@ -172,6 +173,7 @@
   --ni-neg-312: -19.5rem;
   --ni-neg-316: -19.75rem;
   --ni-neg-320: -20rem;
+  --ni-neg-340: -21.25rem;
   --ni-neg-480: -30rem;
   --ni-neg-640: -40rem;
 }

--- a/projects/client/src/style/typography/index.css
+++ b/projects/client/src/style/typography/index.css
@@ -94,6 +94,10 @@ p {
   &.small {
     font-size: var(--ni-14);
   }
+
+  &.smaller {
+    font-size: var(--ni-12);
+  }
 }
 
 span,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds cta cards to empty-ish lists on the homepage.
  - Feature flagged.
  - This is pt1. Pt2 will add the empty list placeholders.
- Left a `fixme` in there to get the team members from the server instead of maintaining the slugs in every app. I'll bring this up a the next tech sync.
- Activity design might not be final, might need a small change pending feedback from @anodpixels.

⚠️ Small design tweaks, see bottom of examples for changes ⚠️

## 👀 Examples 👀
<img width="428" height="929" alt="Screenshot 2025-08-11 at 14 08 19" src="https://github.com/user-attachments/assets/47a645a0-08b0-4e21-8576-c4e29639ad65" />

<img width="428" height="929" alt="Screenshot 2025-08-11 at 14 08 29" src="https://github.com/user-attachments/assets/90f1b508-bef3-4336-8103-9dd4261fc6af" />

⚠️ Updates ⚠️
<img width="428" height="927" alt="Screenshot 2025-08-11 at 15 33 07" src="https://github.com/user-attachments/assets/fe2aad17-7d79-422d-9ffb-3066a7b06f0d" />

<img width="428" height="927" alt="Screenshot 2025-08-11 at 15 33 24" src="https://github.com/user-attachments/assets/d2b0a915-2e1f-476c-b082-9118c080eb14" />

