### PR TITLE
fix(comments): do not hide reactions summary preview

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummaryButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummaryButton.svelte
@@ -13,7 +13,7 @@
 
   const { comment }: { comment: MediaComment } = $props();
 
-  const { summary, isLoading, currentReaction } = $derived(
+  const { summary, currentReaction } = $derived(
     useCommentReactions({ id: comment.id }),
   );
 
@@ -24,7 +24,7 @@
   const restCount = $derived($summary.count - $summary.topCount);
 </script>
 
-{#if !$isLoading && $summary.count > 0}
+{#if $summary.count > 0}
   <button class="trakt-reactions-summary" use:portalTrigger>
     {$summary.top.map(([reaction]) => REACTIONS_MAP[reaction]).join(" ")}
     {#if restCount > 0}


### PR DESCRIPTION
## ♪ Note ♪

- Do not hide preview while loading.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/503331d6-8b7c-49ed-804c-bc875b275b2a

After:

https://github.com/user-attachments/assets/e6d2386f-70c0-4c52-8f28-5e337a91db28

