### PR TITLE
feat(i18n): sync Android strings with EN source

### DIFF
--- a/projects/client/i18n/generator/utils/escapeXml.ts
+++ b/projects/client/i18n/generator/utils/escapeXml.ts
@@ -8,5 +8,6 @@ export function escapeXml(text: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+    .replace(/'/g, '&apos;')
+    .replace(/\.{3}/g, '…');
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -670,7 +670,6 @@
       "default": "Get VIP",
       "description": "Text for the VIP upsell badge. This is shown in a badge and should be as short as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2120,7 +2120,6 @@
       "default": "View All",
       "description": "Text for the button that allows users to drill down on lists to view all items in it.",
       "exclude": [
-        "android",
         "ios"
       ]
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -24,7 +24,6 @@
       "default": "Upcoming Schedule",
       "description": "Title for lists containing upcoming episodes. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -85,7 +84,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -93,7 +91,6 @@
       "default": "Continue Watching",
       "description": "Title for lists containing the next episodes and in progress movies. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -106,7 +103,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -135,7 +131,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -175,7 +170,6 @@
       "default": "Watchlist",
       "description": "Text for the button that allows users to add/remove a movie or show to/from their watchlist.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -183,7 +177,6 @@
       "default": "Mark as Watched",
       "description": "Text for the button that allows users to mark a movie, episode, or show as watched.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -199,7 +192,6 @@
       "default": "Watch again",
       "description": "Text for the button that allows users to mark a movie, episode, or show as re-watched.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -555,7 +547,6 @@
       "default": "Search shows & movies...",
       "description": "Placeholder text for the search input field. This should be a short and concise message that indicates what users can search for.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -563,7 +554,6 @@
       "default": "Join Trakt",
       "description": "Text for the Trakt login button. This should be a short and concise message that indicates what users can do.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -651,7 +641,6 @@
       "default": "Trending",
       "description": "Title for lists containing trending movies or shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -659,7 +648,6 @@
       "default": "Recommended",
       "description": "Title for lists containing recommended movies or shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -667,7 +655,6 @@
       "default": "Anticipated",
       "description": "Title for lists containing anticipated movies or shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -715,7 +702,6 @@
       "default": "Popular",
       "description": "Title for lists containing popular movies or shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -739,7 +725,6 @@
       "default": "Movies",
       "description": "Title for the movies page.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -763,7 +748,6 @@
       "default": "Shows",
       "description": "Title for the shows page.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -787,7 +771,6 @@
       "default": "Home",
       "description": "Title for the homepage.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -808,7 +791,6 @@
       "default": "Log out of Trakt",
       "description": "Text for the logout button.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -824,7 +806,6 @@
       "default": "Coming Soon",
       "description": "Title for lists containing watchlisted movies that are coming soon. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -840,7 +821,6 @@
       "default": "Related Movies",
       "description": "Title for lists containing related movies. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -848,7 +828,6 @@
       "default": "Related Shows",
       "description": "Title for lists containing related shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -1188,24 +1167,23 @@
       "default": "Lists",
       "description": "Title for the lists page.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
     "list_title_watchlist_shows": {
-      "default": "Your Shows",
+      "default": "Shows Watchlist",
       "description": "Title for lists containing shows in the user's watchlist. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "ios",
+        "web"
       ]
     },
     "list_title_watchlist_movies": {
-      "default": "Your Movies",
+      "default": "Movies Watchlist",
       "description": "Title for lists containing movies in the user's watchlist. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "ios",
+        "web"
       ]
     },
     "button_label_stream_on": {
@@ -1906,7 +1884,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -1914,7 +1891,6 @@
       "default": "Seasons",
       "description": "Title for lists containing seasons of a show. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -1927,7 +1903,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -1935,7 +1910,6 @@
       "default": "Specials",
       "description": "Text for the specials season of a show. This should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -1964,7 +1938,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2110,7 +2083,6 @@
       "default": "Actors",
       "description": "Title for lists containing actors of a movie, show, or episode. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2134,7 +2106,6 @@
       "default": "Trending Shows",
       "description": "Title for lists containing trending shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2142,7 +2113,6 @@
       "default": "Trending Movies",
       "description": "Title for lists containing trending movies. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2322,7 +2292,6 @@
       "default": "Favorite Movies",
       "description": "Title for lists containing a user's favorite movies. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2330,7 +2299,6 @@
       "default": "Favorite Shows",
       "description": "Title for lists containing a user's favorite shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2354,7 +2322,6 @@
       "default": "Stream on",
       "description": "Text for the button that allows users to stream a movie or show on an external service.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2396,10 +2363,9 @@
       ]
     },
     "list_title_popular_lists": {
-      "default": "Popular lists",
+      "default": "Popular Lists",
       "description": "Title for lists containing popular lists of movies or shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2420,7 +2386,6 @@
       "default": "by",
       "description": "Text used to indicate the creator of a list.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2454,7 +2419,6 @@
       "default": "No comments yet.",
       "description": "Placeholder text shown when there are no comments in a list.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2462,7 +2426,6 @@
       "default": "Review by",
       "description": "Text used to indicate the author of a review.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2470,8 +2433,15 @@
       "default": "Shout by",
       "description": "Text used to indicate the author of a shout.",
       "exclude": [
-        "android",
         "ios"
+      ]
+    },
+    "text_reply_by": {
+      "default": "Reply by",
+      "description": "Text used to indicate the author of a reply to a comment.",
+      "exclude": [
+        "ios",
+        "web"
       ]
     },
     "text_deleted_username": {
@@ -2622,7 +2592,6 @@
       "default": "Personal",
       "description": "Title for lists containing the user's personal lists. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2720,7 +2689,6 @@
       "default": "Recently Watched",
       "description": "Title for lists containing recently watched movies or episodes. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2736,7 +2704,6 @@
       "default": "Available Now",
       "description": "Title for lists containing watchlisted movies that are currently available to watch. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2865,7 +2832,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2905,7 +2871,6 @@
       "default": "Watch count",
       "description": "Text for the tag that is shown before the movie or show watch count. This should be as short as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2947,7 +2912,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2976,7 +2940,6 @@
         }
       },
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -2984,7 +2947,6 @@
       "default": "Comments",
       "description": "Title for lists containing comments on a movie, show, or episode. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -3196,7 +3158,6 @@
       "default": "Retry",
       "description": "Text for the retry button. Used for things like error pages and failed authentications.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -3390,7 +3351,6 @@
       "default": "The activation was denied, expired, or something unforeseeable happened. Please try again.",
       "description": "Header for the device authentication try again message.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -3398,7 +3358,6 @@
       "default": "Scan the QR code, or sign in at:",
       "description": "Header for the device authentication QR code instruction message.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -3406,7 +3365,6 @@
       "default": "and enter the following code:",
       "description": "Header for the device authentication code instruction message.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -3913,7 +3871,6 @@
       "default": "Extras",
       "description": "Title for lists containing extras (like trailers) for movies or shows. This title should be as short and concise as possible.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -4046,7 +4003,6 @@
       "default": "Search",
       "description": "Title for the search page.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -4112,7 +4068,6 @@
       "default": "View profile",
       "description": "Text for the link that allows users to view their profile.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -5082,7 +5037,6 @@
       "default": "Something went wrong",
       "description": "Title for the unexpected error page.",
       "exclude": [
-        "android",
         "ios"
       ]
     },
@@ -5100,6 +5054,182 @@
       "exclude": [
         "android",
         "ios"
+      ]
+    },
+    "error_text_unexpected_error_short": {
+      "default": "Uh oh… Something unexpected happened. If this keeps happening, please contact Trakt support.",
+      "description": "Short text shown on the unexpected error page, informing the user that something went wrong.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "page_title_where_to_watch": {
+      "default": "Where to Watch",
+      "description": "Title for the all available streaming services page where user can see where to watch movie/show.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_streaming_subscription": {
+      "default": "Subscription",
+      "description": "Text used to indicate the list of all streaming services where media is available to watch in subscription model.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_streaming_free": {
+      "default": "Free",
+      "description": "Text used to indicate the list of all streaming services where media is available to watch for free.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_streaming_purchase": {
+      "default": "Purchase",
+      "description": "Text used to indicate the list of all streaming services where media is available to watch for one time purchase.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_streaming_rent": {
+      "default": "Rent",
+      "description": "Text used to indicate the list of all streaming services where media is available to rent.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_streaming_favorite": {
+      "default": "Favorite",
+      "description": "Text used to indicate the list of all favorite streaming services of a user.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_recently_searched_shows": {
+      "default": "Recently Searched Shows",
+      "description": "Text used to indicate the list of recently searched shows.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_title_recently_searched_movies": {
+      "default": "Recently Searched Movies",
+      "description": "Text used to indicate the list of recently searched movies.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_overview_placeholder": {
+      "default": "Overview is not available.",
+      "description": "Placeholder text shown when there is no description available for show/movie/episode.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_info_signed_in": {
+      "default": "You have been signed in.",
+      "description": "Text shown when a user has successfully signed in.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_info_signed_out": {
+      "default": "You have been signed out.",
+      "description": "Text shown when a user has successfully signed out.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_info_history_added": {
+      "default": "Added to watched history.",
+      "description": "Text shown when a user has added a media item to their watched history.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_info_history_removed": {
+      "default": "Removed from watched history.",
+      "description": "Text shown when a user has removed a media item from their watched history.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_info_watchlist_added": {
+      "default": "Added to watchlist.",
+      "description": "Text shown when a user has added a media item to their watchlist.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "text_info_watchlist_removed": {
+      "default": "Removed from watchlist.",
+      "description": "Text shown when a user has removed a media item from their watchlist.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "button_text_long_press_for_more": {
+      "default": "Long press for more",
+      "description": "Text shown when a user can long press on a button to see more options.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "list_placeholder_empty": {
+      "default": "There is nothing in this list.",
+      "description": "Placeholder text shown when there are no movies or shows in the user's watchlist.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "button_text_yes": {
+      "default": "Yes",
+      "description": "Text for confirming an action in confirmation dialogs.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "button_text_cancel": {
+      "default": "Cancel",
+      "description": "Text for cancelling an action in confirmation dialogs.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "button_text_where_to_watch": {
+      "default": "Where to watch",
+      "description": "Text for the button that opens the where to watch page for a movie or show.",
+      "exclude": [
+        "ios",
+        "web"
+      ]
+    },
+    "button_text_no_services": {
+      "default": "No services",
+      "description": "Text for the button that indicates there are no streaming services available for a movie or show.",
+      "exclude": [
+        "ios",
+        "web"
       ]
     }
   }


### PR DESCRIPTION
- enable required strings already present
- add some new ones to fill the gaps
- use ellipsis symbol instead of 3 dots
