### PR TITLE
Fix/calendar & navbar scroll behavior

### DIFF
--- a/projects/client/src/lib/features/calendar/Calendar.svelte
+++ b/projects/client/src/lib/features/calendar/Calendar.svelte
@@ -2,6 +2,7 @@
   import LoadingIndicator from "$lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte";
   import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
   import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
+  import { trackWindowScrollDirection } from "$lib/utils/actions/trackWindowScrollDirection";
   import CalendarDays from "./_internal/CalendarDays.svelte";
   import CalendarHeader from "./_internal/CalendarHeader.svelte";
   import CalendarItems from "./_internal/CalendarItems.svelte";
@@ -23,6 +24,11 @@
     class="calendar-navigation"
     use:observeDimension
     use:trackWindowScroll={"is-scrolled"}
+    use:trackWindowScrollDirection={{
+      upClassName: "trakt-calendar-scroll-up",
+      downClassName: "trakt-calendar-scroll-down",
+      offsetVar: "var(--navbar-height)",
+    }}
   >
     <CalendarHeader />
     <CalendarDays calendar={$calendar} />
@@ -68,11 +74,13 @@
 
     background-color: var(--color-calendar-background);
 
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: gap, top;
+
     @include backdrop-filter-blur(var(--ni-8));
 
     @include for-mobile {
       --sticky-top: calc(env(safe-area-inset-top, 0) + var(--ni-4));
-      transition: gap var(--transition-increment) ease-in-out;
 
       :global(.calendar-header) {
         transition: height var(--transition-increment) ease-in-out;
@@ -89,6 +97,14 @@
 
     @include for-tablet-sm-and-below {
       top: calc(var(--navbar-height) + var(--sticky-top));
+    }
+  }
+
+  .calendar-navigation {
+    &:global(.trakt-calendar-scroll-down) {
+      @include for-tablet-sm-and-below {
+        top: var(--sticky-top);
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/components/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/TopNavbar.svelte
@@ -14,8 +14,9 @@
     class="trakt-navbar"
     use:trackWindowScroll={"trakt-navbar-scroll"}
     use:trackWindowScrollDirection={{
-      up: "trakt-navbar-scroll-up",
-      down: "trakt-navbar-scroll-down",
+      upClassName: "trakt-navbar-scroll-up",
+      downClassName: "trakt-navbar-scroll-down",
+      offsetVar: "var(--navbar-height)",
     }}
   >
     <div class="trakt-navbar-content">
@@ -96,7 +97,6 @@
       @include backdrop-filter-blur(var(--ni-8));
     }
 
-    &:global(.trakt-navbar-scroll),
     &:global(.trakt-navbar-scroll-down) {
       top: var(--offscreen-top);
       opacity: 0;

--- a/projects/client/src/lib/utils/actions/trackWindowScrollDirection.ts
+++ b/projects/client/src/lib/utils/actions/trackWindowScrollDirection.ts
@@ -1,24 +1,32 @@
+import { useVarToPixels } from '../../stores/css/useVarToPixels.ts';
 import { GlobalEventBus } from '../events/GlobalEventBus.ts';
 
 const SCROLL_THRESHOLD = 10;
 
 export function trackWindowScrollDirection(
   node: HTMLElement,
-  classNames: {
-    up: string;
-    down: string;
+  props: {
+    upClassName: string;
+    downClassName: string;
+    offsetVar: string;
   },
 ) {
   let lastScrollY = 0;
 
+  const offset = useVarToPixels(props.offsetVar);
+  let offsetValue = 0;
+  const unsubscribe = offset.subscribe((value) => {
+    offsetValue = value;
+  });
+
   function reset() {
     lastScrollY = 0;
-    node.classList.remove(classNames.up, classNames.down);
+    node.classList.remove(props.upClassName, props.downClassName);
   }
 
   function handleScroll() {
     const currentScrollY = globalThis.window.scrollY;
-    if (currentScrollY === 0) {
+    if (currentScrollY <= offsetValue) {
       reset();
       return;
     }
@@ -31,8 +39,8 @@ export function trackWindowScrollDirection(
     const isScrollingDown = currentScrollY > lastScrollY;
     const isScrollingUp = currentScrollY < lastScrollY;
 
-    node.classList.toggle(classNames.up, isScrollingUp);
-    node.classList.toggle(classNames.down, isScrollingDown);
+    node.classList.toggle(props.upClassName, isScrollingUp);
+    node.classList.toggle(props.downClassName, isScrollingDown);
 
     lastScrollY = currentScrollY;
   }
@@ -47,6 +55,7 @@ export function trackWindowScrollDirection(
 
   return {
     destroy() {
+      unsubscribe();
       unregister();
     },
   };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Added an offset before hiding the top navbar.
  - It hides only after we can reliably fill up the space under it to avoid having gaps.
- Calendar responds accordingly now.

## 👀 Examples 👀
Before/after:

https://github.com/user-attachments/assets/0d9cff14-778a-4569-923b-5c5ffe809fc0

https://github.com/user-attachments/assets/185c3eac-b04f-4b02-a206-95c286a83605

Before/after:

https://github.com/user-attachments/assets/46ccfbc7-4130-4660-8ffc-ab01cb3caf48

https://github.com/user-attachments/assets/a46ec6ed-9fc8-4bba-bd12-dd6ba419afa3
