### PR TITLE
fix(upcoming): sort upcoming movies

### DIFF
--- a/projects/client/src/lib/sections/lists/watchlist/useUnreleasedList.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useUnreleasedList.ts
@@ -3,28 +3,23 @@ import {
   useWatchList,
   type WatchListStoreProps,
 } from '$lib/sections/lists/watchlist/useWatchList.ts';
+import { isMaxDate } from '$lib/utils/date/isMaxDate.ts';
 import { derived } from 'svelte/store';
 
 // FIXME remove when sorting is fixed
 const UNRELEASED_LIST_LIMIT = 500;
 
-/*
-  For unreleased lists, we consider 'released' also.
-  Depending on the region, an item may be released in general,
-  but not yet in a particular region.
-*/
 const VALID_STATUSES: MediaStatus[] = [
   'planned',
   'post production',
   'in production',
   'upcoming',
-  'released',
 ] as const;
 
 export function useUnreleasedList(params: Omit<WatchListStoreProps, 'sort'>) {
   const { list: watchlist, isLoading, page } = useWatchList({
     ...params,
-    sort: 'rank',
+    sort: 'released',
     limit: UNRELEASED_LIST_LIMIT,
   });
 
@@ -34,10 +29,21 @@ export function useUnreleasedList(params: Omit<WatchListStoreProps, 'sort'>) {
       $watchlist
         .filter((item) => {
           const isUpcomingItem = item.airDate.getTime() > Date.now();
-          const hasValidStatus = VALID_STATUSES.includes(item.status);
+          /*
+            For unreleased lists, we consider 'released' also.
+            Depending on the region, an item may be released in general,
+            but not yet in a particular region.
+          */
+          const isUpcomingReleasedItem = item.status === 'released' &&
+            !isMaxDate(item.airDate);
+
+          const hasValidStatus = VALID_STATUSES.includes(item.status) ||
+            isUpcomingReleasedItem;
 
           return isUpcomingItem && hasValidStatus;
-        }),
+        })
+        // FIXME: add sorting/filter support to api, or switch to calendar api
+        .sort((a, b) => a.airDate.getTime() - b.airDate.getTime()),
   );
 
   return {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes https://github.com/trakt/trakt-web/issues/954
- Also fixes a small bug to filter out 'garbage' (e.g. old released movies that don't have a known air date).
- I left a fixme in there to handle this better on an API level. It might be better to even switch to the calendar API for these 🤔 

## 👀 Example 👀
Before:
<img width="1394" height="309" alt="Screenshot 2025-08-19 at 08 25 34" src="https://github.com/user-attachments/assets/d0324439-74f2-40bc-8dba-db319b1c0082" />

After:
<img width="1394" height="309" alt="Screenshot 2025-08-19 at 08 25 40" src="https://github.com/user-attachments/assets/ab017864-b8e3-4ddc-b8c2-67a6f05aca89" />
