### PR TITLE
fix(summary): deal with unknown episode runtime on show summary

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -16,6 +16,10 @@
   const isActivity = $derived(props.variant === "activity");
   const isHidden = $derived(props.status === "hidden");
   const style = $derived(props.style ?? "cover");
+
+  const runtime = $derived(
+    isNaN(props.episode.runtime) ? props.show.runtime : props.episode.runtime,
+  );
 </script>
 
 {#snippet action()}
@@ -40,7 +44,7 @@
   {:else}
     <div class="trakt-episode-tag">
       {#if ["next", "default"].includes(props.variant)}
-        <DurationTag i18n={TagIntlProvider} runtime={props.episode.runtime} />
+        <DurationTag i18n={TagIntlProvider} {runtime} />
       {/if}
 
       {#if props.variant === "next"}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Use show runtime if ep runtime is not known.
- ~~The 0 remaining also seems weird, since we do know the episode count. I'll check on hyperdrive.~~ nvm, is a client side check, number is correct since it checks aired vs completed.

## 👀 Example 👀

Before:
<img width="1200" height="577" alt="Screenshot 2025-08-19 at 14 58 19" src="https://github.com/user-attachments/assets/dd948644-6648-423c-bfee-a04d48bdbd04" />

After:
<img width="1200" height="577" alt="Screenshot 2025-08-19 at 14 57 57" src="https://github.com/user-attachments/assets/1cb85e3e-d1ce-4c4a-acdc-6784163e1da7" />
