### PR TITLE
fix(toggle): change after transition

### DIFF
--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -24,8 +24,7 @@
     custom animation functions for use with svelte:animate
   */
   let trackerElement: HTMLDivElement;
-  const handleChange = (index: number, optionValue: T) => {
-    onChange(optionValue);
+  const handleChange = (index: number) => {
     trackerIndex.set(index);
 
     requestAnimationFrame(() => {
@@ -47,11 +46,13 @@
     class:text-variant={variant === "text"}
     ontransitionend={(event) => {
       event.currentTarget.classList.remove("moving");
+      const newValue = options.at($trackerIndex)?.value ?? value;
+      onChange(newValue);
     }}
   ></div>
   {#each options as option, index (option.value)}
     <Toggle
-      onclick={() => handleChange(index, option.value)}
+      onclick={() => handleChange(index)}
       isPressed={$trackerIndex === index}
       {variant}
     >


### PR DESCRIPTION
## ♪ Note ♪

- Content could be changed while the toggler is still animating, leading to sluggish animations. The onchange will now be called on transition end.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/01b04687-837f-497b-80d1-84cb9a308de7

After:

https://github.com/user-attachments/assets/b8c42a34-0a0f-4ef1-bb1e-4309834cde13
