### PR TITLE
fix(show): improve season selection logic

### DIFF
--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -35,7 +35,6 @@
   const lastWatchedSeason = $derived(useUserSeason($show?.id));
 
   const { search } = useParameters();
-
   const goToSeason = (slug: string, season: number) => {
     /*
      * TODO: Consider implementing a custom navigation helper within useParameters
@@ -64,12 +63,13 @@
 
     const active = assertDefined(
       $seasons.find((s) => s.number === $lastWatchedSeason.number) ??
-        $seasons.find((s) => s.number === 1),
+        $seasons.find((s) => s.number === 1) ??
+        $seasons.find((s) => s.number !== 0),
       "Active season not found",
     );
-
     const isCurrentSeasonFullyWatched =
-      active.episodes.count === $lastWatchedSeason.episodes.count;
+      active.episodes.count === $lastWatchedSeason.episodes.count &&
+      active.number === $lastWatchedSeason.number;
 
     const maxSeason = assertDefined(
       $seasons.at(-1),


### PR DESCRIPTION
This commit will improve the logic for selecting the active season in the show details page.
It addresses an issue where the active season wasn't correctly identified. The changes ensure that the season is correctly identified by comparing both episode counts and the season number when determining if the current season is fully watched. Additionally, it ensures that a season is always selected, even if the user hasn't watched any episodes.
