### PR TITLE
fix / marker parameter to Trakt API requests

### DIFF
--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -3,6 +3,7 @@ import { getToken } from '$lib/features/auth/token/index.ts';
 import { error } from '$lib/utils/console/print.ts';
 import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';
 import { getUserManager } from '../../features/auth/stores/userManager.ts';
+import { getMarker } from '../../utils/date/Marker.ts';
 
 const SESSION_STORAGE_REFRESH_KEY = 'trakt:is_refreshing';
 
@@ -46,6 +47,16 @@ export function createAuthenticatedFetch<
             stripHttpsOrHttp(TRAKT_TARGET_ENVIRONMENT),
             stripHttpsOrHttp(TRAKT_TARGET_API_ENVIRONMENT),
           );
+      }
+
+      const method = init?.method?.toUpperCase();
+      const marker = getMarker();
+
+      if (method === 'GET' && marker != null) {
+        const [path, queryString] = input.toString().split('?');
+        const params = new URLSearchParams(queryString || '');
+        params.set('marker', marker.toString());
+        input = `${path}?${params.toString()}`;
       }
 
       return baseFetch(

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -7,7 +7,6 @@ import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
-import { getMarker } from '../../../utils/date/Marker.ts';
 import { EpisodeEntrySchema } from '../../models/EpisodeEntry.ts';
 
 export type CalendarShowsParams = {
@@ -28,9 +27,6 @@ const upcomingEpisodesRequest = (
     .shows({
       query: {
         extended: 'full,images',
-        ...{
-          marker: getMarker(),
-        },
       },
       params: {
         target: 'my',

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -13,7 +13,6 @@ import { addYear } from '$lib/utils/date/addYear.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { MovieAnticipatedResponse } from '@trakt/api';
 import { z } from 'zod';
-import { getMarker } from '../../../utils/date/Marker.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 
 export const AnticipatedMovieSchema = MovieEntrySchema.extend({
@@ -49,9 +48,6 @@ const movieAnticipatedRequest = (
         limit,
         ...filter,
         ...search,
-        ...{
-          marker: getMarker(),
-        },
         end_date: addYear(new Date()).toISOString(),
       },
     });

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -11,7 +11,6 @@ import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { getMarker } from '../../../utils/date/Marker.ts';
 
 type MoviePopularParams =
   & PaginationParams
@@ -31,9 +30,6 @@ const moviePopularRequest = (
         limit,
         ...filter,
         ...search,
-        ...{
-          marker: getMarker(),
-        },
       },
     });
 

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -10,7 +10,6 @@ import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { MovieTrendingResponse } from '@trakt/api';
 import { z } from 'zod';
-import { getMarker } from '../../../utils/date/Marker.ts';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 import { getRecordDependencies } from '../../_internal/getRecordDependencies.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
@@ -48,9 +47,6 @@ const movieTrendingRequest = (
         limit,
         ...filter,
         ...search,
-        ...{
-          marker: getMarker(),
-        },
       },
     });
 

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -14,7 +14,6 @@ import { addYear } from '$lib/utils/date/addYear.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { ShowAnticipatedResponse } from '@trakt/api';
 import { z } from 'zod';
-import { getMarker } from '../../../utils/date/Marker.ts';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
 
 export const AnticipatedShowSchema = ShowEntrySchema
@@ -58,9 +57,6 @@ const showAnticipatedRequest = (
         limit,
         ...filter,
         ...search,
-        ...{
-          marker: getMarker(),
-        },
         end_date: addYear(new Date()).toISOString(),
       },
     });

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -13,7 +13,6 @@ import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { ShowResponse } from '@trakt/api';
 import { z } from 'zod';
-import { getMarker } from '../../../utils/date/Marker.ts';
 import { getRecordDependencies } from '../../_internal/getRecordDependencies.ts';
 
 export const PopularShowSchema = ShowEntrySchema.merge(
@@ -51,9 +50,6 @@ const showPopularRequest = (
         limit,
         ...filter,
         ...search,
-        ...{
-          marker: getMarker(),
-        },
       },
     });
 

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -10,7 +10,6 @@ import {
 } from '$lib/requests/models/EpisodeType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { MAX_DATE } from '$lib/utils/constants.ts';
-import { getMarker } from '$lib/utils/date/Marker.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
@@ -30,9 +29,6 @@ const showProgressRequest = (
         hidden: false,
         extended: 'full,images',
         include_stats: true,
-        ...{
-          marker: getMarker(),
-        },
       },
       params: {
         id: slug,

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -9,7 +9,6 @@ import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts'
 import { time } from '$lib/utils/timing/time.ts';
 import type { ShowTrendingResponse } from '@trakt/api';
 import { z } from 'zod';
-import { getMarker } from '../../../utils/date/Marker.ts';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 import { getRecordDependencies } from '../../_internal/getRecordDependencies.ts';
 import { mapToEpisodeCount } from '../../_internal/mapToEpisodeCount.ts';
@@ -53,9 +52,6 @@ const showTrendingRequest = (
         limit,
         ...filter,
         ...search,
-        ...{
-          marker: getMarker(),
-        },
       },
     });
 };

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -7,7 +7,6 @@ import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { mapUpNextResponse } from '$lib/requests/queries/sync/upNextQuery.ts';
-import { getMarker } from '$lib/utils/date/Marker.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
@@ -30,9 +29,6 @@ const upNextNitroRequest = (params: UpNextParams) => {
       query: {
         page,
         limit,
-        ...{
-          marker: getMarker(),
-        },
       },
     });
 };

--- a/projects/client/src/lib/requests/queries/users/dropShowRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/dropShowRequest.ts
@@ -1,5 +1,6 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { HiddenMediaRequest } from '@trakt/api';
+import { setMarker } from '../../../utils/date/Marker.ts';
 
 type DropShowRequest = {
   body: HiddenMediaRequest;
@@ -17,5 +18,9 @@ export function dropShowRequest(
       },
       body,
     })
-    .then(({ status }) => status === 200);
+    .then(({ status }) => {
+      setMarker();
+
+      return status === 200;
+    });
 }

--- a/projects/client/src/lib/requests/sync/removeFromWatchlistRequest.ts
+++ b/projects/client/src/lib/requests/sync/removeFromWatchlistRequest.ts
@@ -1,5 +1,6 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { WatchlistRequest } from '@trakt/api';
+import { setMarker } from '../../utils/date/Marker.ts';
 
 type RemoveFromWatchlistParams = {
   body: WatchlistRequest;
@@ -14,5 +15,9 @@ export function removeFromWatchlistRequest(
     .remove({
       body,
     })
-    .then(({ status }) => status === 200);
+    .then(({ status }) => {
+      setMarker();
+
+      return status === 200;
+    });
 }

--- a/projects/client/src/lib/requests/sync/removeWatchedRequest.ts
+++ b/projects/client/src/lib/requests/sync/removeWatchedRequest.ts
@@ -1,5 +1,6 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { HistoryRemoveRequest } from '@trakt/api';
+import { setMarker } from '../../utils/date/Marker.ts';
 
 type RemoveWatchedParams = {
   body: HistoryRemoveRequest;
@@ -14,5 +15,9 @@ export function removeWatchedRequest(
     .remove({
       body,
     })
-    .then(({ status }) => status === 200);
+    .then(({ status }) => {
+      setMarker();
+
+      return status === 200;
+    });
 }


### PR DESCRIPTION
This change ensures that all Trakt API requests include a `marker` parameter.

- This resolves an issue where the `marker` was missing in some API calls, potentially affecting data consistency.
- The `marker` parameter is now consistently added to all relevant requests.
- Removes the previous interceptor implementation to improve efficiency and reduce redundancy.