### PR TITLE
Feat/ignore defaults

### DIFF
--- a/projects/client/src/lib/features/filters/_internal/constants.ts
+++ b/projects/client/src/lib/features/filters/_internal/constants.ts
@@ -64,14 +64,14 @@ const IGNORE_WATCHED_FILTER: Filter = {
   label: m.header_ignore_watched(),
   key: FilterKey.IgnoreWatched,
   type: 'toggle',
-  defaultValue: 'true',
+  defaultValue: 'false',
 };
 
 const IGNORE_WATCHLISTED_FILTER: Filter = {
   label: m.header_ignore_watchlisted(),
   key: FilterKey.IgnoreWatchlisted,
   type: 'toggle',
-  defaultValue: 'true',
+  defaultValue: 'false',
 };
 
 export const FILTERS = [

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -12,4 +12,4 @@
   <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
 {/snippet}
 
-<DefaultMediaItem {type} {media} {tag} {style} />
+<DefaultMediaItem {type} {media} {tag} {style} canDeemphasize />

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -7,6 +7,8 @@
   import type { MediaInputDefault } from "$lib/models/MediaInput";
   import CheckInAction from "$lib/sections/media-actions/check-in/CheckInAction.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
+  import { useIsWatchlisted } from "$lib/sections/media-actions/watchlist/useIsWatchlisted";
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import type { MediaCardProps } from "../components/MediaCardProps";
   import MediaItem from "./MediaItem.svelte";
@@ -17,8 +19,17 @@
     media,
     style,
     tag,
+    canDeemphasize,
     ...rest
-  }: MediaCardProps<MediaInputDefault> = $props();
+  }: MediaCardProps<MediaInputDefault> & { canDeemphasize?: boolean } =
+    $props();
+
+  const { isWatched } = $derived(useIsWatched({ type, media }));
+  const { isWatchlisted } = $derived(useIsWatchlisted({ type, media }));
+
+  const isDeemphasized = $derived(
+    canDeemphasize && ($isWatched || $isWatchlisted),
+  );
 </script>
 
 {#snippet defaultTag()}
@@ -62,12 +73,35 @@
 {/snippet}
 
 <MediaSwipe {type} {media} {style}>
-  <MediaItem
-    {type}
-    {media}
-    {style}
-    tag={tag ?? defaultTag}
-    {...rest}
-    {popupActions}
-  />
+  <trakt-default-media-item class:is-deemphasized={isDeemphasized}>
+    <MediaItem
+      {type}
+      {media}
+      {style}
+      tag={tag ?? defaultTag}
+      {...rest}
+      {popupActions}
+    />
+  </trakt-default-media-item>
 </MediaSwipe>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  trakt-default-media-item {
+    &.is-deemphasized {
+      :global(.trakt-card) {
+        transition: opacity var(--transition-increment) ease-in-out;
+        opacity: var(--de-emphasized-opacity);
+      }
+
+      @include for-mouse() {
+        &:hover {
+          :global(.trakt-card) {
+            opacity: 1;
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -68,19 +68,25 @@
   </PortraitCard>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-season-title {
     line-height: var(--ni-16);
   }
 
   .trakt-season-item {
-    filter: saturate(0.1) contrast(1.2);
+    cursor: pointer;
+    transition: opacity var(--transition-increment) ease-in-out;
 
-    transition: var(--transition-increment) ease-in-out;
-    transition-property: filter;
+    &:not(.is-current-season) {
+      opacity: var(--de-emphasized-opacity);
 
-    &.is-current-season {
-      filter: saturate(1) contrast(1);
+      @include for-mouse() {
+        &:hover {
+          opacity: 1;
+        }
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/popular/PopularListItem.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularListItem.svelte
@@ -7,4 +7,4 @@
     $props();
 </script>
 
-<DefaultMediaItem {type} {media} {style} {popupActions} />
+<DefaultMediaItem {type} {media} {style} {popupActions} canDeemphasize />

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
@@ -6,4 +6,4 @@
   const { type, media, style }: MediaCardProps<RecommendedEntry> = $props();
 </script>
 
-<DefaultMediaItem {type} {media} {style} />
+<DefaultMediaItem {type} {media} {style} canDeemphasize />

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -12,4 +12,4 @@
   <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
 {/snippet}
 
-<DefaultMediaItem {type} {media} {tag} {style} />
+<DefaultMediaItem {type} {media} {tag} {style} canDeemphasize />

--- a/projects/client/src/style/index.ts
+++ b/projects/client/src/style/index.ts
@@ -23,3 +23,5 @@ import './typography/index.css';
 import './animations/index.css';
 
 import './layers/index.css';
+
+import './states/index.css';

--- a/projects/client/src/style/states/index.css
+++ b/projects/client/src/style/states/index.css
@@ -1,0 +1,3 @@
+:root {
+  --de-emphasized-opacity: 0.4;
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Changes the `ignore watched` and `ignore watchlisted` filter defaults.
- De-emphasizes watched and watchlisted items.

## 👀 Example 👀
<img width="982" height="948" alt="Screenshot 2025-09-09 at 14 08 40" src="https://github.com/user-attachments/assets/c25cf634-6240-4979-83f1-e818eccd1fdd" />
