### PR TITLE
fix(checkin): correctly set initial position of now playing toast

### DIFF
--- a/projects/client/src/lib/sections/now-playing/_internal/useScrollDistance.ts
+++ b/projects/client/src/lib/sections/now-playing/_internal/useScrollDistance.ts
@@ -15,7 +15,7 @@ export function useScrollDistance() {
   };
 
   onMount(() => {
-    handleScroll();
+    requestAnimationFrame(handleScroll);
 
     const unregisterScroll = GlobalEventBus.getInstance().register(
       'scroll',


### PR DESCRIPTION
## ♪ Note ♪

- Correctly sets initial position of the now playing toast.

## 👀 Example 👀

Before:

https://github.com/user-attachments/assets/625684b4-652a-4fdf-84c7-14c1ed7befb9

After:

https://github.com/user-attachments/assets/20e907d4-962d-447b-8c06-0af8f24b5135


