### PR TITLE
fix: constrain name in side navbar

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
+++ b/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
@@ -94,7 +94,7 @@
 
     .profile-name {
       line-height: 150%;
-      max-width: var(--ni-300);
+      max-width: var(--ni-96);
     }
 
     .meta-info {


### PR DESCRIPTION
## ♪ Note ♪

- Was being constrained based on the old side navbar design