### PR TITLE
fix(user): only assume defined data for prefetched query

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -142,35 +142,35 @@ export function useUser() {
   );
   const history = derived(
     historyQueryResponse,
-    ($query) => definedData($query.data),
+    ($query) => $query.data,
   );
   const watchlist = derived(
     watchlistQueryResponse,
-    ($watchlist) => definedData($watchlist.data),
+    ($watchlist) => $watchlist.data,
   );
   const ratings = derived(
     ratingsQueryResponse,
-    ($ratings) => definedData($ratings.data),
+    ($ratings) => $ratings.data,
   );
   const likes = derived(
     commentLikesQueryResponse,
-    ($likes) => definedData($likes.data),
+    ($likes) => $likes.data,
   );
   const reactions = derived(
     commentReactionsQueryResponse,
-    ($reactions) => definedData($reactions.data),
+    ($reactions) => $reactions.data,
   );
   const favorites = derived(
     favoritesQueryResponse,
-    ($favorites) => definedData($favorites.data),
+    ($favorites) => $favorites.data,
   );
   const network = derived(
     followingQueryResponse,
-    ($network) => definedData($network.data),
+    ($network) => $network.data,
   );
   const plexCollection = derived(
     plexCollectionQueryResponse,
-    ($collection) => definedData($collection.data),
+    ($collection) => $collection.data,
   );
 
   return {

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -29,7 +29,7 @@
 
   const { history } = useUser();
 
-  const showProgress = $derived($history.shows.get(show.id));
+  const showProgress = $derived($history?.shows.get(show.id));
   const watchedEpisodes = $derived(showProgress?.episodes);
 
   const hasUnseenEpisodes = $derived(!Boolean(showProgress?.isWatched));

--- a/projects/client/src/lib/sections/summary/components/stream/_internal/usePlexCollection.ts
+++ b/projects/client/src/lib/sections/summary/components/stream/_internal/usePlexCollection.ts
@@ -16,11 +16,11 @@ export function usePlexCollection(target: MetaInfoProps) {
     ($plexCollection) => {
       switch (target.type) {
         case 'movie':
-          return $plexCollection.movieIds.includes(target.media.id);
+          return $plexCollection?.movieIds.includes(target.media.id);
         case 'show':
-          return $plexCollection.showIds.includes(target.media.id);
+          return $plexCollection?.showIds.includes(target.media.id);
         case 'episode':
-          return $plexCollection.episodeIds.includes(target.episode.id);
+          return $plexCollection?.episodeIds.includes(target.episode.id);
       }
     },
   );


### PR DESCRIPTION
## 🎶 Notes 🎶

- Error provider is already paying off.
- Only assume user settings data is defined since that's the only one that's prefetched.

## 👀 Examples 👀

Before:

https://github.com/user-attachments/assets/c2910894-a496-4a19-a020-17212cc2adef

After:

https://github.com/user-attachments/assets/1dec51b9-41ee-474f-82a4-172cfbe5e501


