### PR TITLE
fix(summary): mark upcoming episodes in season lists as such

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -29,9 +29,7 @@
 
   const src = $derived(useEpisodeSpoilerImage({ episode, show }));
 
-  const isShowContext = $derived(
-    rest.variant === "default" && rest.context === "show",
-  );
+  const isShowContext = $derived("context" in rest && rest.context === "show");
   const isActivity = $derived(rest.variant === "activity");
 </script>
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCardProps.ts
@@ -5,9 +5,8 @@ import type { Snippet } from 'svelte';
 
 export type EpisodeItemVariant =
   | { variant: 'next'; episode: EpisodeProgressEntry }
-  | { variant: 'upcoming'; episode: EpisodeEntry }
   | {
-    variant: 'default';
+    variant: 'default' | 'upcoming';
     episode: EpisodeEntry;
     context?: 'show' | 'standalone';
   }

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -71,7 +71,7 @@
       {episode}
       {show}
       popupActions={hasBulkMarkAsWatched(episode) ? popupActions : undefined}
-      variant="default"
+      variant={episode.airDate > new Date() ? "default" : "default"}
       context="show"
     />
   {/snippet}


### PR DESCRIPTION
## ♪ Note ♪

- Mark upcoming episodes in season lists as such.

## 👀 Examples 👀

Before/after:
<img width="428" height="927" alt="Screenshot 2025-08-14 at 22 05 25" src="https://github.com/user-attachments/assets/9893ef9c-8071-452e-b0ea-b770804b8568" /> <img width="428" height="927" alt="Screenshot 2025-08-14 at 22 05 02" src="https://github.com/user-attachments/assets/f52d68d7-cfb9-4195-bfce-681b7255c296" />
