### PR TITLE
fix(comment): use min width for reactions summary

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummaryButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummaryButton.svelte
@@ -62,10 +62,12 @@
 
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: var(--gap-xs);
 
     padding: var(--ni-4) var(--ni-8);
     height: var(--ni-32);
+    min-width: var(--ni-32);
     box-sizing: border-box;
 
     user-select: none;


### PR DESCRIPTION
## ♪ Note ♪

- Summary is now circular when hovering over it when there is only one reaction.