### PR TITLE
fix(footer): reserve space for now playing toast

### DIFF
--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import TraktCoverImage from "$lib/components/background/TraktCoverImage.svelte";
+  import { useNowPlaying } from "$lib/features/now-playing/useNowPlaying";
   import FooterContent from "./components/FooterContent.svelte";
   import { FOOTER_CLASS_NAME } from "./constants";
+
+  const { nowPlaying } = useNowPlaying();
 </script>
 
-<footer class={FOOTER_CLASS_NAME}>
+<footer class={FOOTER_CLASS_NAME} class:has-now-playing={$nowPlaying !== null}>
   <TraktCoverImage />
   <FooterContent />
 </footer>
@@ -29,6 +32,10 @@
     }
 
     @include for-tablet-sm-and-below {
+      &.has-now-playing {
+        margin-top: calc(var(--height-now-playing-card) + var(--gap-xxl));
+      }
+
       height: fit-content;
       position: relative;
     }


### PR DESCRIPTION
## ♪ Note ♪

- Reserve space for the now playing toast in the footer

## 👀 Example 👀
Before:
<img width="427" height="926" alt="before" src="https://github.com/user-attachments/assets/157391be-042c-4067-939d-d2a7edb33a6c" />

After:
<img width="427" height="926" alt="Screenshot 2025-09-02 at 20 39 41" src="https://github.com/user-attachments/assets/5ef7d3af-9cce-4f47-b045-d65ba73930ba" />
