### PR TITLE
Routes API requests to HD domain

### DIFF
--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -15,6 +15,7 @@ declare global {
   const TRAKT_CLIENT_ID: string;
   const TRAKT_MODE: 'development' | 'production' | 'test';
   const TRAKT_TARGET_ENVIRONMENT: Environment;
+  const TRAKT_TARGET_API_ENVIRONMENT: Environment;
 
   const TRAKT_GIT_SHA: string;
 

--- a/projects/client/src/lib/requests/_internal/mediumUrl.ts
+++ b/projects/client/src/lib/requests/_internal/mediumUrl.ts
@@ -3,5 +3,7 @@ export function mediumUrl(url: string | Nil): string | Nil {
     return;
   }
 
-  return url.replace('/thumb/', '/medium/');
+  return url
+    .replace('/thumb/', '/medium/')
+    .replace('/original/', '/medium/');
 }

--- a/projects/client/src/lib/requests/_internal/thumbUrl.ts
+++ b/projects/client/src/lib/requests/_internal/thumbUrl.ts
@@ -3,5 +3,7 @@ export function thumbUrl(url: string | Nil): string | Nil {
     return;
   }
 
-  return url.replace('/medium/', '/thumb/');
+  return url
+    .replace('/medium/', '/thumb/')
+    .replace('/original/', '/thumb/');
 }

--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -52,11 +52,18 @@ const TRAKT_TARGET_ENVIRONMENT = (() => {
   return Environment.production_private;
 })();
 
+const TRAKT_TARGET_API_ENVIRONMENT = (() => {
+  const url = new URL(TRAKT_TARGET_ENVIRONMENT);
+  url.hostname = url.hostname.replace('apiz', 'hd');
+  return url.toString();
+})();
+
 export default defineConfig(({ mode }) => ({
   define: {
     'TRAKT_CLIENT_ID': `"${process.env.TRAKT_CLIENT_ID}"`,
     'TRAKT_MODE': `"${mode}${process.env.IS_PREVIEW ? '-preview' : ''}"`,
     'TRAKT_TARGET_ENVIRONMENT': `"${TRAKT_TARGET_ENVIRONMENT}"`,
+    'TRAKT_TARGET_API_ENVIRONMENT': `"${TRAKT_TARGET_API_ENVIRONMENT}"`,
     'FIREBASE_PROJECT_ID': `"${process.env.FIREBASE_PROJECT_ID}"`,
     'FIREBASE_API_KEY': `"${process.env.FIREBASE_API_KEY}"`,
     'FIREBASE_APP_ID': `"${process.env.FIREBASE_APP_ID}"`,
@@ -72,7 +79,7 @@ export default defineConfig(({ mode }) => ({
     },
     proxy: {
       '/api/trakt': {
-        target: TRAKT_TARGET_ENVIRONMENT,
+        target: TRAKT_TARGET_API_ENVIRONMENT,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/trakt/, ''),
       },


### PR DESCRIPTION
- Ensures API requests are routed to the "hd." subdomain instead of "apiz." 
- Adds a build-time constant for the HD target to avoid hardcoding
- Skips replacement for requests including "watchnow"