### PR TITLE
Refines ETA calculation for improved accuracy

### DIFF
--- a/projects/client/src/lib/utils/formatting/date/toHumanETA.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanETA.spec.ts
@@ -75,7 +75,7 @@ describe('toHumanETA', () => {
 
   it('should handle same day but later time in hours', () => {
     const today = new Date('2023-01-01T10:00:00.000Z');
-    const targetDate = new Date('2023-01-01T23:59:59.999Z'); // Same day, not after midnight
+    const targetDate = new Date('2023-01-01T23:59:59.999Z');
     expect(toHumanETA(today, targetDate, 'en')).toBe('in 14 hours');
   });
 
@@ -100,13 +100,13 @@ describe('toHumanETA', () => {
   it('should round up fractional hours (2.3 hours becomes 3 hours)', () => {
     const today = new Date('2023-01-01T10:00:00.000Z');
     const targetDate = new Date('2023-01-01T12:18:00.000Z');
-    expect(toHumanETA(today, targetDate, 'en')).toBe('in 3 hours');
+    expect(toHumanETA(today, targetDate, 'en')).toBe('in 2 hours');
   });
 
-  it('should return "in 1 hour" for small fractional hours (0.1 hours)', () => {
+  it('should return "in 6m" for small fractional hours (0.1 hours)', () => {
     const today = new Date('2023-01-01T10:00:00.000Z');
     const targetDate = new Date('2023-01-01T10:06:00.000Z');
-    expect(toHumanETA(today, targetDate, 'en')).toBe('in 1 hour');
+    expect(toHumanETA(today, targetDate, 'en')).toBe('in 6m');
   });
 
   it('should switch to days when 24+ hours (25 hours becomes tomorrow)', () => {

--- a/projects/client/src/lib/utils/formatting/date/toHumanETA.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanETA.ts
@@ -9,34 +9,49 @@ export function toHumanETA(
   const MS_PER_DAY = MS_PER_HOUR * 24;
 
   const timeDiff = targetDate.getTime() - today.getTime();
-  const days = Math.ceil(timeDiff / MS_PER_DAY);
-  const hours = Math.ceil(timeDiff / MS_PER_HOUR);
+  const minutes = Math.round(timeDiff / (1000 * 60));
+  const days = Math.round(timeDiff / MS_PER_DAY);
+  const hours = Math.round(timeDiff / MS_PER_HOUR);
 
   const isPastDate = timeDiff < 0;
+
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  const narrowRtf = new Intl.RelativeTimeFormat(locale, {
+    numeric: 'auto',
+    style: 'narrow',
+  });
+
   const year = targetDate.getFullYear().toString();
 
   if (isPastDate) {
     return year;
   }
 
-  const isTargetAfterMidnight = targetDate.getUTCHours() >= 0 &&
-    targetDate.getUTCHours() < 6;
+  const isTodayAfterMidnight = today.getHours() >= 0 &&
+    today.getHours() < 6;
 
-  const isSameDay = today.getUTCFullYear() === targetDate.getUTCFullYear() &&
-    today.getUTCMonth() === targetDate.getUTCMonth() &&
-    today.getUTCDate() === targetDate.getUTCDate();
+  const isTargetAfterMidnight = targetDate.getHours() >= 0 &&
+    targetDate.getHours() < 6;
 
-  if (isSameDay && !isTargetAfterMidnight) {
+  const isSameDay = today.getFullYear() === targetDate.getFullYear() &&
+    today.getMonth() === targetDate.getMonth() &&
+    today.getDate() === targetDate.getDate();
+
+  if (isSameDay) {
+    if (hours === 0) {
+      return narrowRtf.format(minutes, 'minute');
+    }
+
     return rtf.format(hours, 'hour');
   }
 
   if (days <= 6) {
-    return rtf.format(days, 'day');
+    const modifier = isTargetAfterMidnight && !isTodayAfterMidnight ? 1 : 0;
+    return rtf.format(days + modifier, 'day');
   }
 
   const remainingDaysInWeek = days % 7;
-  const exceedsCurrentWeek = today.getUTCDay() + remainingDaysInWeek > 7;
+  const exceedsCurrentWeek = today.getDay() + remainingDaysInWeek > 7;
   const additionalWeek = exceedsCurrentWeek ? 1 : 0;
 
   const weeks = Math.floor(days / 7) + additionalWeek;

--- a/projects/client/vitest-setup.ts
+++ b/projects/client/vitest-setup.ts
@@ -17,6 +17,8 @@ import { setAuthorization } from '$test/beds/store/renderStore.ts';
 import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { server } from './src/mocks/server.ts';
 
+process.env.TZ = 'UTC';
+
 beforeAll(() => server.listen());
 afterEach(() => {
   vi.clearAllMocks();


### PR DESCRIPTION
Improves the accuracy of the estimated time of arrival (ETA) calculation by:

- Using `round` instead of `ceil` for time differences to avoid overestimation.
- Showing minutes for ETAs less than an hour, providing more granular information.
- Corrects logic for same-day ETAs, especially around midnight.

The changes ensure more accurate and user-friendly ETA displays.

Before:
<img width="1066" height="216" alt="image" src="https://github.com/user-attachments/assets/011d80ab-ce22-4f17-aa71-3460101868df" />

After:
<img width="1066" height="216" alt="image" src="https://github.com/user-attachments/assets/f51c3aac-2c07-491d-9757-5bbeaf3d0de4" />

