### PR TITLE
fix(navbar): account for badge

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
+++ b/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
@@ -72,7 +72,11 @@
 
     :global(.profile-image-container .vip-badge) {
       top: var(--ni-neg-10);
-      right: var(--ni-neg-10);
+      right: var(--ni-neg-4);
+    }
+
+    :global(.profile-image-container.is-vip) {
+      padding-right: var(--ni-8);
     }
 
     @include for-tablet-sm-and-below {


### PR DESCRIPTION
## ♪ Note ♪

- Woops, removed a bit too much during the refactor 😅

## 👀 Example 👀
Before:
<img width="361" height="175" alt="Screenshot 2025-09-05 at 17 00 35" src="https://github.com/user-attachments/assets/1c8cf62f-f74d-4b9b-ac37-537e8216cad9" />

After:
<img width="361" height="175" alt="Screenshot 2025-09-05 at 17 02 09" src="https://github.com/user-attachments/assets/67bedbd8-9c72-40d9-9561-f60994924cdd" />

