### PR TITLE
chore(social): update social icon

### DIFF
--- a/projects/client/src/lib/components/icons/SocialIcon.svelte
+++ b/projects/client/src/lib/components/icons/SocialIcon.svelte
@@ -1,52 +1,43 @@
-<!-- TODO better icon? -->
 <svg
-  width="16"
-  height="16"
-  viewBox="0 0 16 16"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
-    d="M9 9C7.2 7.2 4.8 7.2 3 9"
+    d="M19.0959 5C19.0959 8.20914 17.3051 11 15.0959 11C12.8868 11 11.0959 8.20914 11.0959 5C11.0959 2.79086 12.8868 1 15.0959 1C17.3051 1 19.0959 2.79086 19.0959 5Z"
     stroke="currentColor"
-    stroke-width="1.5"
+    stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
   />
   <path
-    d="M6 8L6 10"
+    d="M8.09592 11C5.88678 11 4.09592 8.20914 4.09592 5C4.09592 2.79086 5.88678 1 8.09592 1"
     stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
+    stroke-width="2"
     stroke-linejoin="round"
   />
   <path
-    d="M7.5 3C7.5 4.38 6.88 5.5 6 5.5C5.12 5.5 4.5 4.38 4.5 3C4.5 2.17 5.12 1.5 6 1.5C6.88 1.5 7.5 2.17 7.5 3Z"
+    d="M7.09591 22.015C7.09591 19.0605 8 16 12 16"
     stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-
-  <path
-    d="M14 14C12.2 12.2 9.8 12.2 8 14"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
+    stroke-width="2"
+    stroke-linecap="square"
     stroke-linejoin="round"
   />
   <path
-    d="M11 13L11 15"
+    d="M0.999995 23C0.999991 18 3 16 5.99999 16"
     stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
+    stroke-width="2"
     stroke-linejoin="round"
   />
-  <path
-    d="M12.5 8C12.5 9.38 11.88 10.5 11 10.5C10.12 10.5 9.5 9.38 9.5 8C9.5 7.17 10.12 6.5 11 6.5C11.88 6.5 12.5 7.17 12.5 8Z"
+  <circle
+    cx="19.5"
+    cy="19.5"
+    r="3.5"
     stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
+    stroke-width="2"
+    stroke-linecap="square"
     stroke-linejoin="round"
   />
 </svg>


### PR DESCRIPTION
## ♪ Note ♪

- We now have a social icon, so the crappy version I made can be replaced.

## 👀 Example 👀
Before:
<img width="428" height="208" alt="Screenshot 2025-09-09 at 16 23 56" src="https://github.com/user-attachments/assets/6451d3a0-7542-47b4-b424-ad6327b123a9" />

After:
<img width="428" height="208" alt="Screenshot 2025-09-09 at 16 24 45" src="https://github.com/user-attachments/assets/42e3c318-899d-4822-afe9-3c3ad0a8a11e" />
