### PR TITLE
fix(errors): do not depend on contexts in error pages

### DIFF
--- a/projects/client/src/lib/pages/errors/ErrorLockedAccountPage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorLockedAccountPage.svelte
@@ -2,18 +2,15 @@
   import * as m from "$lib/features/i18n/messages.ts";
 
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import ErrorPage from "./ErrorPage.svelte";
-
-  const { user } = useUser();
 </script>
 
 <ErrorPage title={m.page_title_account_locked()}>
   <p>
     <MessageWithLink
       message={m.error_text_locked_account()}
-      href={UrlBuilder.og.support($user.slug)}
+      href={UrlBuilder.og.support()}
       target="_blank"
     />
   </p>


### PR DESCRIPTION
## ♪ Note ♪

- Fix for [error page using context that is not available](https://trakt-tv.sentry.io/issues/59227721/?query=is%3Aunresolved&referrer=issue-stream&sort=freq).