### PR TITLE
feat(comment): use animated emojis

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -14,7 +14,7 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i2.wp.com/ https://*.contentsquare.net https://*.youtube.com;
+        img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i2.wp.com/ https://*.contentsquare.net https://*.youtube.com https://fonts.gstatic.com;
         script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com https://*.contentsquare.net http://*.contentsquare.net;
         script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/ https://*.contentsquare.net https://static.hj.contentsquare.net http://*.contentsquare.net http://t.contentsquare.net https://static.hj.contentsquare.net https://cdnjs.cloudflare.com;
         worker-src 'self' blob:;

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionDetails.svelte
@@ -2,17 +2,25 @@
   import { getLocale } from "$lib/features/i18n";
   import type { Reaction } from "$lib/requests/queries/comments/commentReactionsQuery";
   import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
-  import { REACTIONS_MAP } from "./constants";
+  import ReactionEmoji from "./ReactionEmoji.svelte";
+  import { REACTIONS_CODE_MAP } from "./constants";
 
   const {
     reaction,
     count,
     isCurrent,
-  }: { reaction: Reaction; count: number; isCurrent: boolean } = $props();
+    index,
+  }: { reaction: Reaction; count: number; isCurrent: boolean; index: number } =
+    $props();
 </script>
 
 <div class="trakt-reaction-details" class:is-current={isCurrent}>
-  {REACTIONS_MAP[reaction]}
+  <ReactionEmoji
+    code={REACTIONS_CODE_MAP[reaction]}
+    label={reaction}
+    animation={isCurrent ? "infinite" : "none"}
+    {index}
+  />
   <p class="small">{toHumanNumber(count, getLocale())}</p>
 </div>
 
@@ -26,7 +34,6 @@
     min-width: var(--ni-66);
     height: var(--ni-30);
 
-    font-size: var(--ni-18);
     color: var(--color-foreground);
 
     box-sizing: border-box;

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionEmoji.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionEmoji.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { time } from "$lib/utils/timing/time";
+  import { onMount } from "svelte";
+  import { writable } from "svelte/store";
+  import { EMOJI_BASE_URL } from "./constants";
+
+  const {
+    code,
+    label,
+    animation = "none",
+    index,
+  }: {
+    code: string;
+    label: string;
+    index: number;
+    animation?: "initial" | "infinite" | "none";
+  } = $props();
+
+  const baseUrl = $derived(`${EMOJI_BASE_URL}/${code}`);
+
+  const hasInitialAnimation = writable(false);
+
+  // FIXME: switch to Lottie animations for better control on the animation and reduce file size
+  const hasAnimation = $derived(
+    animation === "infinite" || $hasInitialAnimation,
+  );
+
+  onMount(() => {
+    if (animation !== "initial") {
+      return;
+    }
+
+    const duration = time.seconds(1.25);
+    const delay = time.seconds(0.05) * (index + 1);
+
+    const startTimeoutId = setTimeout(
+      () => hasInitialAnimation.set(true),
+      delay,
+    );
+
+    const endTimeoutId = setTimeout(
+      () => hasInitialAnimation.set(false),
+      delay + duration,
+    );
+
+    return () => {
+      clearTimeout(startTimeoutId);
+      clearTimeout(endTimeoutId);
+    };
+  });
+</script>
+
+<div class="trakt-reaction-emoji-container" class:is-animated={hasAnimation}>
+  <picture class="trakt-reaction-emoji animated">
+    <source srcset={`${baseUrl}/512.webp`} type="image/webp" />
+    <CrossOriginImage loading="eager" src={`${baseUrl}/512.gif`} alt={label} />
+  </picture>
+
+  <picture class="trakt-reaction-emoji static">
+    <CrossOriginImage
+      loading="eager"
+      src={`${baseUrl}/emoji.svg`}
+      alt={label}
+    />
+  </picture>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-reaction-emoji-container {
+    .animated {
+      display: none;
+    }
+
+    &.is-animated {
+      .animated {
+        display: flex;
+      }
+
+      .static {
+        display: none;
+      }
+    }
+  }
+
+  .trakt-reaction-emoji {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: var(--ni-24);
+    height: var(--ni-24);
+
+    :global(img) {
+      width: var(--ni-18);
+      height: var(--ni-18);
+    }
+  }
+
+  :global(.trakt-action-button) {
+    @include for-mouse() {
+      &:hover {
+        .trakt-reaction-emoji-container {
+          .animated {
+            display: flex;
+          }
+
+          .static {
+            display: none;
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionPicker.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionPicker.svelte
@@ -4,7 +4,8 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { Reaction } from "$lib/requests/queries/comments/commentReactionsQuery";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
-  import { REACTIONS_MAP } from "./constants";
+  import ReactionEmoji from "./ReactionEmoji.svelte";
+  import { REACTIONS_CODE_MAP } from "./constants";
 
   const {
     currentReaction,
@@ -26,7 +27,7 @@
     <CloseIcon />
   </ActionButton>
 
-  {#each Object.entries(REACTIONS_MAP) as [reaction, emoji], index (reaction)}
+  {#each Object.entries(REACTIONS_CODE_MAP) as [reaction, code], index (reaction)}
     <div
       class="trakt-react-button-container"
       class:is-current={currentReaction === reaction}
@@ -39,7 +40,7 @@
         onclick={() => onChange(reaction as Reaction)}
         style="ghost"
       >
-        {emoji}
+        <ReactionEmoji {code} label={reaction} {index} animation="initial" />
       </ActionButton>
     </div>
   {/each}
@@ -67,27 +68,18 @@
 
     :global(.trakt-action-button) {
       transition: var(--transition-increment) ease-in-out;
-      transition-property: font-size, background-color;
+      transition-property: background-color;
 
       border-radius: 50%;
 
       background-color: transparent;
       backdrop-filter: none;
-      font-size: var(--ni-18);
 
       opacity: 0;
 
       --delay-factor: calc(var(--animation-duration) / 6);
       animation: bump-in var(--animation-duration) ease-in forwards;
       animation-delay: calc(var(--reaction-index) * var(--delay-factor));
-    }
-  }
-
-  .trakt-react-button-container:not(.is-current) {
-    :global(.trakt-action-button) {
-      &:hover {
-        font-size: var(--ni-24);
-      }
     }
   }
 

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsDistribution.svelte
@@ -4,7 +4,7 @@
   import type { Reaction } from "$lib/requests/queries/comments/commentReactionsQuery";
   import { slide } from "svelte/transition";
   import type { ReactionDistribution } from "../models/ReactionDistribution";
-  import { REACTIONS_MAP } from "./constants";
+  import { REACTIONS_CODE_MAP } from "./constants";
   import ReactionDetails from "./ReactionDetails.svelte";
 
   const {
@@ -27,11 +27,12 @@
     <ReactionIcon state="default" />{m.header_comment_reactions()}
   </span>
   <div class="trakt-reactions">
-    {#each Object.entries(REACTIONS_MAP) as [reaction] (reaction)}
+    {#each Object.entries(REACTIONS_CODE_MAP) as [reaction], index (reaction)}
       <ReactionDetails
         reaction={reaction as Reaction}
         count={distribution?.[reaction as Reaction] ?? 0}
         isCurrent={currentReaction === reaction}
+        {index}
       />
     {/each}
   </div>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummary.svelte
@@ -2,14 +2,21 @@
   import { getLocale } from "$lib/features/i18n";
   import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
   import type { ReactionSummary } from "../models/ReactionSummary";
-  import { REACTIONS_MAP } from "./constants";
+  import ReactionEmoji from "./ReactionEmoji.svelte";
+  import { REACTIONS_CODE_MAP } from "./constants";
 
   const { summary }: { summary: ReactionSummary } = $props();
 </script>
 
 <div class="trakt-reactions-summary">
   <div class="trakt-reaction-emojis">
-    {summary.top.map((reaction) => REACTIONS_MAP[reaction]).join(" ")}
+    {#each summary.top as reaction, index}
+      <ReactionEmoji
+        code={REACTIONS_CODE_MAP[reaction]}
+        label={reaction}
+        {index}
+      />
+    {/each}
   </div>
 
   {#if summary.count > 0}

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/constants.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/constants.ts
@@ -1,11 +1,14 @@
 import type { Reaction } from '$lib/requests/queries/comments/commentReactionsQuery.ts';
 
-export const REACTIONS_MAP: Record<Reaction, string> = {
-  like: '👍',
-  dislike: '👎',
-  love: '❤️',
-  laugh: '😂',
-  shocked: '😱',
-  bravo: '👏',
-  spoiler: '🫣',
+export const EMOJI_BASE_URL = 'https://fonts.gstatic.com/s/e/notoemoji/latest';
+
+// Source: https://googlefonts.github.io/noto-emoji-animation/
+export const REACTIONS_CODE_MAP: Record<Reaction, string> = {
+  like: '1f44d',
+  dislike: '1f44e',
+  love: '2764_fe0f',
+  laugh: '1f602',
+  shocked: '1f631',
+  bravo: '1f44f',
+  spoiler: '1fae3',
 } as const;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds animated emojis to reactions.
- ~~Current selection is continuously animated.~~
- ~~In all other cases, they are animated for 1.5sec on mount.~~
- In the distribution, the current reaction is animated infinitely.
- In the picker, they are animated for a short duration as the appear.

## 👀 Example 👀

New:

https://github.com/user-attachments/assets/ca23cae3-9bc8-4482-b2c8-7ae7e99fcf73

Old:

https://github.com/user-attachments/assets/2d2f7838-8fec-4629-8014-274f3d4c9c5c

