### PR TITLE
chore(landing): add a blur to the step shadows

### DIFF
--- a/projects/client/src/lib/sections/landing/v2/components/Step.svelte
+++ b/projects/client/src/lib/sections/landing/v2/components/Step.svelte
@@ -51,6 +51,7 @@
     position: absolute;
 
     opacity: 0.35;
+    filter: blur(var(--ni-4));
 
     z-index: var(--layer-background);
 


### PR DESCRIPTION
## ♪ Note ♪

- Adds a blur to the step shadows on the new landing page.

## 👀 Example 👀
Before / after
<img width="374" height="665" alt="Screenshot 2025-08-26 at 11 06 26" src="https://github.com/user-attachments/assets/a5fe1323-afd2-4814-b0e8-7b5d1dbf8f13" /> <img width="374" height="665" alt="Screenshot 2025-08-26 at 11 07 43" src="https://github.com/user-attachments/assets/d1f1fae2-a094-4b78-9e72-456389a71578" />
