### PR TITLE
fix(i18n): ensures 'values' is used for en locale

### DIFF
--- a/projects/client/i18n/generator/core/I18nGenerator.spec.ts
+++ b/projects/client/i18n/generator/core/I18nGenerator.spec.ts
@@ -51,7 +51,6 @@ describe('I18nGenerator', () => {
           variables: {
             name: {
               type: 'string',
-              description: 'User display name',
             },
           },
         },
@@ -61,7 +60,6 @@ describe('I18nGenerator', () => {
           variables: {
             count: {
               type: 'number',
-              description: 'Number of items',
             },
           },
         },
@@ -91,11 +89,9 @@ describe('I18nGenerator', () => {
           variables: {
             userName: {
               type: 'string',
-              description: 'The user name',
             },
             count: {
               type: 'number',
-              description: 'Message count',
             },
           },
         },
@@ -343,7 +339,7 @@ describe('I18nGenerator', () => {
       const androidPath = path.join(
         tempDir,
         'android',
-        'values-en',
+        'values',
         'strings.xml',
       );
       expect(await fs.promises.access(androidPath)).toBeUndefined();
@@ -373,7 +369,7 @@ describe('I18nGenerator', () => {
       expect(inlangExists).toBe(true);
 
       const androidExists = await fs.promises.access(
-        path.join(tempDir, 'android', 'values-en', 'strings.xml'),
+        path.join(tempDir, 'android', 'values', 'strings.xml'),
       )
         .then(() => true)
         .catch(() => false);
@@ -452,7 +448,6 @@ describe('I18nGenerator', () => {
             variables: {
               value: {
                 type: 'string',
-                description: 'Test value',
               },
             },
           },

--- a/projects/client/i18n/generator/utils/generateAndroidResourceFolder.spec.ts
+++ b/projects/client/i18n/generator/utils/generateAndroidResourceFolder.spec.ts
@@ -33,7 +33,7 @@ describe('generateAndroidResourceFolder', () => {
   });
 
   it('should handle pure language codes correctly', () => {
-    expect(generateAndroidResourceFolder('en', ['en', 'fr'])).toBe('values-en');
+    expect(generateAndroidResourceFolder('en', ['en', 'fr'])).toBe('values');
     expect(generateAndroidResourceFolder('fr', ['en', 'fr'])).toBe('values-fr');
   });
 

--- a/projects/client/i18n/generator/utils/generateAndroidResourceFolder.ts
+++ b/projects/client/i18n/generator/utils/generateAndroidResourceFolder.ts
@@ -7,6 +7,11 @@ export function generateAndroidResourceFolder(
   locale: string,
   allLocales: string[],
 ): string {
+  if (locale === 'en') {
+    // Special case for English, always use values
+    return 'values';
+  }
+
   const normalizedLocale = locale.toLowerCase();
 
   // Extract language code (first part before hyphen)


### PR DESCRIPTION
Forces the use of the 'values' resource folder for the English
locale, regardless of regional variations. This simplifies
resource management for the default language.
