### PR TITLE
fix(search): use same label for all popular search types

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Разширени"
     },
-    "list_title_most_searched_media": {
-      "default": "Най-търсени медии"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Най-търсени филми"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Най-търсени сериали"
+    "list_title_most_popular_searches": {
+      "default": "Най-популярни търсения"
     },
     "list_title_birthdays_this_month": {
       "default": "Рождени дни този месец"

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Avanceret"
     },
-    "list_title_most_searched_media": {
-      "default": "Mest søgte medier"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Mest søgte film"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Mest søgte serier"
+    "list_title_most_popular_searches": {
+      "default": "Mest populære søgninger"
     },
     "list_title_birthdays_this_month": {
       "default": "Fødselsdage denne måned"

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1926,17 +1926,11 @@
     "link_text_advanced_settings": {
       "default": "Erweitert"
     },
-    "list_title_most_searched_media": {
-      "default": "Am häufigsten gesuchte Medien"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Am häufigsten gesuchte Filme"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Am häufigsten gesuchte Serien"
+    "list_title_most_popular_searches": {
+      "default": "Beliebteste Suchen"
     },
     "list_title_birthdays_this_month": {
-      "default": "Geburtstage in diesem Monat"
+      "default": "Geburtstage diesen Monat"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1926,17 +1926,11 @@
     "link_text_advanced_settings": {
       "default": "Advanced"
     },
-    "list_title_most_searched_media": {
-      "default": "Most searched media"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Most searched movies"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Most searched shows"
+    "list_title_most_popular_searches": {
+      "default": "Most Popular Searches"
     },
     "list_title_birthdays_this_month": {
-      "default": "Birthdays this month"
+      "default": "Birthdays This Month"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5412,32 +5412,15 @@
         "ios"
       ]
     },
-    "list_title_most_searched_media": {
-      "default": "Most searched media",
-      "description": "Title for lists containing the most searched media.",
+    "list_title_most_popular_searches": {
+      "default": "Most Popular Searches",
+      "description": "Title for lists containing the most popular media, movies, or show searches.",
       "exclude": [
-        "android",
-        "ios"
-      ]
-    },
-    "list_title_most_searched_movies": {
-      "default": "Most searched movies",
-      "description": "Title for lists containing the most searched movies.",
-      "exclude": [
-        "android",
-        "ios"
-      ]
-    },
-    "list_title_most_searched_shows": {
-      "default": "Most searched shows",
-      "description": "Title for lists containing the most searched shows.",
-      "exclude": [
-        "android",
         "ios"
       ]
     },
     "list_title_birthdays_this_month": {
-      "default": "Birthdays this month",
+      "default": "Birthdays This Month",
       "description": "Title for lists containing the birthdays this month.",
       "exclude": [
         "android",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1926,17 +1926,11 @@
     "link_text_advanced_settings": {
       "default": "Avanzado"
     },
-    "list_title_most_searched_media": {
-      "default": "Medios más buscados"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Películas más buscadas"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Series más buscadas"
+    "list_title_most_popular_searches": {
+      "default": "Búsquedas más populares"
     },
     "list_title_birthdays_this_month": {
-      "default": "Cumpleaños este mes"
+      "default": "Cumpleaños de este mes"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Avanzado"
     },
-    "list_title_most_searched_media": {
-      "default": "Medios más buscados"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Películas más buscadas"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Series más buscadas"
+    "list_title_most_popular_searches": {
+      "default": "Búsquedas más populares"
     },
     "list_title_birthdays_this_month": {
       "default": "Cumpleaños de este mes"

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Avancé"
     },
-    "list_title_most_searched_media": {
-      "default": "Médias les plus recherchés"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Films les plus recherchés"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Séries les plus recherchées"
+    "list_title_most_popular_searches": {
+      "default": "Recherches les plus populaires"
     },
     "list_title_birthdays_this_month": {
       "default": "Anniversaires ce mois-ci"

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Avancé"
     },
-    "list_title_most_searched_media": {
-      "default": "Médias les plus recherchés"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Films les plus recherchés"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Séries les plus recherchées"
+    "list_title_most_popular_searches": {
+      "default": "Recherches les plus populaires"
     },
     "list_title_birthdays_this_month": {
       "default": "Anniversaires ce mois-ci"

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1926,17 +1926,11 @@
     "link_text_advanced_settings": {
       "default": "Avanzate"
     },
-    "list_title_most_searched_media": {
-      "default": "Media più cercati"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Film più cercati"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Serie TV più cercate"
+    "list_title_most_popular_searches": {
+      "default": "Ricerche più popolari"
     },
     "list_title_birthdays_this_month": {
-      "default": "Compleanni questo mese"
+      "default": "Compleanni di questo mese"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "詳細"
     },
-    "list_title_most_searched_media": {
-      "default": "最も検索されたメディア"
-    },
-    "list_title_most_searched_movies": {
-      "default": "最も検索された映画"
-    },
-    "list_title_most_searched_shows": {
-      "default": "最も検索されたドラマ"
+    "list_title_most_popular_searches": {
+      "default": "最も人気の検索"
     },
     "list_title_birthdays_this_month": {
       "default": "今月の誕生日"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Avansert"
     },
-    "list_title_most_searched_media": {
-      "default": "Mest søkte medier"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Mest søkte filmer"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Mest søkte serier"
+    "list_title_most_popular_searches": {
+      "default": "Mest populære søk"
     },
     "list_title_birthdays_this_month": {
       "default": "Bursdager denne måneden"

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Geavanceerd"
     },
-    "list_title_most_searched_media": {
-      "default": "Meest gezochte media"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Meest gezochte films"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Meest gezochte series"
+    "list_title_most_popular_searches": {
+      "default": "Meest populaire zoekopdrachten"
     },
     "list_title_birthdays_this_month": {
       "default": "Verjaardagen deze maand"

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Zaawansowane"
     },
-    "list_title_most_searched_media": {
-      "default": "Najczęściej wyszukiwane media"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Najczęściej wyszukiwane filmy"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Najczęściej wyszukiwane seriale"
+    "list_title_most_popular_searches": {
+      "default": "Najpopularniejsze wyszukiwania"
     },
     "list_title_birthdays_this_month": {
       "default": "Urodziny w tym miesiącu"

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1926,17 +1926,11 @@
     "link_text_advanced_settings": {
       "default": "Avançado"
     },
-    "list_title_most_searched_media": {
-      "default": "Mídia mais pesquisada"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Filmes mais pesquisados"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Séries mais pesquisadas"
+    "list_title_most_popular_searches": {
+      "default": "Buscas Mais Populares"
     },
     "list_title_birthdays_this_month": {
-      "default": "Aniversários este mês"
+      "default": "Aniversários Este Mês"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Avansat"
     },
-    "list_title_most_searched_media": {
-      "default": "Media cele mai căutate"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Filmele cele mai căutate"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Seriale cele mai căutate"
+    "list_title_most_popular_searches": {
+      "default": "Cele mai populare căutări"
     },
     "list_title_birthdays_this_month": {
       "default": "Zile de naștere luna aceasta"

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1926,17 +1926,11 @@
     "link_text_advanced_settings": {
       "default": "Avancerat"
     },
-    "list_title_most_searched_media": {
-      "default": "Mest sökta media"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Mest sökta filmer"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Mest sökta serier"
+    "list_title_most_popular_searches": {
+      "default": "Mest populära sökningar"
     },
     "list_title_birthdays_this_month": {
-      "default": "Födelsedagar den här månaden"
+      "default": "Födelsedagar denna månad"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1926,14 +1926,8 @@
     "link_text_advanced_settings": {
       "default": "Розширене"
     },
-    "list_title_most_searched_media": {
-      "default": "Найпопулярніші медіа"
-    },
-    "list_title_most_searched_movies": {
-      "default": "Найпопулярніші фільми"
-    },
-    "list_title_most_searched_shows": {
-      "default": "Найпопулярніші серіали"
+    "list_title_most_popular_searches": {
+      "default": "Найпопулярніші пошуки"
     },
     "list_title_birthdays_this_month": {
       "default": "Дні народження цього місяця"

--- a/projects/client/src/lib/features/search/SearchPlaceHolder.svelte
+++ b/projects/client/src/lib/features/search/SearchPlaceHolder.svelte
@@ -10,14 +10,10 @@
 
   const title = $derived.by(() => {
     switch ($mode) {
-      case "media":
-        return m.list_title_most_searched_media();
-      case "movie":
-        return m.list_title_most_searched_movies();
-      case "show":
-        return m.list_title_most_searched_shows();
       case "people":
         return m.list_title_birthdays_this_month();
+      default:
+        return m.list_title_most_popular_searches();
     }
   });
 </script>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Uses the same list title for all search types when there is no search query.
- Had a quick chat with Coco, we're going with `Most Popular Searches`. cc @michaldrabik 

## 👀 Example 👀
<img width="1444" height="811" alt="Screenshot 2025-09-15 at 13 07 16" src="https://github.com/user-attachments/assets/48b4ffd2-72be-4db3-807a-00944cba5ec2" />
