### PR TITLE
fix(dropdown): open at correct location

### DIFF
--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -243,6 +243,7 @@
     --list-padding: var(--ni-12);
     @include transform-position(var(--list-padding));
 
+    position: absolute;
     width: max(var(--button-width), var(--ni-180));
     padding: var(--list-padding);
 


### PR DESCRIPTION
## ♪ Note ♪

- Open dropdown at correct location

## 👀 Examples 👀

Before:

https://github.com/user-attachments/assets/a6ae5e29-aa06-4098-a5fa-0d8553e5087e

After:

https://github.com/user-attachments/assets/f6638a6f-f5bd-40dd-ab87-c62daaee6e14

Before:

https://github.com/user-attachments/assets/970006a5-538f-4ab1-a935-a7722bf62d29

After:

https://github.com/user-attachments/assets/fd311cd4-4159-4318-94f6-1d54650dbbf6


