### PR TITLE
Fix/layout sizing

### DIFF
--- a/projects/client/src/lib/features/calendar/Calendar.svelte
+++ b/projects/client/src/lib/features/calendar/Calendar.svelte
@@ -24,14 +24,7 @@
   </div>
 
   {#if $isLoading}
-    <!--
-    Loading indicator is keyed to ensure destruction, since
-    the calendar items depend on accurate element positions onMount
-    FIXME: change the scroll sync to a simpler approach and remove this hack
-   -->
-    {#key "calendar-loading"}
-      <LoadingIndicator />
-    {/key}
+    <LoadingIndicator />
   {:else}
     <CalendarItems calendar={$calendar} safeAreaOffset={$observedDimension} />
   {/if}

--- a/projects/client/src/lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte
@@ -3,7 +3,8 @@
   import { fade } from "svelte/transition";
 </script>
 
-<div class="loading-indicator" out:fade={{ duration: 150 }}>
+<!-- FIXME: Add a proper crossfade component -->
+<div class="loading-indicator" in:fade={{ duration: 150 }}>
   <LoaderIcon />
 </div>
 

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -104,10 +104,6 @@
     body.dialog-open {
       overflow: hidden;
     }
-
-    body:has(.trakt-side-navbar) {
-      --layout-sidebar-distance: calc(var(--side-navbar-width) + var(--ni-16));
-    }
   </style>
 
   {#if data.device === "tv"}

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -83,6 +83,4 @@
   @-moz-document url-prefix() {
     --layout-scrollbar-width: var(--ni-16);
   }
-
-  --layout-sidebar-distance: var(--ni-0);
 }

--- a/projects/client/src/style/layout/modes.scss
+++ b/projects/client/src/style/layout/modes.scss
@@ -2,8 +2,13 @@
 
 :root {
   --layout-distance-side: var(--ni-24);
+  --layout-sidebar-distance: calc(var(--side-navbar-width) + var(--ni-16));
 
   @include for-mobile {
     --layout-distance-side: var(--ni-12);
+  }
+
+  @include for-tablet-sm-and-below {
+    --layout-sidebar-distance: var(--ni-0);
   }
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Reserve sidebar space using media queries, do not depend on it already being present.
- Do not keep loading indicator in the dom tree on removal:
  - Because it was being faded out, this could lead to content jumps due to both the indicator and actual content being present at the same time for a short time.

## 👀 Examples 👀

Before/after:

https://github.com/user-attachments/assets/388eaccc-6a14-4b0f-8239-bdb01a038bb2

https://github.com/user-attachments/assets/3cac5975-6140-436f-bf7a-4150f6a8768a

Calendar example without the key hack:

https://github.com/user-attachments/assets/b0308e00-c483-4239-949e-9385003200b9


