### PR TITLE
Fix/filters

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -19,6 +19,7 @@ export const AnalyticsEvent = {
   Theme: buildEventKey(ACTION_PREFIX, 'theme'),
   Locale: buildEventKey(ACTION_PREFIX, 'locale'),
   Filter: buildEventKey(ACTION_PREFIX, 'filter'),
+  Filters: buildEventKey(ACTION_PREFIX, 'filters'),
 
   Drop: buildEventKey(MEDIA_ACTION_PREFIX, 'drop'),
   Restore: buildEventKey(MEDIA_ACTION_PREFIX, 'restore'),

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -7,6 +7,7 @@ import { AnalyticsEvent } from './AnalyticsEvent.ts';
 type ActionType = { action: 'add' | 'remove' };
 type RatingType = { action: 'added' | 'changed'; rating: SimpleRating };
 type FilterType = { id: string; action: 'set' | 'reset' };
+type FiltersType = { action: 'save' | 'reset' };
 type CheckInType = { type: 'episode' | 'movie'; action: 'start' | 'stop' };
 type FollowType = { action: 'follow' | 'unfollow' };
 type ExtrasType = { slug: string; type: MediaVideoType };
@@ -23,6 +24,7 @@ export type AnalyticsEventDataMap = {
   [AnalyticsEvent.Theme]: { theme: Theme };
   [AnalyticsEvent.Locale]: { locale: string };
   [AnalyticsEvent.Filter]: FilterType;
+  [AnalyticsEvent.Filters]: FiltersType;
 
   [AnalyticsEvent.Drop]: never;
   [AnalyticsEvent.Restore]: never;

--- a/projects/client/src/lib/features/filters/_internal/isDifferentFilterSet.spec.ts
+++ b/projects/client/src/lib/features/filters/_internal/isDifferentFilterSet.spec.ts
@@ -1,0 +1,80 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { describe, expect, it } from 'vitest';
+import type { StoredFilter } from '../useStoredFilters.ts';
+import { FILTERS } from './constants.ts';
+import { isDifferentFilterSet } from './isDifferentFilterSet.ts';
+
+function createSearchParams(obj: Record<string, string>) {
+  const params = new URLSearchParams();
+  Object.entries(obj).forEach(([key, value]) => {
+    params.set(key, value);
+  });
+  return params;
+}
+
+describe('isDifferentFilterSet', () => {
+  const filterKeys = FILTERS.map((f) => f.key).filter(Boolean);
+  const baseFilters: StoredFilter = {};
+  filterKeys.forEach((key, i) => {
+    baseFilters[key] = `value${i}`;
+  });
+
+  it('returns false when filters and searchParams match', () => {
+    const params = createSearchParams(
+      Object.fromEntries(
+        Object.entries(baseFilters).map(([k, v]) => [k, String(v)]),
+      ),
+    );
+
+    expect(isDifferentFilterSet(baseFilters, params)).toBe(false);
+  });
+
+  it('returns true when filters have different values', () => {
+    const changed = { ...baseFilters };
+    const firstKey = assertDefined(filterKeys.at(0));
+    changed[firstKey] = 'otherValue';
+
+    const params = createSearchParams(
+      Object.fromEntries(
+        Object.entries(changed).map(([k, v]) => [k, String(v)]),
+      ),
+    );
+
+    expect(isDifferentFilterSet(baseFilters, params)).toBe(true);
+  });
+
+  it('returns true when filters have different length', () => {
+    const firstKey = assertDefined(filterKeys.at(0));
+    const lessFilters = { [firstKey]: 'any_value' };
+
+    const params = createSearchParams(
+      Object.fromEntries(
+        Object.entries(lessFilters).map(([k, v]) => [k, String(v)]),
+      ),
+    );
+
+    expect(isDifferentFilterSet(baseFilters, params)).toBe(true);
+  });
+
+  it('ignores non-filter params in searchParams', () => {
+    const params = createSearchParams({
+      ...Object.fromEntries(
+        Object.entries(baseFilters).map(([k, v]) => [k, String(v)]),
+      ),
+      notAFilter: 'x',
+    });
+
+    expect(isDifferentFilterSet(baseFilters, params)).toBe(false);
+  });
+
+  it('returns true if searchParams missing a filter key', () => {
+    const paramObj = Object.fromEntries(
+      Object.entries(baseFilters).map(([k, v]) => [k, String(v)]),
+    );
+    const params = createSearchParams(paramObj);
+    const firstKey = assertDefined(filterKeys.at(0));
+    params.delete(firstKey);
+
+    expect(isDifferentFilterSet(baseFilters, params)).toBe(true);
+  });
+});

--- a/projects/client/src/lib/features/filters/_internal/isDifferentFilterSet.ts
+++ b/projects/client/src/lib/features/filters/_internal/isDifferentFilterSet.ts
@@ -1,0 +1,21 @@
+import type { FilterKey } from '../models/Filter.ts';
+import type { StoredFilter } from '../useStoredFilters.ts';
+import { FILTERS } from './constants.ts';
+
+export function isDifferentFilterSet(
+  filters: StoredFilter,
+  searchParams: URLSearchParams,
+) {
+  const filterKeys = FILTERS.map((filter) => filter.key);
+  const filterParams = Array.from(searchParams.entries())
+    .filter(([key]) => filterKeys.includes(key as FilterKey));
+
+  const currentFilters = Object.fromEntries(filterParams);
+
+  return (
+    Object.keys(filters).length !== filterParams.length ||
+    Object.entries(filters).some(([key, value]) =>
+      currentFilters[key] !== value
+    )
+  );
+}

--- a/projects/client/src/lib/features/filters/_internal/processFilterParams.ts
+++ b/projects/client/src/lib/features/filters/_internal/processFilterParams.ts
@@ -7,7 +7,7 @@ export function processFilterParams(
     | URLSearchParamsIterator<[string, ParameterType]>,
   callback: (key: string, value: ParameterType) => void,
 ) {
-  params.forEach(([key, value]) => {
+  Array.from(params).forEach(([key, value]) => {
     const isValidKey = FILTERS.some((filter) => filter.key === key);
     isValidKey && callback(key, value);
   });

--- a/projects/client/src/lib/features/filters/useFilter.ts
+++ b/projects/client/src/lib/features/filters/useFilter.ts
@@ -1,6 +1,8 @@
+import { page } from '$app/state';
 import type { FilterKey } from '$lib/features/filters/models/Filter.ts';
 import { useParameters } from '$lib/features/parameters/useParameters.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { derived, readable } from 'svelte/store';
 import { useUser } from '../auth/stores/useUser.ts';
 import { FILTERS } from './_internal/constants.ts';
@@ -8,10 +10,19 @@ import { isDifferentFilterSet } from './_internal/isDifferentFilterSet.ts';
 import { mapToSearchParamValue } from './_internal/mapToSearchParamValue.ts';
 import { useStoredFilters } from './useStoredFilters.ts';
 
+const UNSUPPORTED_ROUTES = [
+  UrlBuilder.profile.me(),
+  UrlBuilder.home(),
+  UrlBuilder.search(),
+] as const;
+
 export function useFilter() {
   const { search } = useParameters();
   const { user } = useUser();
   const { storedFilters } = useStoredFilters();
+
+  const hasFilterSupport = (route: string) =>
+    !UNSUPPORTED_ROUTES.includes(route);
 
   return {
     filters: readable(FILTERS),
@@ -29,11 +40,19 @@ export function useFilter() {
     hasActiveFilter: derived(
       [search, storedFilters],
       ([$search, $storedFilters]) => {
+        if (UNSUPPORTED_ROUTES.includes(page.route.id ?? '')) {
+          return false;
+        }
+
         const defaultFilters = $storedFilters ?? {};
         return isDifferentFilterSet(defaultFilters, $search);
       },
     ),
     filterMap: derived([search, user], ([$search, $user]) => {
+      if (!hasFilterSupport(page.route.id ?? '')) {
+        return {};
+      }
+
       return FILTERS
         .filter((filter) => {
           const hasParameter = Boolean($search.get(filter.key));
@@ -50,5 +69,6 @@ export function useFilter() {
           return filterMap;
         }, {} as Record<string, string>);
     }),
+    hasFilterSupport,
   };
 }

--- a/projects/client/src/lib/features/filters/useStoredFilters.ts
+++ b/projects/client/src/lib/features/filters/useStoredFilters.ts
@@ -2,6 +2,8 @@ import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { derived, get, writable } from 'svelte/store';
+import { AnalyticsEvent } from '../analytics/events/AnalyticsEvent.ts';
+import { useTrack } from '../analytics/useTrack.ts';
 import type { ParameterType } from '../parameters/_internal/createParameterContext.ts';
 import { useParameters } from '../parameters/useParameters.ts';
 import { FILTERS } from './_internal/constants.ts';
@@ -17,6 +19,7 @@ const storedFilters = writable<StoredFilter | null>(getDefaultFilters());
 
 export function useStoredFilters() {
   const { search } = useParameters();
+  const { track } = useTrack(AnalyticsEvent.Filters);
 
   const goToStoredFilters = (filters: StoredFilter) => {
     processFilterParams(
@@ -30,6 +33,8 @@ export function useStoredFilters() {
   };
 
   const saveFilters = () => {
+    track({ action: 'save' });
+
     const searchParams = get(search);
     const filtersObject: StoredFilter = {};
 
@@ -56,6 +61,8 @@ export function useStoredFilters() {
   };
 
   const resetFilters = () => {
+    track({ action: 'reset' });
+
     const defaultFilters = getDefaultFilters();
     if (!defaultFilters) {
       goto(page.url.pathname, { replaceState: true });

--- a/projects/client/src/lib/features/filters/useStoredFilters.ts
+++ b/projects/client/src/lib/features/filters/useStoredFilters.ts
@@ -1,7 +1,7 @@
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
-import { get } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 import type { ParameterType } from '../parameters/_internal/createParameterContext.ts';
 import { useParameters } from '../parameters/useParameters.ts';
 import { FILTERS } from './_internal/constants.ts';
@@ -11,7 +11,9 @@ import { processFilterParams } from './_internal/processFilterParams.ts';
 
 export const STORED_FILTERS_KEY = 'trakt-global-filters' as const;
 
-type StoredFilter = Record<string, ParameterType>;
+export type StoredFilter = Record<string, ParameterType>;
+
+const storedFilters = writable<StoredFilter | null>(getDefaultFilters());
 
 export function useStoredFilters() {
   const { search } = useParameters();
@@ -38,6 +40,7 @@ export function useStoredFilters() {
       },
     );
 
+    storedFilters.set(filtersObject);
     safeLocalStorage.setItem(STORED_FILTERS_KEY, JSON.stringify(filtersObject));
   };
 
@@ -67,5 +70,6 @@ export function useStoredFilters() {
     saveFilters,
     restoreFilters,
     resetFilters,
+    storedFilters: derived(storedFilters, ($storedFilters) => $storedFilters),
   };
 }

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import Button from "$lib/components/buttons/Button.svelte";
   import FilterIcon from "$lib/components/icons/FilterIcon.svelte";
   import { useFilter } from "$lib/features/filters/useFilter";
@@ -8,21 +9,24 @@
   import FilterSidebar from "./FilterSidebar.svelte";
 
   const { size }: { size: "small" | "normal" } = $props();
-  const { hasActiveFilter } = useFilter();
+  const { hasActiveFilter, hasFilterSupport } = useFilter();
 
   const state = $derived($hasActiveFilter ? "filtered" : "unfiltered");
 
   const isSidebarOpen = writable(false);
   const onClose = () => isSidebarOpen.set(false);
+
+  const isDisabled = $derived(!hasFilterSupport(page.route.id ?? ""));
 </script>
 
-<div class="trakt-filter-button">
+<div class="trakt-filter-button" class:has-filter-support={!isDisabled}>
   <Button
     style="flat"
     label={m.button_label_filters()}
     text="capitalize"
     color="custom"
     {size}
+    disabled={isDisabled}
     navigationType={DpadNavigationType.Item}
     onclick={() => {
       isSidebarOpen.set(true);
@@ -45,6 +49,17 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-filter-button {
+    opacity: 0.25;
+    transition: opacity var(--transition-increment) ease-in-out;
+
+    &.has-filter-support {
+      opacity: 1;
+    }
+
+    :global(.trakt-button[disabled]) {
+      background: transparent;
+    }
+
     @include for-mouse {
       :global(.trakt-button) {
         &:hover,

--- a/projects/client/src/lib/sections/navbar/components/filter/_internal/ResetAllButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/_internal/ResetAllButton.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  import { page } from "$app/state";
   import Button from "$lib/components/buttons/Button.svelte";
   import { useFilter } from "$lib/features/filters/useFilter";
+  import { useStoredFilters } from "$lib/features/filters/useStoredFilters";
   import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import GlobalParameterEscaper from "$lib/features/parameters/GlobalParameterEscaper.svelte";
 
   const { hasActiveFilter } = useFilter();
+  const { resetFilters } = useStoredFilters();
 </script>
 
 <GlobalParameterEscaper enabled>
@@ -17,7 +18,7 @@
     style="flat"
     variant="secondary"
     disabled={!$hasActiveFilter || undefined}
-    href={page.url.pathname}
+    onclick={resetFilters}
     navigationType={DpadNavigationType.Item}
   >
     {m.button_text_reset_all_filters()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Resetting filters now resets to the saved ones.
- Filter button is only marked as `active` when deviating from the saved ones (if there are any).
- Small fix to using `forEach` on `URLSearchParamsIterator`; should now work on older browsers.
- Filtering is disabled on `home`, `search` and your profile page.
  - I went with disabling the button instead of hiding it; the content jump gets really annoying.
- Adds telemetry to saving and resetting filters (individual filters already have tracking).

## 👀 Example 👀

https://github.com/user-attachments/assets/4f48b6c6-1b7c-4c3b-8cb7-045dfe53ab69

