### PR TITLE
fix(summary): scroll current season into view

### DIFF
--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -7,15 +7,46 @@
   import type { Season } from "$lib/requests/models/Season";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
 
+  const SCROLL_OFFSET = 8;
+
   const {
     season,
     urlBuilder,
     isCurrentSeason,
   }: { season: Season; urlBuilder: () => string; isCurrentSeason: boolean } =
     $props();
+
+  const scrollToItem = (element: HTMLElement) => {
+    if (!isCurrentSeason) return;
+
+    const parent = element.parentElement;
+    if (!parent) {
+      return;
+    }
+
+    const parentRight = parent.scrollLeft + parent.clientWidth;
+    const elementLeft = element.offsetLeft;
+    const elementRight = elementLeft + element.offsetWidth;
+    const isOutOfView = elementRight > parentRight;
+
+    if (!isOutOfView) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      parent.scrollTo({
+        left: elementLeft - SCROLL_OFFSET,
+        behavior: "instant",
+      });
+    });
+  };
 </script>
 
-<div class="trakt-season-item" class:is-current-season={isCurrentSeason}>
+<div
+  class="trakt-season-item"
+  class:is-current-season={isCurrentSeason}
+  use:scrollToItem
+>
   <PortraitCard>
     <Link focusable={false} href={urlBuilder()} noscroll>
       <CardCover


### PR DESCRIPTION
## ♪ Note ♪

- When opening a show summary, scroll to the current season if it is not in view.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/29fa0188-2f74-435c-962f-3f6ad85c33fb

After:

https://github.com/user-attachments/assets/46d6ee0b-9ad4-43df-9d1c-2b7d6ae2c2d0


