### PR TITLE
Reverts to using version range for Deno version

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -5,7 +5,7 @@ inputs:
   deno-version:
     description: 'Deno version to install'
     required: false
-    default: 'v2.3.3'
+    default: 'v2.x'
 
 runs:
   using: composite

--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,7 @@
     "broadcast-channel",
     "sloppy-imports"
   ],
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": "manual",
   "fmt": {
     "singleQuote": true,
     "indentWidth": 2


### PR DESCRIPTION
## 🎶 Notes 🎶

- Forgot to revert the fixed deno version 🥲 This should fix the builds:
<img width="400" height="42" alt="image" src="https://github.com/user-attachments/assets/491673e3-bb1b-4021-9ba4-2eb28bded2c4" />

- Sets the `nodeModulesDir` to `manual` to fix:
<img width="1284" height="357" alt="Screenshot 2025-08-29 at 12 18 06" src="https://github.com/user-attachments/assets/01cc9a1f-dc89-4356-93c9-b8e18f25a301" />

Recommended here: https://github.com/denoland/deno/issues/30424#issuecomment-3200006441

The docs also mention: [`It is recommended for projects using frameworks like Next.js, Remix, Svelte, Qwik etc, or tools like Vite, Parcel or Rollup.`](https://docs.deno.com/runtime/fundamentals/node/#automatic-node_modules-creation)