### PR TITLE
fix: do not use navigation outside component initialisation

### DIFF
--- a/projects/client/src/lib/utils/actions/mobileAppleDeviceTriggerHack.ts
+++ b/projects/client/src/lib/utils/actions/mobileAppleDeviceTriggerHack.ts
@@ -1,4 +1,3 @@
-import { afterNavigate } from '$app/navigation';
 import { NOOP_FN } from '../constants.ts';
 import { getMobileAppleDeviceType } from '../devices/getMobileAppleDeviceType.ts';
 
@@ -14,19 +13,14 @@ export function isMobileAppleDevice() {
  * This utility ensures that a click event is triggered when a touch event ends,
  * providing a consistent user experience across different devices.
  */
-export function mobileAppleDeviceTriggerHack(
-  node: HTMLAnchorElement,
-  enabled = true,
-) {
-  // TODO(@seferturan): investigate why we need to disable for search items
-  // relates to https://github.com/trakt/trakt-web/issues/291
-  if (!enabled || !isMobileAppleDevice()) {
+export function mobileAppleDeviceTriggerHack(node: HTMLAnchorElement) {
+  if (!isMobileAppleDevice()) {
     return {
       destroy: NOOP_FN,
     };
   }
 
-  const handleTouchEnd = async (event: PointerEvent) => {
+  const handleTouchEnd = (event: PointerEvent) => {
     const isMouse = event.pointerType === 'mouse';
 
     if (isMouse) {
@@ -38,20 +32,9 @@ export function mobileAppleDeviceTriggerHack(
       return;
     }
 
-    const navigationCheck = () =>
-      new Promise<boolean>((resolve) => {
-        afterNavigate(() => resolve(true));
-        // If no navigation occurs within a frame, resolve with false
-        requestAnimationFrame(() => resolve(false));
-      });
-
-    const didNavigate = await navigationCheck();
-
-    if (!didNavigate) {
-      event.preventDefault();
-      event.stopPropagation();
-      event.target.click();
-    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.target.click();
   };
 
   node.addEventListener('pointerup', handleTouchEnd);


### PR DESCRIPTION
## 🎶 Notes 🎶

- This navigation check hasn't worked in a while, it's been throwing lifecyle errors. Reverting it since the original issue it was supposed to fix no longer is applicable: https://github.com/trakt/trakt-web/issues/291
- If we ever do cards in a popup like that again, we can use usePortal nowadays adds an underlay; which adds an underlay you can't click through.
- I did play around a bit with beforeNavigate and afterNavigate outside of the handler; they're never called before the requestAnimationFrame.