### PR TITLE
feat(landing): page copy and translations

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -211,7 +211,7 @@
       "default": "Какво ти се гледа?"
     },
     "button_text_join_trakt": {
-      "default": "Присъедини се към Trakt"
+      "default": "Присъединете се към Trakt"
     },
     "button_label_join_trakt": {
       "default": "Присъедини се към trakt.tv, за да следиш какво гледаш"
@@ -223,25 +223,25 @@
       "default": "Направено с любов из различни кътчета на света"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Присъедини се към Trakt безплатно"
+      "default": "Присъединете се безплатно"
     },
     "header_landing_discover": {
       "default": "Октий"
     },
     "text_landing_discover": {
-      "default": "какво е актуално и къде да го гледаш."
+      "default": "Филми и сериали, които ще харесате и къде се стриймват в момента."
     },
     "header_landing_track": {
       "default": "Следи"
     },
     "text_landing_track": {
-      "default": "всички предавания и филми, които някога сте гледали.."
+      "default": "Всеки филм, епизод и сезон, които сте гледали, на едно място."
     },
     "header_landing_share": {
       "default": "Сподели"
     },
     "text_landing_share": {
-      "default": "коментари, оценки и препоръки."
+      "default": "Мнения, оценки и списъци, които другите ще харесат да следят."
     },
     "list_title_trending": {
       "default": "Популярно в моменра"

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -211,7 +211,7 @@
       "default": "Søg serier og film..."
     },
     "button_text_join_trakt": {
-      "default": "Tilmeld Trakt"
+      "default": "Tilmeld dig Trakt"
     },
     "button_label_join_trakt": {
       "default": "Tilmeld trakt.tv for at holde styr på, hvad du ser"
@@ -223,25 +223,25 @@
       "default": "Håndlavet verden over"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Tilmeld Trakt gratis"
+      "default": "Tilmeld dig gratis"
     },
     "header_landing_discover": {
       "default": "Opdag"
     },
     "text_landing_discover": {
-      "default": "Hvad er populært og hvor du kan streame det."
+      "default": "Film og serier du vil elske, og hvor de streamer lige nu."
     },
     "header_landing_track": {
       "default": "Hold styr"
     },
     "text_landing_track": {
-      "default": "Alle serier og film, du nogensinde har set."
+      "default": "Hver film, episode og sæson du har set, alt på ét sted."
     },
     "header_landing_share": {
       "default": "Del"
     },
     "text_landing_share": {
-      "default": "Kommentarer, bedømmelser og anbefalinger."
+      "default": "Meninger, vurderinger og lister, som andre vil elske at følge."
     },
     "list_title_trending": {
       "default": "Populært"

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -223,25 +223,25 @@
       "default": "Handgefertigt auf der ganzen Welt"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Trakt kostenlos beitreten"
+      "default": "Kostenlos dabei"
     },
     "header_landing_discover": {
       "default": "Entdecken"
     },
     "text_landing_discover": {
-      "default": "Finde heraus, was angesagt ist und wo du es streamen kannst."
+      "default": "Filme und Serien, die du lieben wirst, und wo sie gerade gestreamt werden."
     },
     "header_landing_track": {
       "default": "Verfolgen"
     },
     "text_landing_track": {
-      "default": "Verfolge alle Serien und Filme, die du je gesehen hast."
+      "default": "Jeder Film, jede Episode und jede Staffel, die du gesehen hast, an einem Ort."
     },
     "header_landing_share": {
       "default": "Teilen"
     },
     "text_landing_share": {
-      "default": "Teile Kommentare, Bewertungen und Empfehlungen."
+      "default": "Meinungen, Bewertungen und Listen, denen andere gerne folgen werden."
     },
     "list_title_trending": {
       "default": "Angesagt"

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -223,25 +223,25 @@
       "default": "A global Trakt community"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Join Trakt for Free"
+      "default": "Join Free"
     },
     "header_landing_discover": {
       "default": "Discover"
     },
     "text_landing_discover": {
-      "default": "what's hot and where to stream it."
+      "default": "Movies and shows you will love and where they are streaming right now."
     },
     "header_landing_track": {
       "default": "Track"
     },
     "text_landing_track": {
-      "default": "all the shows and movies you have ever watched."
+      "default": "Every movie, episode, and season you’ve seen, all in one place."
     },
     "header_landing_share": {
       "default": "Share"
     },
     "text_landing_share": {
-      "default": "comments, ratings and recommendations."
+      "default": "Opinions, ratings, and lists that others will love to follow."
     },
     "list_title_trending": {
       "default": "Trending"

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -561,7 +561,7 @@
     },
     "button_text_join_trakt": {
       "default": "Join Trakt",
-      "description": "Text for the button that takes users to the Trakt login page.",
+      "description": "Text for the Trakt login button. This should be a short and concise message that indicates what users can do.",
       "exclude": [
         "android",
         "ios"
@@ -593,7 +593,7 @@
     },
     "button_text_join_trakt_for_free": {
       "default": "Join Trakt for Free",
-      "description": "Text for the button that takes users to the Trakt login page.",
+      "description": "Text for the button that takes users to the Trakt login page, keep the text as short as possible (always as short or shorter than the english version).",
       "exclude": [
         "android",
         "ios"
@@ -608,7 +608,7 @@
       ]
     },
     "text_landing_discover": {
-      "default": "what's hot and where to stream it.",
+      "default": "movies and shows you will love and where they are streaming right now.",
       "description": "Description for the discover step. This should be a short and concise message that indicates what users can discover.",
       "exclude": [
         "android",
@@ -624,7 +624,7 @@
       ]
     },
     "text_landing_track": {
-      "default": "all the shows and movies you have ever watched.",
+      "default": "every movie, episode, and season you’ve seen, all in one place.",
       "description": "Description for the track step. This should be a short and concise message that indicates what users can track.",
       "exclude": [
         "android",
@@ -640,7 +640,7 @@
       ]
     },
     "text_landing_share": {
-      "default": "comments, ratings and recommendations.",
+      "default": "opinions, ratings, and lists that others will love to follow.",
       "description": "Description for the share step. This should be a short and concise message that indicates what users can share.",
       "exclude": [
         "android",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -223,25 +223,25 @@
       "default": "Hecho con ❤️ alrededor del mundo"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Únete a Trakt gratis"
+      "default": "Únete Gratis"
     },
     "header_landing_discover": {
       "default": "Descubre"
     },
     "text_landing_discover": {
-      "default": "Lo más popular y dónde verlo en streaming."
+      "default": "Películas y series que te encantarán y dónde se están transmitiendo ahora mismo."
     },
     "header_landing_track": {
       "default": "Sigue"
     },
     "text_landing_track": {
-      "default": "Todo lo que has visto."
+      "default": "Cada película, episodio y temporada que has visto, todo en un solo lugar."
     },
     "header_landing_share": {
       "default": "Compartir"
     },
     "text_landing_share": {
-      "default": "comentarios, puntuaciones y recomendaciones."
+      "default": "Opiniones, valoraciones y listas que otros adorarán seguir."
     },
     "list_title_trending": {
       "default": "Tendencias"

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -223,25 +223,25 @@
       "default": "Hecho con ❤️ alrededor del mundo"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Únete a Trakt gratis"
+      "default": "Únete Gratis"
     },
     "header_landing_discover": {
       "default": "Descubre"
     },
     "text_landing_discover": {
-      "default": "Lo más popular y dónde verlo."
+      "default": "Películas y series que te van a encantar y dónde las puedes ver ahora mismo."
     },
     "header_landing_track": {
       "default": "Seguimiento"
     },
     "text_landing_track": {
-      "default": "Todo lo que has visto."
+      "default": "Cada película, episodio y temporada que has visto, todo en un solo lugar."
     },
     "header_landing_share": {
       "default": "Compartir"
     },
     "text_landing_share": {
-      "default": "Comentarios, calificaciones y recomendaciones. ¡Prepárate para un peliculón! <3"
+      "default": "Opiniones, calificaciones y listas que a otros les encantará seguir."
     },
     "list_title_trending": {
       "default": "Tendencias"

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -211,7 +211,7 @@
       "default": "Rechercher séries & films..."
     },
     "button_text_join_trakt": {
-      "default": "Rejoindre Trakt"
+      "default": "Joignez-vous à Trakt"
     },
     "button_label_join_trakt": {
       "default": "Rejoignez trakt.tv pour suivre vos visionnements"
@@ -223,25 +223,25 @@
       "default": "Créé avec ❤ autour du monde"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Rejoindre Trakt gratuitement"
+      "default": "Joignez-vous !"
     },
     "header_landing_discover": {
       "default": "Découvrir"
     },
     "text_landing_discover": {
-      "default": "Ce qui est populaire et où le visionner."
+      "default": "Films et séries que vous allez adorer, et où ils sont diffusés en ce moment."
     },
     "header_landing_track": {
       "default": "Suivre"
     },
     "text_landing_track": {
-      "default": "Tout ce que vous avez regardé."
+      "default": "Chaque film, épisode et saison que vous avez vu, au même endroit."
     },
     "header_landing_share": {
       "default": "Partager"
     },
     "text_landing_share": {
-      "default": "Commentaires, évaluations et recommandations."
+      "default": "Opinions, cotes et listes que les autres vont adorer suivre."
     },
     "list_title_trending": {
       "default": "Tendance"

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -211,7 +211,7 @@
       "default": "Rechercher séries & films..."
     },
     "button_text_join_trakt": {
-      "default": "Rejoindre Trakt"
+      "default": "Rejoignez Trakt"
     },
     "button_label_join_trakt": {
       "default": "Rejoignez trakt.tv pour suivre vos visionnages"
@@ -223,25 +223,25 @@
       "default": "Créé avec ❤️ partout dans le monde"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Rejoindre Trakt gratuitement"
+      "default": "Rejoignez Trakt"
     },
     "header_landing_discover": {
       "default": "Découvrir"
     },
     "text_landing_discover": {
-      "default": "Ce qui est tendance et où le regarder."
+      "default": "Films et séries que vous allez adorer et où ils sont diffusés en ce moment."
     },
     "header_landing_track": {
       "default": "Suivre"
     },
     "text_landing_track": {
-      "default": "Tout ce que vous avez regardé."
+      "default": "Chaque film, épisode et saison que vous avez vu, en un seul endroit."
     },
     "header_landing_share": {
       "default": "Partager"
     },
     "text_landing_share": {
-      "default": "commentaires, notes et recommandations. "
+      "default": "Opinions, notes et listes que les autres adoreront suivre."
     },
     "list_title_trending": {
       "default": "Tendances"

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -211,7 +211,7 @@
       "default": "Cerca serie e film..."
     },
     "button_text_join_trakt": {
-      "default": "Iscriviti a Trakt"
+      "default": "Unisciti a Trakt"
     },
     "button_label_join_trakt": {
       "default": "Iscriviti a trakt.tv per tenere traccia di ciò che stai guardando"
@@ -223,25 +223,25 @@
       "default": "Realizzato a mano in tutto il mondo"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Iscriviti a Trakt gratuitamente"
+      "default": "Iscriviti Gratis"
     },
     "header_landing_discover": {
       "default": "Scopri"
     },
     "text_landing_discover": {
-      "default": "cosa c'è di bello e dove guardarlo in streaming."
+      "default": "Film e serie TV che amerai e dove sono in streaming adesso."
     },
     "header_landing_track": {
       "default": "Traccia"
     },
     "text_landing_track": {
-      "default": "tutti i programmi e i film che hai guardato."
+      "default": "Ogni film, episodio e stagione che hai visto, tutto in un unico posto."
     },
     "header_landing_share": {
       "default": "Condividi"
     },
     "text_landing_share": {
-      "default": "commenti, giudizi e raccomandazioni."
+      "default": "Opinioni, valutazioni e liste che gli altri adoreranno seguire."
     },
     "list_title_trending": {
       "default": "Tendenze"

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -223,25 +223,25 @@
       "default": "世界中から愛を込めて制作"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Traktに無料登録"
+      "default": "無料で参加"
     },
     "header_landing_discover": {
       "default": "作品を探す"
     },
     "text_landing_discover": {
-      "default": "話題の作品と配信サービス。"
+      "default": "あなたが好きになる映画やドラマ、そして今すぐどこで見られるか。"
     },
     "header_landing_track": {
       "default": "視聴状況を記録"
     },
     "text_landing_track": {
-      "default": "視聴済みの作品をすべて管理。"
+      "default": "見たすべての映画、エピソード、シーズンを、すべて1か所に。"
     },
     "header_landing_share": {
       "default": "共有する"
     },
     "text_landing_share": {
-      "default": "コメント、評価、おすすめ情報を共有。"
+      "default": "他の人がフォローしたくなるような意見、評価、リスト。"
     },
     "list_title_trending": {
       "default": "話題の作品"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -223,25 +223,25 @@
       "default": "Håndlaget rundt om i verden"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Bli med i Trakt gratis"
+      "default": "Bli med gratis"
     },
     "header_landing_discover": {
       "default": "Oppdag"
     },
     "text_landing_discover": {
-      "default": "Hva som er populært og hvor du kan streame det."
+      "default": "Filmer og serier du kommer til å elske og hvor de strømmes akkurat nå."
     },
     "header_landing_track": {
       "default": "Spor"
     },
     "text_landing_track": {
-      "default": "Alle serier og filmer du noen gang har sett."
+      "default": "Hver film, episode og sesong du har sett, alt på ett sted."
     },
     "header_landing_share": {
       "default": "Del"
     },
     "text_landing_share": {
-      "default": "Kommentarer, vurderinger og anbefalinger."
+      "default": "Meninger, vurderinger og lister som andre vil elske å følge."
     },
     "list_title_trending": {
       "default": "Populært"

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -211,7 +211,7 @@
       "default": "Zoek series & films..."
     },
     "button_text_join_trakt": {
-      "default": "Doe mee met Trakt"
+      "default": "Word lid van Trakt"
     },
     "button_label_join_trakt": {
       "default": "Doe mee met trakt.tv om bij te houden wat je bekijkt"
@@ -223,25 +223,25 @@
       "default": "Handgemaakt over de hele wereld"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Doe gratis mee met Trakt"
+      "default": "Word lid"
     },
     "header_landing_discover": {
       "default": "Ontdekken"
     },
     "text_landing_discover": {
-      "default": "wat populair is en waar je het kunt streamen."
+      "default": "Films en series waar je van gaat houden en waar ze nu te streamen zijn."
     },
     "header_landing_track": {
       "default": "Bijhouden"
     },
     "text_landing_track": {
-      "default": "alle series en films die je ooit hebt gezien."
+      "default": "Elke film, aflevering en seizoen die je hebt gezien, allemaal op één plek."
     },
     "header_landing_share": {
       "default": "Delen"
     },
     "text_landing_share": {
-      "default": "opmerkingen, beoordelingen en aanbevelingen."
+      "default": "Meningen, beoordelingen en lijsten die anderen graag zullen volgen."
     },
     "list_title_trending": {
       "default": "Trending"

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -223,25 +223,25 @@
       "default": "Dopracowane przez społeczność na całym świecie"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Dołącz do Trakt za darmo"
+      "default": "Dołącz za darmo"
     },
     "header_landing_discover": {
       "default": "Odkrywaj"
     },
     "text_landing_discover": {
-      "default": "co jest na czasie i gdzie można to obejrzeć."
+      "default": "Filmy i seriale, które pokochasz i gdzie są teraz dostępne."
     },
     "header_landing_track": {
       "default": "Śledź"
     },
     "text_landing_track": {
-      "default": "wszystkie seriale i filmy, które kiedykolwiek oglądałeś."
+      "default": "Każdy film, odcinek i sezon, które widziałeś, wszystko w jednym miejscu."
     },
     "header_landing_share": {
       "default": "Dziel się z innymi"
     },
     "text_landing_share": {
-      "default": "komentarze, oceny i rekomendacje."
+      "default": "Opinie, oceny i listy, które inni pokochają obserwować."
     },
     "list_title_trending": {
       "default": "Teraz popularne"

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -223,25 +223,25 @@
       "default": "Feito com ❤️ ao redor do mundo"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Junte-se ao Trakt Grátis"
+      "default": "Junte-se Grátis"
     },
     "header_landing_discover": {
       "default": "Descubra"
     },
     "text_landing_discover": {
-      "default": "O que está bombando e onde assistir."
+      "default": "Filmes e séries que você vai amar e onde estão em streaming agora."
     },
     "header_landing_track": {
       "default": "Acompanhe"
     },
     "text_landing_track": {
-      "default": "Tudo o que você assistiu."
+      "default": "Todo filme, episódio e temporada que você assistiu, tudo em um só lugar."
     },
     "header_landing_share": {
       "default": "Compartilhe"
     },
     "text_landing_share": {
-      "default": "Comentários, avaliações e recomendações."
+      "default": "Opiniões, avaliações e listas que outros vão adorar seguir."
     },
     "list_title_trending": {
       "default": "Tendências"

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -223,25 +223,25 @@
       "default": "Elaborat manual în toată lumea"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Alătură-te Trakt gratuit"
+      "default": "Alătură-te Gratuit"
     },
     "header_landing_discover": {
       "default": "Descoperă"
     },
     "text_landing_discover": {
-      "default": "ce este popular și unde îl poți urmări."
+      "default": "Filme și seriale pe care le vei adora și unde sunt disponibile acum."
     },
     "header_landing_track": {
       "default": "Urmărește"
     },
     "text_landing_track": {
-      "default": "toate serialele și filmele pe care le-ai urmărit vreodată."
+      "default": "Fiecare film, episod și sezon pe care l-ai văzut, într-un singur loc."
     },
     "header_landing_share": {
       "default": "Partajează"
     },
     "text_landing_share": {
-      "default": "comentarii, evaluări și recomandări."
+      "default": "Opinii, evaluări și liste pe care alții le vor adora să le urmărească."
     },
     "list_title_trending": {
       "default": "Trending"

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -223,25 +223,25 @@
       "default": "Handgjord runt om i världen"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Gå med i Trakt gratis"
+      "default": "Gå med gratis"
     },
     "header_landing_discover": {
       "default": "Upptäck"
     },
     "text_landing_discover": {
-      "default": "Vad som är hett och var man kan streama det."
+      "default": "Filmer och serier du kommer att älska och var de streamas just nu."
     },
     "header_landing_track": {
       "default": "Spåra"
     },
     "text_landing_track": {
-      "default": "Alla serier och filmer du någonsin har sett."
+      "default": "Varje film, avsnitt och säsong du har sett, allt på ett ställe."
     },
     "header_landing_share": {
       "default": "Dela"
     },
     "text_landing_share": {
-      "default": "Kommentarer, betyg och rekommendationer."
+      "default": "Åsikter, betyg och listor som andra kommer att älska att följa."
     },
     "list_title_trending": {
       "default": "Trendigt"

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -223,25 +223,25 @@
       "default": "Створено по всьому світу"
     },
     "button_text_join_trakt_for_free": {
-      "default": "Приєднатися до Trakt безкоштовно"
+      "default": "Приєднатися безкоштовно"
     },
     "header_landing_discover": {
       "default": "Відкрити"
     },
     "text_landing_discover": {
-      "default": "що популярне і де це можна переглянути."
+      "default": "Фільми та серіали, які вам сподобаються, і де їх можна переглянути прямо зараз."
     },
     "header_landing_track": {
       "default": "Відстежувати"
     },
     "text_landing_track": {
-      "default": "усі серіали та фільми, які ви коли-небудь дивились."
+      "default": "Кожен фільм, епізод і сезон, які ви бачили, в одному місці."
     },
     "header_landing_share": {
       "default": "Поділитися"
     },
     "text_landing_share": {
-      "default": "коментарі, оцінки та рекомендації."
+      "default": "Думки, оцінки та списки, які інші захочуть відстежувати."
     },
     "list_title_trending": {
       "default": "Тренди"

--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -15,7 +15,7 @@
   .trakt-footer {
     height: var(--ni-300);
 
-    margin-top: var(--ni-120);
+    margin-top: var(--gap-xxl);
     margin-left: var(--layout-sidebar-distance);
 
     padding-left: var(--layout-distance-side);

--- a/projects/client/src/lib/sections/landing/Landing.svelte
+++ b/projects/client/src/lib/sections/landing/Landing.svelte
@@ -36,10 +36,5 @@
     @include for-tablet-lg-and-below {
       padding: 0;
     }
-
-    @include for-mobile {
-      grid-template-columns: 1fr;
-      justify-items: center;
-    }
   }
 </style>

--- a/projects/client/src/lib/sections/landing/components/Step.svelte
+++ b/projects/client/src/lib/sections/landing/components/Step.svelte
@@ -63,6 +63,7 @@
     p {
       margin-left: var(--ni-24);
       max-width: var(--ni-252);
+      text-transform: lowercase;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/landing/components/Steps.svelte
+++ b/projects/client/src/lib/sections/landing/components/Steps.svelte
@@ -39,6 +39,17 @@
     @include for-tablet-lg-and-below {
       margin-top: 0;
     }
+
+    @include for-mobile {
+      display: flex;
+      gap: unset;
+      flex-direction: column;
+      height: min(
+        calc(95dvh - var(--navbar-height) - var(--mobile-navbar-height)),
+        var(--ni-640)
+      );
+      justify-content: space-between;
+    }
   }
 
   .trakt-landing-join {


### PR DESCRIPTION
Refreshes the landing page copy to be more concise and impactful.

Also, adjusts translations to reflect the updated copy and improve overall clarity and consistency across languages.
