### PR TITLE
chore: enable source maps

### DIFF
--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -110,6 +110,11 @@ export default defineConfig(({ mode }) => ({
     }),
     svelteTesting(),
   ],
+
+  build: {
+    sourcemap: true,
+  },
+
   //TODO enable globals when typings are fixed
   test: {
     include: [


### PR DESCRIPTION
## ♪ Note ♪

- Adds source maps to builds.

## 👀 Examples 👀
Examples from a preview build:

<img width="647" height="100" alt="Screenshot 2025-08-19 at 14 23 17" src="https://github.com/user-attachments/assets/3906d168-5eb5-48cf-8708-e14912b71b1d" />

<img width="1261" height="809" alt="Screenshot 2025-08-19 at 14 24 32" src="https://github.com/user-attachments/assets/c0f56a84-b1a7-40be-8553-a649fd0d8b18" />
