### PR TITLE
fix: update default popular and anticipated filters

### DIFF
--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -9,7 +9,6 @@ import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
-import { addYear } from '$lib/utils/date/addYear.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { MovieAnticipatedResponse } from '@trakt/api';
 import { z } from 'zod';
@@ -48,7 +47,6 @@ const movieAnticipatedRequest = (
         limit,
         ...filter,
         ...search,
-        end_date: addYear(new Date()).toISOString(),
       },
     });
 

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -9,7 +9,6 @@ import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
-import { addYear } from '$lib/utils/date/addYear.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { ShowAnticipatedResponse } from '@trakt/api';
 import { z } from 'zod';
@@ -55,7 +54,6 @@ const showAnticipatedRequest = (
         limit,
         ...filter,
         ...search,
-        end_date: addYear(new Date()).toISOString(),
       },
     });
 

--- a/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
@@ -13,6 +13,7 @@ import {
 } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import type { CreateQueryOptions } from '@tanstack/svelte-query';
+import { addYear } from '../../../utils/date/addYear.ts';
 
 export type AnticipatedEntry = AnticipatedMovie | AnticipatedShow;
 export type AnticipatedMediaList = Array<AnticipatedEntry>;
@@ -28,6 +29,14 @@ type AnticipatedListStoreProps =
 function typeToQuery(
   { type, ...params }: AnticipatedListStoreProps,
 ) {
+  if (!params.filter?.years) {
+    // FIXME: remove this when behavior is uplifted to the server
+    params.filter = params.filter ?? {};
+    // @ts-expect-error we are extending the object to dedupe
+    params.filter.end_date = params.filter?.end_date ??
+      addYear(new Date(), 1).toISOString();
+  }
+
   switch (type) {
     case 'movie':
       return movieAnticipatedQuery(params) as CreateQueryOptions<

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/requests/queries/shows/showPopularQuery.ts';
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import type { CreateQueryOptions } from '@tanstack/svelte-query';
+import { addYear } from '../../../utils/date/addYear.ts';
 
 export type PopularEntry = ShowEntry | MovieEntry;
 export type PopularMediaList = Array<PopularEntry>;
@@ -26,10 +27,16 @@ type PopularListStoreProps =
 function typeToQuery(
   { type, ...params }: PopularListStoreProps,
 ) {
-  // FIXME: remove this when behavior is uplifted to the server
-  params.filter = params.filter ?? {};
-  params.filter.years = params.filter?.years ??
-    new Date().getFullYear().toString();
+  if (!params.filter?.years) {
+    // FIXME: remove this when behavior is uplifted to the server
+    params.filter = params.filter ?? {};
+    // @ts-expect-error we are extending the object to dedupe
+    params.filter.start_date = params.filter?.start_date ??
+      addYear(new Date(), -1).toISOString();
+    // @ts-expect-error we are extending the object to dedupe
+    params.filter.end_date = params.filter?.end_date ??
+      addYear(new Date(), 0).toISOString();
+  }
 
   switch (type) {
     case 'movie':

--- a/projects/client/src/lib/utils/date/addYear.spec.ts
+++ b/projects/client/src/lib/utils/date/addYear.spec.ts
@@ -4,7 +4,7 @@ import { addYear } from './addYear.ts';
 describe('addYear', () => {
   it('should add one year to a regular date', () => {
     const date = new Date('2023-06-15');
-    const result = addYear(date);
+    const result = addYear(date, 1);
     expect(result.getFullYear()).toBe(2024);
     expect(result.getMonth()).toBe(date.getMonth());
     expect(result.getDate()).toBe(date.getDate());
@@ -12,7 +12,7 @@ describe('addYear', () => {
 
   it('should handle leap year to non-leap year transition', () => {
     const date = new Date('2024-02-29');
-    const result = addYear(date);
+    const result = addYear(date, 1);
     expect(result.getFullYear()).toBe(2025);
     expect(result.getMonth()).toBe(2); // March
     expect(result.getDate()).toBe(1); // Becomes March 1st
@@ -20,7 +20,7 @@ describe('addYear', () => {
 
   it('should handle non-leap year to leap year transition', () => {
     const date = new Date('2023-02-28');
-    const result = addYear(date);
+    const result = addYear(date, 1);
     expect(result.getFullYear()).toBe(2024);
     expect(result.getMonth()).toBe(1);
     expect(result.getDate()).toBe(28);
@@ -29,13 +29,13 @@ describe('addYear', () => {
   it('should not mutate the original date', () => {
     const originalDate = new Date('2023-06-15');
     const originalYear = originalDate.getFullYear();
-    addYear(originalDate);
+    addYear(originalDate, 1);
     expect(originalDate.getFullYear()).toBe(originalYear);
   });
 
   it('should handle year transition from 1999 to 2000', () => {
     const date = new Date('1999-12-31');
-    const result = addYear(date);
+    const result = addYear(date, 1);
     expect(result.getFullYear()).toBe(2000);
     expect(result.getMonth()).toBe(11); // December
     expect(result.getDate()).toBe(31);
@@ -43,10 +43,74 @@ describe('addYear', () => {
 
   it('should preserve time components', () => {
     const date = new Date('2023-06-15T14:30:45.123Z');
-    const result = addYear(date);
+    const result = addYear(date, 1);
     expect(result.getHours()).toBe(date.getHours());
     expect(result.getMinutes()).toBe(date.getMinutes());
     expect(result.getSeconds()).toBe(date.getSeconds());
     expect(result.getMilliseconds()).toBe(date.getMilliseconds());
+  });
+
+  it('should handle zero offset', () => {
+    const date = new Date('2023-06-15');
+    const result = addYear(date, 0);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it('should subtract one year', () => {
+    const date = new Date('2023-06-15');
+    const result = addYear(date, -1);
+    expect(result.getFullYear()).toBe(2022);
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it('should add two years', () => {
+    const date = new Date('2023-06-15');
+    const result = addYear(date, 2);
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it('should subtract two years', () => {
+    const date = new Date('2023-06-15');
+    const result = addYear(date, -2);
+    expect(result.getFullYear()).toBe(2021);
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it('should handle large positive offset', () => {
+    const date = new Date('2023-06-15');
+    const result = addYear(date, 100);
+    expect(result.getFullYear()).toBe(2123);
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it('should handle large negative offset', () => {
+    const date = new Date('2023-06-15');
+    const result = addYear(date, -100);
+    expect(result.getFullYear()).toBe(1923);
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it('should handle leap year with negative offset', () => {
+    const date = new Date('2024-02-29');
+    const result = addYear(date, -1);
+    expect(result.getFullYear()).toBe(2023);
+    expect(result.getMonth()).toBe(2); // March
+    expect(result.getDate()).toBe(1);
+  });
+
+  it('should handle non-leap year with positive offset to leap year', () => {
+    const date = new Date('2023-02-28');
+    const result = addYear(date, 2);
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(1);
+    expect(result.getDate()).toBe(28);
   });
 });

--- a/projects/client/src/lib/utils/date/addYear.ts
+++ b/projects/client/src/lib/utils/date/addYear.ts
@@ -1,5 +1,5 @@
-export function addYear(date: Date): Date {
+export function addYear(date: Date, offset: number): Date {
   const newDate = new Date(date);
-  newDate.setFullYear(newDate.getFullYear() + 1);
+  newDate.setFullYear(newDate.getFullYear() + offset);
   return newDate;
 }


### PR DESCRIPTION
Removes the hardcoded `end_date` from anticipated and popular list queries in the client, which would cause the queries to not return the proper results.

Also adds and fixes some tests to the `addYear` util function.
