### PR TITLE
fix: use medium and thumb images for headshots

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToHeadshot.ts
+++ b/projects/client/src/lib/requests/_internal/mapToHeadshot.ts
@@ -1,0 +1,26 @@
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
+import { findDefined } from '$lib/utils/string/findDefined.ts';
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+import type { PeopleSummaryResponse } from '@trakt/api';
+import type { PersonSummary } from '../models/PersonSummary.ts';
+import { mediumUrl } from './mediumUrl.ts';
+import { thumbUrl } from './thumbUrl.ts';
+
+export function mapToHeadshot(
+  images: PeopleSummaryResponse['images'],
+): PersonSummary['headshot'] {
+  const headshotCandidate = findDefined(...(images?.headshot ?? []));
+
+  return {
+    url: {
+      medium: prependHttps(
+        mediumUrl(headshotCandidate),
+        MEDIA_POSTER_PLACEHOLDER,
+      ),
+      thumb: prependHttps(
+        thumbUrl(headshotCandidate),
+        MEDIA_POSTER_PLACEHOLDER,
+      ),
+    },
+  };
+}

--- a/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
@@ -3,10 +3,8 @@ import type {
   CrewMember,
   MediaCrew,
 } from '$lib/requests/models/MediaCrew.ts';
-import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
-import { findDefined } from '$lib/utils/string/findDefined.ts';
-import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { CastResponse, CrewResponse, PeopleResponse } from '@trakt/api';
+import { mapToHeadshot } from './mapToHeadshot.ts';
 
 function toCrewMember(
   crewResponse: CrewResponse,
@@ -21,18 +19,11 @@ function toCrewMember(
 function toCastMember(
   castResponse: CastResponse,
 ): CastMember {
-  const headshotCandidate = findDefined(
-    ...(castResponse.person.images?.headshot ?? []),
-  );
-
   return ({
     name: castResponse.person.name,
     characterName: castResponse.characters.at(0) ?? '',
     id: castResponse.person.ids.slug,
-    headShotUrl: prependHttps(
-      headshotCandidate,
-      MEDIA_POSTER_PLACEHOLDER,
-    ),
+    headshot: mapToHeadshot(castResponse.person.images),
   });
 }
 

--- a/projects/client/src/lib/requests/_internal/mapToPersonSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPersonSummary.ts
@@ -1,24 +1,15 @@
-import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
-import { findDefined } from '$lib/utils/string/findDefined.ts';
-import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { PeopleSummaryResponse } from '@trakt/api';
+import { mapToHeadshot } from './mapToHeadshot.ts';
 
 export const mapToPersonSummary = (
   response: PeopleSummaryResponse,
 ) => {
-  const headshotCandidate = findDefined(
-    ...(response.images?.headshot ?? []),
-  );
-
   return {
     id: response.ids.trakt,
     slug: response.ids.slug,
     name: response.name,
     biography: response.biography ?? '',
     knownFor: response.known_for_department,
-    headShotUrl: prependHttps(
-      headshotCandidate,
-      MEDIA_POSTER_PLACEHOLDER,
-    ),
+    headshot: mapToHeadshot(response.images),
   };
 };

--- a/projects/client/src/lib/requests/models/MediaCrew.ts
+++ b/projects/client/src/lib/requests/models/MediaCrew.ts
@@ -1,5 +1,6 @@
 import { jobOptionSchema } from '@trakt/api';
 import { z } from 'zod';
+import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 const JobSchema = jobOptionSchema;
 export type Job = z.output<typeof JobSchema>;
@@ -15,7 +16,9 @@ export const CastMemberSchema = z.object({
   name: z.string(),
   characterName: z.string(),
   id: z.string(),
-  headShotUrl: z.string().url(),
+  headshot: z.object({
+    url: ImageUrlsSchema,
+  }),
 });
 export type CastMember = z.infer<typeof CastMemberSchema>;
 

--- a/projects/client/src/lib/requests/models/PersonSummary.ts
+++ b/projects/client/src/lib/requests/models/PersonSummary.ts
@@ -1,12 +1,14 @@
 import { crewPositionSchema } from '@trakt/api';
 import { z } from 'zod';
-import { HttpsUrlSchema } from './HttpsUrlSchema.ts';
+import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 export const PersonSummarySchema = z.object({
   id: z.number(),
   name: z.string(),
   biography: z.string(),
-  headShotUrl: HttpsUrlSchema,
+  headshot: z.object({
+    url: ImageUrlsSchema,
+  }),
   slug: z.string(),
   knownFor: crewPositionSchema.nullish(),
 });

--- a/projects/client/src/lib/sections/lists/PersonList.svelte
+++ b/projects/client/src/lib/sections/lists/PersonList.svelte
@@ -28,7 +28,7 @@
       <Link focusable={false} href={UrlBuilder.people(person.slug)}>
         <CardCover
           title={person.name}
-          src={person.headShotUrl}
+          src={person.headshot.url.thumb}
           alt={`${m.image_alt_person_headshot({ person: person.name })}`}
         />
         <CardFooter>

--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -18,7 +18,7 @@
   <Link focusable={false} href={UrlBuilder.people(castMember.id)}>
     <CardCover
       title={castMember.name}
-      src={castMember.headShotUrl}
+      src={castMember.headshot.url.thumb}
       alt={`${m.image_alt_person_headshot({ person: castMember.name })}`}
     />
     <CardFooter>

--- a/projects/client/src/lib/sections/summary/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/PeopleSummary.svelte
@@ -18,7 +18,7 @@
 
 <SummaryContainer>
   {#snippet poster()}
-    <SummaryPoster src={person.headShotUrl} alt={person.name} />
+    <SummaryPoster src={person.headshot.url.medium} alt={person.name} />
   {/snippet}
 
   <SummaryHeader>

--- a/projects/client/src/mocks/data/people/mapped/PersonFergusonMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonFergusonMappedMock.ts
@@ -3,8 +3,14 @@ import type { PersonSummary } from '$lib/requests/models/PersonSummary.ts';
 export const PersonFergusonMappedMock: PersonSummary = {
   biography:
     'Rebecca Louisa Ferguson Sundström (born October 19, 1983) is a Swedish actress. She began her acting career with the Swedish soap opera Nya tider (1999–2000) and went on to star in the slasher film Drowning Ghost (2004). She came to international prominence with her portrayal of Elizabeth Woodville in the British television miniseries The White Queen (2013), for which she was nominated for a Golden Globe for Best Actress in a Miniseries or Television Film. In 2023, she starred in the Apple TV+ science fiction drama series Silo.\n\nFerguson starred as MI6 agent Ilsa Faust in the action spy film Mission: Impossible – Rogue Nation (2015) and its sequels Mission: Impossible – Fallout (2018) and Mission: Impossible – Dead Reckoning Part One (2023). She also played Jenny Lind in the musical film The Greatest Showman (2017) and acted in science fiction horror film Life (2017), starred in the horror film Doctor Sleep (2019), and had supporting parts in the comedy-drama Florence Foster Jenkins (2016), the mystery thriller The Girl on the Train (2016), and the science fiction film Men in Black: International (2019). She portrayed Lady Jessica in the sci-fi epic Dune (2021) and reprised her role in its sequel Dune: Part Two (2024).',
-  headShotUrl:
-    'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+  headshot: {
+    url: {
+      thumb:
+        'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+      medium:
+        'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/medium/d7e3e2fc64.jpg.webp',
+    },
+  },
   name: 'Rebecca Ferguson',
   slug: 'rebecca-ferguson',
   knownFor: 'acting',

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloPeopleMappedMock.ts
@@ -4,50 +4,92 @@ export const EpisodeSiloPeopleMappedMock: MediaCrew = {
   'cast': [
     {
       'characterName': 'Juliette Nichols',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/medium/d7e3e2fc64.jpg.webp',
+        },
+      },
       'id': 'rebecca-ferguson',
       'name': 'Rebecca Ferguson',
     },
     {
       'characterName': 'Robert Sims',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/412/328/headshots/thumb/35b36ce399.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/412/328/headshots/thumb/35b36ce399.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/412/328/headshots/medium/35b36ce399.jpg.webp',
+        },
+      },
       'id': 'common',
       'name': 'Common',
     },
     {
       'characterName': 'Martha Walker',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/016/797/headshots/thumb/987b640c84.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/016/797/headshots/thumb/987b640c84.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/016/797/headshots/medium/987b640c84.jpg.webp',
+        },
+      },
       'id': 'harriet-walter',
       'name': 'Harriet Walter',
     },
     {
       'characterName': 'Paul Billings',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/748/739/headshots/thumb/628b796714.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/748/739/headshots/thumb/628b796714.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/748/739/headshots/medium/628b796714.jpg.webp',
+        },
+      },
       'id': 'chinaza-uche',
       'name': 'Chinaza Uche',
     },
     {
       'characterName': 'Lukas Kyle',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/627/038/headshots/thumb/110e52f004.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/627/038/headshots/thumb/110e52f004.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/627/038/headshots/medium/110e52f004.jpg.webp',
+        },
+      },
       'id': 'avi-nash',
       'name': 'Avi Nash',
     },
     {
       'characterName': 'Patrick Kennedy',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/014/904/headshots/thumb/d67b0392d8.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/014/904/headshots/thumb/d67b0392d8.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/014/904/headshots/medium/d67b0392d8.jpg.webp',
+        },
+      },
       'id': 'rick-gomez',
       'name': 'Rick Gomez',
     },
     {
       'characterName': 'Bernard Holland',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/015/518/headshots/medium/7aa5eb6e65.jpg.webp',
+        },
+      },
       'id': 'tim-robbins',
       'name': 'Tim Robbins',
     },

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
@@ -4,105 +4,194 @@ export const MovieHereticPeopleMappedMock: MediaCrew = {
   'cast': [
     {
       'characterName': 'Mr. Reed',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/004/705/headshots/thumb/55cd537cc1.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/004/705/headshots/thumb/55cd537cc1.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/004/705/headshots/medium/55cd537cc1.jpg.webp',
+        },
+      },
       'id': 'hugh-grant',
       'name': 'Hugh Grant',
     },
     {
       'characterName': 'Sister Barnes',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/001/075/624/headshots/thumb/f25b061dd4.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/001/075/624/headshots/thumb/f25b061dd4.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/001/075/624/headshots/medium/f25b061dd4.jpg.webp',
+        },
+      },
       'id': 'sophie-thatcher',
       'name': 'Sophie Thatcher',
     },
     {
       'characterName': 'Sister Paxton',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/597/826/headshots/thumb/aa952fefe6.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/597/826/headshots/thumb/aa952fefe6.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/597/826/headshots/medium/aa952fefe6.jpg.webp',
+        },
+      },
       'id': 'chloe-east',
       'name': 'Chloe East',
     },
     {
       'characterName': 'Elder Kennedy',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/413/327/headshots/thumb/2a4168772c.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/413/327/headshots/thumb/2a4168772c.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/413/327/headshots/medium/2a4168772c.jpg.webp',
+        },
+      },
       'id': 'topher-grace',
       'name': 'Topher Grace',
     },
     {
       'characterName': 'Prophet',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/001/119/654/headshots/thumb/bf246a5e3a.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/001/119/654/headshots/thumb/bf246a5e3a.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/001/119/654/headshots/medium/bf246a5e3a.jpg.webp',
+        },
+      },
       'id': 'elle-young-1119654',
       'name': 'Elle Young',
     },
     {
       'characterName': 'Pedestrian',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/918/391/headshots/thumb/9c6d5de83f.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/918/391/headshots/thumb/9c6d5de83f.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/918/391/headshots/medium/9c6d5de83f.jpg.webp',
+        },
+      },
       'id': 'julie-lynn-mortensen',
       'name': 'Julie Lynn-Mortensen',
     },
     {
       'characterName': 'Teenager',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/004/119/501/headshots/thumb/3b3d999544.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/004/119/501/headshots/thumb/3b3d999544.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/004/119/501/headshots/medium/3b3d999544.jpg.webp',
+        },
+      },
       'id': 'haylie-hansen',
       'name': 'Haylie Hansen',
     },
     {
       'characterName': 'Teenager',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/776/688/headshots/thumb/d629e49aab.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/776/688/headshots/thumb/d629e49aab.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/776/688/headshots/medium/d629e49aab.jpg.webp',
+        },
+      },
       'id': 'elle-mckinnon',
       'name': 'Elle McKinnon',
     },
     {
       'characterName': 'Teenager',
-      'headShotUrl': '/placeholders/portrait_placeholder.png' as HttpsUrl,
+      'headshot': {
+        'url': {
+          'thumb': '/placeholders/portrait_placeholder.png' as HttpsUrl,
+          'medium': '/placeholders/portrait_placeholder.png' as HttpsUrl,
+        },
+      },
       'id': 'hanna-huffman',
       'name': 'Hanna Huffman',
     },
     {
       'characterName': 'Neighbor',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/310/402/headshots/thumb/b786a1fb1e.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/310/402/headshots/thumb/b786a1fb1e.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/310/402/headshots/medium/b786a1fb1e.jpg.webp',
+        },
+      },
       'id': 'anesha-bailey',
       'name': 'Anesha Bailey',
     },
     {
       'characterName': 'Neighbor',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/002/195/383/headshots/thumb/dde9f0dc4e.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/002/195/383/headshots/thumb/dde9f0dc4e.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/002/195/383/headshots/medium/dde9f0dc4e.jpg.webp',
+        },
+      },
       'id': 'miguel-castillo',
       'name': 'Miguel Castillo',
     },
     {
       'characterName': 'Believer',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/996/294/headshots/thumb/bbb7d1275b.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/996/294/headshots/thumb/bbb7d1275b.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/996/294/headshots/medium/bbb7d1275b.jpg.webp',
+        },
+      },
       'id': 'stephanie-lavigne',
       'name': 'Stephanie Lavigne',
     },
     {
       'characterName': 'Disciple',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/003/058/237/headshots/thumb/bb81a3f466.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/003/058/237/headshots/thumb/bb81a3f466.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/003/058/237/headshots/medium/bb81a3f466.jpg.webp',
+        },
+      },
       'id': 'wendy-gorling',
       'name': 'Wendy Gorling',
     },
     {
       'characterName': 'Missionary #1 (uncredited)',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/003/335/090/headshots/thumb/d12413a443.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/003/335/090/headshots/thumb/d12413a443.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/003/335/090/headshots/medium/d12413a443.jpg.webp',
+        },
+      },
       'id': 'river-codack',
       'name': 'River Codack',
     },
     {
       'characterName': 'Driver with Car (uncredited)',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/197/574/headshots/thumb/80e3e863a0.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/197/574/headshots/thumb/80e3e863a0.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/197/574/headshots/medium/80e3e863a0.jpg.webp',
+        },
+      },
       'id': 'carolyn-adair',
       'name': 'Carolyn Adair',
     },

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
@@ -4,92 +4,170 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
   'cast': [
     {
       'characterName': 'Juliette Nichols',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/medium/d7e3e2fc64.jpg.webp',
+        },
+      },
       'id': 'rebecca-ferguson',
       'name': 'Rebecca Ferguson',
     },
     {
       'characterName': 'Robert Sims',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/412/328/headshots/thumb/35b36ce399.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/412/328/headshots/thumb/35b36ce399.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/412/328/headshots/medium/35b36ce399.jpg.webp',
+        },
+      },
       'id': 'common',
       'name': 'Common',
     },
     {
       'characterName': 'Martha Walker',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/016/797/headshots/thumb/987b640c84.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/016/797/headshots/thumb/987b640c84.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/016/797/headshots/medium/987b640c84.jpg.webp',
+        },
+      },
       'id': 'harriet-walter',
       'name': 'Harriet Walter',
     },
     {
       'characterName': 'Paul Billings',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/748/739/headshots/thumb/628b796714.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/748/739/headshots/thumb/628b796714.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/748/739/headshots/medium/628b796714.jpg.webp',
+        },
+      },
       'id': 'chinaza-uche',
       'name': 'Chinaza Uche',
     },
     {
       'characterName': 'Lukas Kyle',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/627/038/headshots/thumb/ba0377d6b0.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/627/038/headshots/thumb/ba0377d6b0.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/627/038/headshots/medium/ba0377d6b0.jpg.webp',
+        },
+      },
       'id': 'avi-nash',
       'name': 'Avi Nash',
     },
     {
       'characterName': 'Patrick Kennedy',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/014/904/headshots/thumb/d67b0392d8.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/014/904/headshots/thumb/d67b0392d8.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/014/904/headshots/medium/d67b0392d8.jpg.webp',
+        },
+      },
       'id': 'rick-gomez',
       'name': 'Rick Gomez',
     },
     {
       'characterName': 'Bernard Holland',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/015/518/headshots/medium/7aa5eb6e65.jpg.webp',
+        },
+      },
       'id': 'tim-robbins',
       'name': 'Tim Robbins',
     },
     {
       'characterName': 'Knox',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/431/779/headshots/thumb/d9ba2e0cd9.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/431/779/headshots/thumb/d9ba2e0cd9.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/431/779/headshots/medium/d9ba2e0cd9.jpg.webp',
+        },
+      },
       'id': 'shane-mcrae',
       'name': 'Shane McRae',
     },
     {
       'characterName': 'Hank',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/668/720/headshots/thumb/f9a6bc12fd.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/668/720/headshots/thumb/f9a6bc12fd.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/668/720/headshots/medium/f9a6bc12fd.jpg.webp',
+        },
+      },
       'id': 'billy-postlethwaite',
       'name': 'Billy Postlethwaite',
     },
     {
       'characterName': 'Shirley',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/001/477/761/headshots/thumb/32559bdf7c.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/001/477/761/headshots/thumb/32559bdf7c.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/001/477/761/headshots/medium/32559bdf7c.jpg.webp',
+        },
+      },
       'id': 'remmie-milner',
       'name': 'Remmie Milner',
     },
     {
       'characterName': 'Camille Sims',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/001/350/141/headshots/thumb/862651c2ae.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/001/350/141/headshots/thumb/862651c2ae.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/001/350/141/headshots/medium/862651c2ae.jpg.webp',
+        },
+      },
       'id': 'alexandria-riley',
       'name': 'Alexandria Riley',
     },
     {
       'characterName': 'Carla McLain',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/107/387/headshots/thumb/9f71e2f97c.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/107/387/headshots/thumb/9f71e2f97c.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/107/387/headshots/medium/9f71e2f97c.jpg.webp',
+        },
+      },
       'id': 'clare-perkins',
       'name': 'Clare Perkins',
     },
     {
       'characterName': 'Solo',
-      'headShotUrl':
-        'https://walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/014/103/headshots/medium/2e92bf71ee.jpg.webp',
+        },
+      },
       'id': 'steve-zahn',
       'name': 'Steve Zahn',
     },

--- a/projects/client/src/routes/people/[slug]/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/+page.svelte
@@ -8,7 +8,11 @@
   const { person, isLoading } = $derived(usePerson(page.params.slug));
 </script>
 
-<TraktPage audience="all" title={$person?.name} image={$person?.headShotUrl}>
+<TraktPage
+  audience="all"
+  title={$person?.name}
+  image={$person?.headshot?.url.medium}
+>
   {#if !$isLoading}
     <PeopleSummary person={$person!} />
   {:else}

--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -41,7 +41,7 @@
       return item?.cover?.url.medium;
     }
 
-    return $results.items.at(0)?.headShotUrl;
+    return $results.items.at(0)?.headshot.url.medium;
   });
 
   const pageTitle = $derived(


### PR DESCRIPTION
## ♪ Note ♪

- Headshot images were always used as is 😅 This fixes it to map to `medium` and `thumb` versions and uses the correct one where applicable.