### PR TITLE
fix(list): do not rerender list items  after rename

### DIFF
--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -7,7 +7,7 @@
   import { mapToMediaType } from "./_internal/mapToMediaType";
   import { userListSummary } from "./userListSummary.ts";
 
-  const { list, isLoading } = $derived(
+  const { list } = $derived(
     userListSummary({
       userId: page.params.user,
       listId: page.params.list,
@@ -26,7 +26,7 @@
 >
   <TraktPageCoverSetter />
 
-  {#if !$isLoading}
-    <UserListPaginatedList title={listName} list={$list!} {type} />
+  {#if $list}
+    <UserListPaginatedList title={listName} list={$list} {type} />
   {/if}
 </TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Do not rerender list items after renaming.
- The list items were being rerendered since it depended on the loading state of the list summary 🤦

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/2e99091b-91a5-4c9a-a846-0b0b0bb1c50f


After:

https://github.com/user-attachments/assets/45e9186b-0cc9-40a1-86e6-713be9a546f4

