### PR TITLE
feat(errors): add error page for unexpected client errors

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Вижте личната активност"
+    },
+    "page_title_unexpected_error": {
+      "default": "Нещо се обърка"
+    },
+    "error_text_unexpected_error": {
+      "default": "О, не… Нещо неочаквано се случи. Ако това продължава, моля, <a>създайте нов проблем</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Vis personlig aktivitet"
+    },
+    "page_title_unexpected_error": {
+      "default": "Noget gik galt"
+    },
+    "error_text_unexpected_error": {
+      "default": "Ups... Noget uventet skete. Hvis dette fortsætter, skal du <a>oprette et nyt problem</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Persönliche Aktivität ansehen"
+    },
+    "page_title_unexpected_error": {
+      "default": "Etwas ist schiefgelaufen"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oje... Etwas Unerwartetes ist passiert. Wenn dies weiterhin auftritt, bitte <a>erstelle ein neues Ticket</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "View personal activity"
+    },
+    "page_title_unexpected_error": {
+      "default": "Something went wrong"
+    },
+    "error_text_unexpected_error": {
+      "default": "Uh oh... Something unexpected happened. If this keeps happening, please <a>create a new issue</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5061,6 +5061,22 @@
         "android",
         "ios"
       ]
+    },
+    "page_title_unexpected_error": {
+      "default": "Something went wrong",
+      "description": "Title for the unexpected error page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "error_text_unexpected_error": {
+      "default": "Uh oh... Something unexpected happened. If this keeps happening, please <a>create a new issue</a>.",
+      "description": "Text shown on the unexpected error page, informing the user that something went wrong and providing a link to create a new issue.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Ver actividad personal"
+    },
+    "page_title_unexpected_error": {
+      "default": "Algo salió mal"
+    },
+    "error_text_unexpected_error": {
+      "default": "Vaya... Algo inesperado ha sucedido. Si esto sigue ocurriendo, por favor, <a>crea un nuevo informe</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Ver actividad personal"
+    },
+    "page_title_unexpected_error": {
+      "default": "Algo salió mal"
+    },
+    "error_text_unexpected_error": {
+      "default": "¡Uy! Algo inesperado pasó. Si esto sigue, por favor, <a>reporta un nuevo problema</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Voir votre activité"
+    },
+    "page_title_unexpected_error": {
+      "default": "Quelque chose s'est mal passé"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oups... Un imprévu est survenu. Si ça continue, merci de <a>signaler un nouveau problème</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Voir l'activité personnelle"
+    },
+    "page_title_unexpected_error": {
+      "default": "Un problème est survenu"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oups... Quelque chose d'inattendu s'est produit. Si cela persiste, merci de <a>signaler un nouveau problème</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Visualizza attività personale"
+    },
+    "page_title_unexpected_error": {
+      "default": "Qualcosa è andato storto"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oh no... Qualcosa di inaspettato è successo. Se continua ad accadere, per favore, <a>crea un nuovo ticket</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "パーソナルアクティビティを表示"
+    },
+    "page_title_unexpected_error": {
+      "default": "問題が発生しました"
+    },
+    "error_text_unexpected_error": {
+      "default": "おっと…予期せぬことが起きました。もしこれが続くようでしたら、<a>新しい問題を報告してください</a>。"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Vis personlig aktivitet"
+    },
+    "page_title_unexpected_error": {
+      "default": "Noe gikk galt"
+    },
+    "error_text_unexpected_error": {
+      "default": "Jøss... Noe uventet skjedde. Hvis dette fortsetter, vennligst <a>opprett en ny sak</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Bekijk persoonlijke activiteit"
+    },
+    "page_title_unexpected_error": {
+      "default": "Er is iets misgegaan"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oeps... Er is iets onverwachts gebeurd. Als dit blijft gebeuren, <a>maak dan een nieuw probleem aan</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Wyświetl aktywność osobistą"
+    },
+    "page_title_unexpected_error": {
+      "default": "Coś poszło nie tak"
+    },
+    "error_text_unexpected_error": {
+      "default": "Ups... Coś niespodziewanego się wydarzyło. Jeśli to się powtarza, proszę <a>zgłosić nowy problem</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Ver atividade pessoal"
+    },
+    "page_title_unexpected_error": {
+      "default": "Algo deu errado"
+    },
+    "error_text_unexpected_error": {
+      "default": "Ah não... Algo inesperado aconteceu. Se isso continuar acontecendo, por favor, <a>crie um novo chamado</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Vezi activitatea personală"
+    },
+    "page_title_unexpected_error": {
+      "default": "Ceva n-a mers bine"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oups... S-a întâmplat ceva neașteptat. Dacă asta continuă, te rugăm să <a>creezi o nouă sesizare</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Visa personlig aktivitet"
+    },
+    "page_title_unexpected_error": {
+      "default": "Något gick fel"
+    },
+    "error_text_unexpected_error": {
+      "default": "Oj då... Något oväntat hände. Om detta fortsätter, vänligen <a>skapa ett nytt ärende</a>."
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1767,6 +1767,12 @@
     },
     "button_label_personal": {
       "default": "Переглянути особисту активність"
+    },
+    "page_title_unexpected_error": {
+      "default": "Щось пішло не так"
+    },
+    "error_text_unexpected_error": {
+      "default": "Ой… Сталася неочікувана помилка. Якщо це повторюється, будь ласка, <a>створіть новий запит</a>."
     }
   }
 }

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -193,6 +193,12 @@ declare global {
       'onclickoutside'?: (ev: CustomEvent) => void;
       'onfiles'?: (ev: CustomEvent<{ files: FileList }>) => void;
     }
+
+    interface IntrinsicElements {
+      'svelte:window': {
+        onerror?: (event: ErrorEvent) => void;
+      };
+    }
   }
 
   interface WebOS {

--- a/projects/client/src/lib/pages/errors/UnexpectedErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/UnexpectedErrorPage.svelte
@@ -1,0 +1,25 @@
+<script>
+  import Button from "$lib/components/buttons/Button.svelte";
+  import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import ErrorPage from "./ErrorPage.svelte";
+</script>
+
+<ErrorPage title={m.page_title_unexpected_error()}>
+  <p>
+    <MessageWithLink
+      message={m.error_text_unexpected_error()}
+      href={UrlBuilder.github.reportIssue()}
+      target="_blank"
+    />
+  </p>
+  <Button
+    variant="primary"
+    color="purple"
+    onclick={() => window.location.reload()}
+    label={m.button_label_retry()}
+  >
+    {m.button_text_retry()}
+  </Button>
+</ErrorPage>

--- a/projects/client/src/lib/sections/footer/components/ExternalLinks.svelte
+++ b/projects/client/src/lib/sections/footer/components/ExternalLinks.svelte
@@ -29,7 +29,7 @@
     </Link>
   {/if}
 
-  <Link href={UrlBuilder.github()} target="_blank">
+  <Link href={UrlBuilder.github.web()} target="_blank">
     <GithubIcon />
   </Link>
   <Link href={UrlBuilder.app.ios()} target="_blank">

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -169,7 +169,10 @@ export const UrlBuilder = {
     android: () => 'https://trakt.tv/a/trakt-android',
     ios: () => 'https://trakt.tv/a/trakt-ios',
   },
-  github: () => 'https://github.com/trakt/trakt-web',
+  github: {
+    web: () => 'https://github.com/trakt/trakt-web',
+    reportIssue: () => 'https://github.com/trakt/trakt-web/issues/new',
+  },
   vip: () => 'https://trakt.tv/vip',
   og: {
     getVip: () => 'https://trakt.tv/vip',


### PR DESCRIPTION
## 🎶 Notes 🎶

- The error provider now also deals with unexpected client errors.
- Rather than taking the link to support, users can create a new issue.
- Not sure if this is gonna be overkill. But then again, we should strive for a situation without any errors to begin with :P 

## 👀 Example 👀
Example with an error thrown on mount:
<img width="1422" height="1220" alt="Screenshot 2025-08-19 at 14 04 40" src="https://github.com/user-attachments/assets/4b046981-9903-44aa-be90-81ab46148b11" />
