### PR TITLE
feat(summary): add spoiler section for summary v2

### DIFF
--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -2,7 +2,6 @@
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
   import RatingList from "$lib/components/summary/RatingList.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
-  import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaCrew } from "$lib/requests/models/MediaCrew";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
@@ -10,11 +9,11 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import Summary from "../../_internal/Summary.svelte";
   import MediaDetails from "../../details/MediaDetails.svelte";
-  import SummaryOverview from "../../summary/SummaryOverview.svelte";
   import type { MediaSummaryProps } from "../MediaSummaryProps";
   import { useMediaMetaInfo } from "../useMediaMetaInfo";
   import MediaActions from "./_internal/MediaActions.svelte";
   import SideActions from "./_internal/SideActions.svelte";
+  import SpoilerSection from "./_internal/SpoilerSection.svelte";
   import SummaryTitle from "./_internal/SummaryTitle.svelte";
 
   const {
@@ -58,9 +57,9 @@
     </RenderFor>
   {/snippet}
 
-  <Spoiler {media} {type}>
-    <SummaryOverview {title} overview={intl.overview ?? media.overview} />
-  </Spoiler>
+  <SpoilerSection {media} title="description">
+    {intl.overview ?? media.overview}
+  </SpoilerSection>
 
   <MediaDetails {media} {studios} {crew} {type} />
 </Summary>

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/SpoilerSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/SpoilerSection.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import DropIcon from "$lib/components/icons/DropIcon.svelte";
+  import ClampedText from "$lib/components/text/ClampedText.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import { useMediaSpoiler } from "$lib/features/spoilers/useMediaSpoiler";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import { writable } from "svelte/store";
+  import { slide } from "svelte/transition";
+
+  const {
+    media,
+    title,
+    children,
+  }: { media: MediaEntry; title: string } & ChildrenProps = $props();
+
+  const { isSpoilerHidden } = $derived(
+    useMediaSpoiler({ media, type: media.type }),
+  );
+  const isExpanded = writable(false);
+
+  // FIXME: i18n as design is finalized
+</script>
+
+{#snippet spoiler()}
+  <button
+    class="trakt-spoiler-section"
+    aria-label={$isExpanded
+      ? `Hide ${title} spoilers`
+      : `View ${title} spoilers`}
+    onclick={() => isExpanded.set(!$isExpanded)}
+    class:is-expanded={$isExpanded}
+  >
+    <div class="trakt-spoiler-section-header">
+      <p class="meta-info">
+        {$isExpanded ? `Hide ${title}` : `View ${title}`}
+      </p>
+      <p class="meta-info">Spoiler alert <DropIcon /></p>
+    </div>
+
+    {#if $isExpanded}
+      <div
+        class="trakt-spoiler-section-content"
+        transition:slide={{ duration: 150, axis: "y" }}
+      >
+        <p class="secondary">
+          {@render children()}
+        </p>
+      </div>
+    {/if}
+  </button>
+{/snippet}
+
+{#if $isSpoilerHidden}
+  {@render spoiler()}
+{:else}
+  <ClampedText
+    classList="secondary"
+    label={m.button_label_expand_media_overview({ title })}
+  >
+    {@render children()}
+  </ClampedText>
+{/if}
+
+<style>
+  .trakt-spoiler-section {
+    all: unset;
+    -webkit-tap-highlight-color: transparent;
+
+    display: flex;
+    flex-direction: column;
+
+    padding: var(--ni-8);
+    padding-left: var(--ni-12);
+
+    color: var(--color-foreground-red);
+    background-color: var(--red-900);
+
+    border-radius: var(--border-radius-xxl);
+    border: var(--ni-2) solid var(--color-background-red);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: background-color, color, border-color, border-radius;
+
+    .trakt-spoiler-section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      .meta-info {
+        display: flex;
+        align-items: center;
+        gap: var(--gap-xs);
+      }
+
+      :global(svg) {
+        width: var(--ni-16);
+        height: var(--ni-16);
+        transition: transform var(--transition-increment) ease-in-out;
+      }
+    }
+
+    .trakt-spoiler-section-content {
+      padding: var(--ni-8);
+    }
+
+    &.is-expanded {
+      background-color: transparent;
+      color: var(--color-foreground);
+      border-color: var(--red-900);
+      border-radius: var(--border-radius-l);
+
+      .trakt-spoiler-section-header {
+        :global(svg) {
+          transform: rotate(180deg);
+        }
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds spoiler section for media overview.
- @anodpixels is still to do a pass over the design/interaction.
  - i18n will be tackled when finalizing design.

## 👀 Example 👀

https://github.com/user-attachments/assets/b0b97180-040e-4b6a-8f84-7024435e0e31

