### PR TITLE
refactor: extract common toggler component

### DIFF
--- a/projects/client/src/lib/components/toggles/ToggleOption.ts
+++ b/projects/client/src/lib/components/toggles/ToggleOption.ts
@@ -1,0 +1,7 @@
+import type { Snippet } from 'svelte';
+
+export interface ToggleOption {
+  value: string;
+  label: string;
+  content?: Snippet;
+}

--- a/projects/client/src/lib/components/toggles/ToggleOption.ts
+++ b/projects/client/src/lib/components/toggles/ToggleOption.ts
@@ -1,7 +1,8 @@
 import type { Snippet } from 'svelte';
 
-export interface ToggleOption {
-  value: string;
+export interface ToggleOption<T> {
+  value: T;
+  text: string;
   label: string;
   content?: Snippet;
 }

--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import ToggleTag from "$lib/sections/components/ToggleTag.svelte";
+  import type { Writable } from "svelte/store";
+  import type { ToggleOption } from "./ToggleOption.ts";
+
+  interface TogglerProps {
+    type: "combo" | "radio";
+    value: Writable<string[]>;
+    options: ToggleOption[];
+    class?: string;
+  }
+
+  const { type, value, options, class: className }: TogglerProps = $props();
+
+  const allValues = $derived(options.map((option) => option.value));
+
+  const handleComboChange = (optionValue: string) => {
+    const currentValues = $value;
+    const isCurrentlySelected = currentValues.includes(optionValue);
+
+    const newValues = isCurrentlySelected
+      ? currentValues.filter((v) => v !== optionValue)
+      : [...currentValues, optionValue];
+
+    value.set(newValues.length > 0 ? newValues : allValues);
+  };
+
+  const handleRadioChange = (optionValue: string) => {
+    value.set([optionValue]);
+  };
+
+  const isSelected = (optionValue: string): boolean => {
+    return $value.includes(optionValue);
+  };
+</script>
+
+<div class={`toggler ${className || ""}`} role="group">
+  {#each options as option (option.value)}
+    <ToggleTag
+      label={option.label}
+      onclick={() =>
+        type === "combo"
+          ? handleComboChange(option.value)
+          : handleRadioChange(option.value)}
+      isPressed={isSelected(option.value)}
+    >
+      {#if option.content}
+        {@render option.content()}
+      {:else}
+        {option.label}
+      {/if}
+    </ToggleTag>
+  {/each}
+</div>
+
+<style>
+  .toggler {
+    display: flex;
+    justify-content: center;
+    gap: var(--gap-xxs);
+
+    /* To visually align the buttons better with the header */
+    padding-top: var(--ni-2);
+  }
+</style>

--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -1,40 +1,39 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   import ToggleTag from "$lib/sections/components/ToggleTag.svelte";
-  import type { Writable } from "svelte/store";
   import type { ToggleOption } from "./ToggleOption.ts";
 
   interface TogglerProps {
     type: "combo" | "radio";
-    value: Writable<string[]>;
-    options: ToggleOption[];
+    value: T[];
+    onChange: (value: T[]) => void;
+    options: ToggleOption<T>[];
     class?: string;
   }
 
-  const { type, value, options, class: className }: TogglerProps = $props();
+  const { type, value, onChange, options }: TogglerProps = $props();
 
   const allValues = $derived(options.map((option) => option.value));
 
-  const handleComboChange = (optionValue: string) => {
-    const currentValues = $value;
-    const isCurrentlySelected = currentValues.includes(optionValue);
+  const handleComboChange = (optionValue: T) => {
+    const isCurrentlySelected = value.includes(optionValue);
 
     const newValues = isCurrentlySelected
-      ? currentValues.filter((v) => v !== optionValue)
-      : [...currentValues, optionValue];
+      ? value.filter((v) => v !== optionValue)
+      : [...value, optionValue];
 
-    value.set(newValues.length > 0 ? newValues : allValues);
+    onChange(newValues.length > 0 ? newValues : allValues);
   };
 
-  const handleRadioChange = (optionValue: string) => {
-    value.set([optionValue]);
+  const handleRadioChange = (optionValue: T) => {
+    onChange([optionValue]);
   };
 
-  const isSelected = (optionValue: string): boolean => {
-    return $value.includes(optionValue);
+  const isSelected = (optionValue: T): boolean => {
+    return value.includes(optionValue);
   };
 </script>
 
-<div class={`toggler ${className || ""}`} role="group">
+<div class="trakt-toggler" role="group">
   {#each options as option (option.value)}
     <ToggleTag
       label={option.label}
@@ -47,14 +46,14 @@
       {#if option.content}
         {@render option.content()}
       {:else}
-        {option.label}
+        {option.text}
       {/if}
     </ToggleTag>
   {/each}
 </div>
 
 <style>
-  .toggler {
+  .trakt-toggler {
     display: flex;
     justify-content: center;
     gap: var(--gap-xxs);

--- a/projects/client/src/lib/sections/lists/activity/ActivityList.svelte
+++ b/projects/client/src/lib/sections/lists/activity/ActivityList.svelte
@@ -6,6 +6,7 @@
   import { writable } from "svelte/store";
   import CtaItem from "../components/cta/CtaItem.svelte";
 
+  import { assertDefined } from "$lib/utils/assert/assertDefined.ts";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import RecentlyWatchedItem from "../history/RecentlyWatchedItem.svelte";
   import ActivityToggle from "./_internal/ActivityToggle.svelte";
@@ -15,10 +16,11 @@
 
   /** once we have a proper social hub we should encourage people to find other users to follow, aka: empty placeholder */
 
-  const selectedType = writable<ActivityType>("social");
+  const selectedType = writable<[ActivityType]>(["social"]);
+  const activityType = $derived(assertDefined($selectedType.at(0)));
 
   const urlBuilder = $derived(
-    $selectedType === "social"
+    activityType === "social"
       ? UrlBuilder.social.activity
       : UrlBuilder.history.all,
   );
@@ -33,8 +35,7 @@
 <DrillableMediaList
   id={`${$selectedType}-activity-list`}
   type="episode"
-  useList={(params) =>
-    useActivityList({ ...params, activityType: $selectedType })}
+  useList={(params) => useActivityList({ ...params, activityType })}
   {urlBuilder}
   drilldownLabel={m.button_label_view_all_social_activity()}
   title={m.list_title_activity()}

--- a/projects/client/src/lib/sections/lists/activity/ActivityList.svelte
+++ b/projects/client/src/lib/sections/lists/activity/ActivityList.svelte
@@ -16,7 +16,9 @@
 
   /** once we have a proper social hub we should encourage people to find other users to follow, aka: empty placeholder */
 
-  const selectedType = writable<[ActivityType]>(["social"]);
+  const selectedType = writable<ActivityType[]>(["social"]);
+  const handleTypeChange = (value: ActivityType[]) => selectedType.set(value);
+
   const activityType = $derived(assertDefined($selectedType.at(0)));
 
   const urlBuilder = $derived(
@@ -26,7 +28,7 @@
   );
 
   const cta = $derived(
-    $selectedType === "social" ? "activity" : "personal-activity",
+    activityType === "social" ? "activity" : "personal-activity",
   );
   // FIXME: coalesce on list level & combine drilled down versions
 </script>
@@ -58,7 +60,7 @@
         <CtaItem {cta} variant="placeholder" />
       {/snippet}
 
-      {#if $selectedType === "social"}
+      {#if activityType === "social"}
         {m.list_placeholder_activity_social_empty()}
       {:else}
         {m.list_placeholder_activity_personal_empty()}
@@ -67,6 +69,6 @@
   {/snippet}
 
   {#snippet badge()}
-    <ActivityToggle type={selectedType} />
+    <ActivityToggle value={$selectedType} onChange={handleTypeChange} />
   {/snippet}
 </DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/activity/_internal/ActivityToggle.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/ActivityToggle.svelte
@@ -1,35 +1,33 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
-  import ToggleTag from "$lib/sections/components/ToggleTag.svelte";
+
+  import type { ToggleOption } from "$lib/components/toggles/ToggleOption";
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { type Writable } from "svelte/store";
   import type { ActivityType } from "../models/ActivityType";
 
   type ActivityToggleProps = {
-    type: Writable<ActivityType>;
+    type: Writable<[ActivityType]>;
   };
 
   const { type }: ActivityToggleProps = $props();
+
+  const options: ToggleOption[] = [
+    {
+      value: "social",
+      label: m.button_text_social(),
+    },
+    {
+      value: "personal",
+      label: m.button_text_personal(),
+    },
+  ];
 </script>
 
-<div class="watchlist-type-toggles" role="group">
-  <ToggleTag
-    label={m.button_label_social()}
-    onclick={() => type.set("social")}
-    isPressed={$type === "social"}
-  >
-    {m.button_text_social()}
-  </ToggleTag>
-  <ToggleTag
-    label={m.button_label_personal()}
-    onclick={() => type.set("personal")}
-    isPressed={$type === "personal"}
-  >
-    {m.button_text_personal()}
-  </ToggleTag>
-</div>
+<Toggler type="radio" value={type} {options} class="activity-type-toggles" />
 
 <style>
-  .watchlist-type-toggles {
+  :global(.activity-type-toggles) {
     display: flex;
     justify-content: center;
     gap: var(--gap-xxs);

--- a/projects/client/src/lib/sections/lists/activity/_internal/ActivityToggle.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/ActivityToggle.svelte
@@ -3,36 +3,27 @@
 
   import type { ToggleOption } from "$lib/components/toggles/ToggleOption";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
-  import { type Writable } from "svelte/store";
   import type { ActivityType } from "../models/ActivityType";
 
   type ActivityToggleProps = {
-    type: Writable<[ActivityType]>;
+    value: ActivityType[];
+    onChange: (value: ActivityType[]) => void;
   };
 
-  const { type }: ActivityToggleProps = $props();
+  const { value, onChange }: ActivityToggleProps = $props();
 
-  const options: ToggleOption[] = [
+  const options: ToggleOption<ActivityType>[] = [
     {
       value: "social",
-      label: m.button_text_social(),
+      text: m.button_text_social(),
+      label: m.button_label_social(),
     },
     {
       value: "personal",
-      label: m.button_text_personal(),
+      text: m.button_text_personal(),
+      label: m.button_label_personal(),
     },
   ];
 </script>
 
-<Toggler type="radio" value={type} {options} class="activity-type-toggles" />
-
-<style>
-  :global(.activity-type-toggles) {
-    display: flex;
-    justify-content: center;
-    gap: var(--gap-xxs);
-
-    /* To visually align the buttons better with the header */
-    padding-top: var(--ni-2);
-  }
-</style>
+<Toggler type="radio" {value} {onChange} {options} />

--- a/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
@@ -32,6 +32,7 @@
   const selectedTypes = writable<MediaType[]>(
     defaultType ? [defaultType] : ["movie", "show"],
   );
+  const handleTypeChange = (value: MediaType[]) => selectedTypes.set(value);
 
   const type = $derived(
     $selectedTypes.length === 1 ? $selectedTypes.at(0) : undefined,
@@ -88,7 +89,7 @@
 
   {#snippet badge()}
     {#if status === "all"}
-      <TypeToggles types={selectedTypes} />
+      <TypeToggles value={$selectedTypes} onChange={handleTypeChange} />
     {/if}
 
     {#if status === "unreleased" || status === "released"}

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -28,6 +28,7 @@
   const selectedTypes = writable<MediaType[]>(
     type ? [type] : ["movie", "show"],
   );
+  const handleTypeChange = (value: MediaType[]) => selectedTypes.set(value);
 
   onMount(() => {
     if (!onTypeChange) {
@@ -59,7 +60,7 @@
 
   {#snippet badge()}
     {#if status === "all" && onTypeChange}
-      <TypeToggles types={selectedTypes} />
+      <TypeToggles value={$selectedTypes} onChange={handleTypeChange} />
     {/if}
 
     {#if status === "unreleased" || status === "released"}

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/TypeToggles.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/TypeToggles.svelte
@@ -4,35 +4,26 @@
   import * as m from "$lib/features/i18n/messages.ts";
 
   import type { MediaType } from "$lib/requests/models/MediaType";
-  import { type Writable } from "svelte/store";
 
   type TypeTogglesProps = {
-    types: Writable<MediaType[]>;
+    value: MediaType[];
+    onChange: (value: MediaType[]) => void;
   };
 
-  const { types }: TypeTogglesProps = $props();
+  const { value, onChange }: TypeTogglesProps = $props();
 
-  const options: ToggleOption[] = [
+  const options: ToggleOption<MediaType>[] = [
     {
       value: "movie",
-      label: m.button_text_movies(),
+      text: m.button_text_movies(),
+      label: m.button_label_movies(),
     },
     {
       value: "show",
-      label: m.button_text_shows(),
+      text: m.button_text_shows(),
+      label: m.button_label_shows(),
     },
   ];
 </script>
 
-<Toggler type="combo" value={types} {options} class="watchlist-type-toggles" />
-
-<style>
-  :global(.watchlist-type-toggles) {
-    display: flex;
-    justify-content: center;
-    gap: var(--gap-xxs);
-
-    /* To visually align the buttons better with the header */
-    padding-top: var(--ni-2);
-  }
-</style>
+<Toggler type="combo" {value} {onChange} {options} />

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/TypeToggles.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/TypeToggles.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import type { ToggleOption } from "$lib/components/toggles/ToggleOption";
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+
   import type { MediaType } from "$lib/requests/models/MediaType";
-  import ToggleTag from "$lib/sections/components/ToggleTag.svelte";
   import { type Writable } from "svelte/store";
 
   type TypeTogglesProps = {
@@ -10,37 +12,22 @@
 
   const { types }: TypeTogglesProps = $props();
 
-  const handleTypeChange = (newType: MediaType) => {
-    types.update((types) => {
-      if (types.includes(newType)) {
-        const newTypes = types.filter((type) => type !== newType);
-        return newTypes.length > 0 ? newTypes : ["movie", "show"];
-      }
-
-      return [...types, newType];
-    });
-  };
+  const options: ToggleOption[] = [
+    {
+      value: "movie",
+      label: m.button_text_movies(),
+    },
+    {
+      value: "show",
+      label: m.button_text_shows(),
+    },
+  ];
 </script>
 
-<div class="watchlist-type-toggles" role="group">
-  <ToggleTag
-    label={m.button_label_movies()}
-    onclick={() => handleTypeChange("movie")}
-    isPressed={$types.includes("movie")}
-  >
-    {m.button_text_movies()}
-  </ToggleTag>
-  <ToggleTag
-    label={m.button_label_shows()}
-    onclick={() => handleTypeChange("show")}
-    isPressed={$types.includes("show")}
-  >
-    {m.button_text_shows()}
-  </ToggleTag>
-</div>
+<Toggler type="combo" value={types} {options} class="watchlist-type-toggles" />
 
 <style>
-  .watchlist-type-toggles {
+  :global(.watchlist-type-toggles) {
     display: flex;
     justify-content: center;
     gap: var(--gap-xxs);


### PR DESCRIPTION
Refactors the toggle components to be more generic and reusable.

- Introduces a new `Toggler` component that handles both combo and radio button toggle types.
- Creates a `ToggleOption` interface to define the structure of toggle options.
- Replaces the specific toggle implementations in the activity list and watchlist with the new `Toggler` component.