### PR TITLE
Feat/people summary

### DIFF
--- a/projects/client/src/lib/sections/summary/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/PeopleSummary.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
-  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import CreditsList from "../lists/CreditsList.svelte";
-  import SummaryContainer from "./components/summary/SummaryContainer.svelte";
-  import SummaryHeader from "./components/summary/SummaryHeader.svelte";
-  import SummaryOverview from "./components/summary/SummaryOverview.svelte";
-  import SummaryTitle from "./components/summary/SummaryTitle.svelte";
+  import PeopleSummary from "./components/people/PeopleSummary.svelte";
+  import PeopleSummaryV2 from "./components/people/v2/PeopleSummary.svelte";
 
   const {
     person,
@@ -16,23 +15,19 @@
   } = $props();
 </script>
 
-<SummaryContainer>
-  {#snippet poster()}
-    <SummaryPoster src={person.headshot.url.medium} alt={person.name} />
-  {/snippet}
-
-  <SummaryHeader>
-    {#snippet headerActions()}
-      <ShareButton
-        title={person.name}
-        textFactory={({ title: name }) => m.text_share_person({ name })}
-      />
+<RenderFor audience="all" device={["mobile"]}>
+  <RenderForFeature flag={FeatureFlag.SummaryV2}>
+    {#snippet enabled()}
+      <PeopleSummaryV2 {person} />
     {/snippet}
-    <SummaryTitle title={person.name} />
-  </SummaryHeader>
 
-  <SummaryOverview title={person.name} overview={person.biography} />
-</SummaryContainer>
+    <PeopleSummary {person} />
+  </RenderForFeature>
+</RenderFor>
+
+<RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
+  <PeopleSummary {person} />
+</RenderFor>
 
 <CreditsList title={m.list_title_movie_credits()} type="movie" {person} />
 <CreditsList title={m.list_title_show_credits()} type="show" {person} />

--- a/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import SummarySideActions from "./SummarySideActions.svelte";
+
+  const {
+    children,
+    poster,
+    meta,
+    sideActions,
+    color,
+  }: {
+    poster: Snippet;
+    meta: Snippet;
+    sideActions: Snippet;
+    color?: string;
+  } & ChildrenProps = $props();
+
+  const mainColor = $derived(color ?? "rgba(0, 0, 0, 0.56)");
+</script>
+
+<div class="trakt-summary">
+  <div class="trakt-summary-main" style={`--main-color: ${mainColor}`}>
+    {@render poster()}
+
+    <SummarySideActions>
+      {@render sideActions()}
+    </SummarySideActions>
+  </div>
+
+  <div class="trakt-summary-meta-info">
+    {@render meta()}
+  </div>
+
+  {@render children()}
+</div>
+
+<style>
+  .trakt-summary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+
+    padding-left: var(--layout-distance-side);
+    padding-right: var(--layout-distance-side);
+  }
+
+  .trakt-summary-main {
+    --side-action-bar-width: var(--ni-40);
+    --summary-gap: var(--gap-s);
+    --poster-side-distance: calc(
+      var(--layout-distance-side) + var(--side-action-bar-width) +
+        var(--summary-gap)
+    );
+    --poster-width: calc(100dvw - 2 * var(--poster-side-distance));
+
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: var(--summary-gap);
+
+    :global(.trakt-summary-poster-container) {
+      grid-column-start: 2;
+    }
+
+    :global(.trakt-summary-poster-container),
+    :global(.trakt-summary-poster img) {
+      width: var(--poster-width);
+      height: calc(var(--poster-width) * 1.5);
+    }
+
+    :global(.trakt-summary-poster img) {
+      box-shadow:
+        var(--ni-0) var(--ni-11) var(--ni-24) var(--ni-0)
+          color-mix(in srgb, var(--main-color) 16%, transparent),
+        var(--ni-0) var(--ni-44) var(--ni-44) var(--ni-0)
+          color-mix(in srgb, var(--main-color) 14%, transparent),
+        var(--ni-0) var(--ni-104) var(--ni-60) var(--ni-0)
+          color-mix(in srgb, var(--main-color) 8%, transparent),
+        var(--ni-0) var(--ni-180) var(--ni-72) var(--ni-0)
+          color-mix(in srgb, var(--main-color) 2%, transparent),
+        var(--ni-0) var(--ni-280) var(--ni-80) var(--ni-0) transparent;
+    }
+  }
+
+  .trakt-summary-meta-info {
+    display: flex;
+    flex-direction: column;
+
+    justify-content: center;
+    align-items: center;
+
+    gap: var(--gap-s);
+
+    :global(.vote-count) {
+      display: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummarySideActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummarySideActions.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  const { children }: ChildrenProps = $props();
+</script>
+
+<div class="trakt-summary-side-actions">
+  {@render children()}
+</div>
+
+<style>
+  .trakt-summary-side-actions {
+    display: flex;
+    flex-direction: column;
+
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    gap: var(--gap-s);
+
+    :global(.trakt-action-button) {
+      background: transparent;
+      backdrop-filter: none;
+
+      :global(svg) {
+        color: var(--color-foreground);
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -8,6 +8,7 @@
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaStudio } from "$lib/requests/models/MediaStudio";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import Summary from "../../_internal/Summary.svelte";
   import MediaDetails from "../../details/MediaDetails.svelte";
   import SummaryOverview from "../../summary/SummaryOverview.svelte";
   import type { MediaSummaryProps } from "../MediaSummaryProps";
@@ -31,98 +32,35 @@
 
   const { ratings } = $derived(useMediaMetaInfo({ media, type }));
   const title = $derived(intl?.title ?? media?.title ?? "");
-  const mainMediaColor = $derived(media.colors?.at(0) ?? "rgba(0, 0, 0, 0.56)");
 </script>
 
 <CoverImageSetter src={media.cover.url.medium} colors={media.colors} {type} />
 
-<div class="trakt-media-summary">
-  <div
-    class="trakt-media-summary-main"
-    style={`--main-media-color: ${mainMediaColor}`}
-  >
+<Summary color={media.colors?.at(0)}>
+  {#snippet poster()}
     <SummaryPoster
       src={media.poster.url.medium}
       alt={title}
       href={streamOn?.preferred?.link ?? media.trailer}
     />
-    <SideActions {title} {type} trailer={media.trailer} />
-  </div>
+  {/snippet}
 
-  <div class="trakt-media-summary-meta-info">
+  {#snippet sideActions()}
+    <SideActions {title} {type} trailer={media.trailer} />
+  {/snippet}
+
+  {#snippet meta()}
     <RatingList ratings={$ratings} airDate={media.airDate} />
     <SummaryTitle {title} genres={media.genres} year={media.year} />
 
     <RenderFor audience="authenticated">
       <MediaActions {media} />
     </RenderFor>
-  </div>
+  {/snippet}
 
   <Spoiler {media} {type}>
     <SummaryOverview {title} overview={intl.overview ?? media.overview} />
   </Spoiler>
 
   <MediaDetails {media} {studios} {crew} {type} />
-</div>
-
-<style>
-  .trakt-media-summary {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-m);
-
-    padding-left: var(--layout-distance-side);
-    padding-right: var(--layout-distance-side);
-  }
-
-  .trakt-media-summary-main {
-    --side-action-bar-width: var(--ni-40);
-    --summary-gap: var(--gap-s);
-    --poster-side-distance: calc(
-      var(--layout-distance-side) + var(--side-action-bar-width) +
-        var(--summary-gap)
-    );
-    --poster-width: calc(100dvw - 2 * var(--poster-side-distance));
-
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    gap: var(--summary-gap);
-
-    :global(.trakt-summary-poster-container) {
-      grid-column-start: 2;
-    }
-
-    :global(.trakt-summary-poster-container),
-    :global(.trakt-summary-poster img) {
-      width: var(--poster-width);
-      height: calc(var(--poster-width) * 1.5);
-    }
-
-    :global(.trakt-summary-poster img) {
-      box-shadow:
-        var(--ni-0) var(--ni-11) var(--ni-24) var(--ni-0)
-          color-mix(in srgb, var(--main-media-color) 16%, transparent),
-        var(--ni-0) var(--ni-44) var(--ni-44) var(--ni-0)
-          color-mix(in srgb, var(--main-media-color) 14%, transparent),
-        var(--ni-0) var(--ni-104) var(--ni-60) var(--ni-0)
-          color-mix(in srgb, var(--main-media-color) 8%, transparent),
-        var(--ni-0) var(--ni-180) var(--ni-72) var(--ni-0)
-          color-mix(in srgb, var(--main-media-color) 2%, transparent),
-        var(--ni-0) var(--ni-280) var(--ni-80) var(--ni-0) transparent;
-    }
-  }
-
-  .trakt-media-summary-meta-info {
-    display: flex;
-    flex-direction: column;
-
-    justify-content: center;
-    align-items: center;
-
-    gap: var(--gap-s);
-
-    :global(.vote-count) {
-      display: none;
-    }
-  }
-</style>
+</Summary>

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/SideActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/SideActions.svelte
@@ -13,46 +13,23 @@
   }: { title: string; type: MediaType; trailer: string } = $props();
 </script>
 
-<div class="trakt-summary-side-actions">
-  <ShareButton
-    {title}
-    style="ghost"
-    textFactory={({ title }) => {
-      switch (type) {
-        case "movie":
-          return m.text_share_movie({ title });
-        case "show":
-          return m.text_share_show({ title });
-      }
-    }}
-  />
-
-  <ActionButton
-    style="ghost"
-    href={trailer}
-    label={m.translated_value_video_type_trailer()}
-  >
-    <YouTubeIcon />
-  </ActionButton>
-</div>
-
-<style>
-  .trakt-summary-side-actions {
-    display: flex;
-    flex-direction: column;
-
-    justify-content: flex-start;
-    align-items: flex-start;
-
-    gap: var(--gap-s);
-
-    :global(.trakt-action-button) {
-      background: transparent;
-      backdrop-filter: none;
-
-      :global(svg) {
-        color: var(--color-foreground);
-      }
+<ShareButton
+  {title}
+  style="ghost"
+  textFactory={({ title }) => {
+    switch (type) {
+      case "movie":
+        return m.text_share_movie({ title });
+      case "show":
+        return m.text_share_show({ title });
     }
-  }
-</style>
+  }}
+/>
+
+<ActionButton
+  style="ghost"
+  href={trailer}
+  label={m.translated_value_video_type_trailer()}
+>
+  <YouTubeIcon />
+</ActionButton>

--- a/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import SummaryContainer from "./../summary/SummaryContainer.svelte";
+  import SummaryHeader from "./../summary/SummaryHeader.svelte";
+  import SummaryOverview from "./../summary/SummaryOverview.svelte";
+  import SummaryTitle from "./../summary/SummaryTitle.svelte";
+
+  const { person }: { person: PersonSummary } = $props();
+</script>
+
+<SummaryContainer>
+  {#snippet poster()}
+    <SummaryPoster src={person.headshot.url.medium} alt={person.name} />
+  {/snippet}
+
+  <SummaryHeader>
+    {#snippet headerActions()}
+      <ShareButton
+        title={person.name}
+        textFactory={({ title: name }) => m.text_share_person({ name })}
+      />
+    {/snippet}
+    <SummaryTitle title={person.name} />
+  </SummaryHeader>
+
+  <SummaryOverview title={person.name} overview={person.biography} />
+</SummaryContainer>

--- a/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import Summary from "./../../_internal/Summary.svelte";
+  import SummaryOverview from "./../../summary/SummaryOverview.svelte";
+  import SummaryTitle from "./../../summary/SummaryTitle.svelte";
+
+  const { person }: { person: PersonSummary } = $props();
+</script>
+
+<Summary>
+  {#snippet poster()}
+    <SummaryPoster src={person.headshot.url.medium} alt={person.name} />
+  {/snippet}
+
+  {#snippet sideActions()}
+    <ShareButton
+      title={person.name}
+      textFactory={({ title: name }) => m.text_share_person({ name })}
+      style="ghost"
+    />
+  {/snippet}
+
+  {#snippet meta()}
+    <SummaryTitle title={person.name} />
+  {/snippet}
+
+  <SummaryOverview title={person.name} overview={person.biography} />
+</Summary>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Extracts a generic component for the new summary designs.
- Use the new design also for people (feature flagged, mobile only also).

## 👀 Example 👀
<img width="428" height="930" alt="Screenshot 2025-09-17 at 12 50 45" src="https://github.com/user-attachments/assets/fb48e212-f0e1-4d22-b40d-7848c03dd339" />
