### PR TITLE
chore(analytics): also add telemetry for summary drilldowns

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -21,6 +21,7 @@ export const AnalyticsEvent = {
   Filter: buildEventKey(ACTION_PREFIX, 'filter'),
   Filters: buildEventKey(ACTION_PREFIX, 'filters'),
   Drilldown: buildEventKey(ACTION_PREFIX, 'drilldown'),
+  SummaryDrilldown: buildEventKey(ACTION_PREFIX, 'summary-drilldown'),
   Search: buildEventKey(ACTION_PREFIX, 'search'),
 
   Drop: buildEventKey(MEDIA_ACTION_PREFIX, 'drop'),

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -29,6 +29,7 @@ export type AnalyticsEventDataMap = {
   [AnalyticsEvent.Filter]: FilterType;
   [AnalyticsEvent.Filters]: FiltersType;
   [AnalyticsEvent.Drilldown]: DrilldownType;
+  [AnalyticsEvent.SummaryDrilldown]: DrilldownType;
   [AnalyticsEvent.Search]: SearchType;
 
   [AnalyticsEvent.Drop]: never;

--- a/projects/client/src/lib/features/search/SearchResultsGrid.svelte
+++ b/projects/client/src/lib/features/search/SearchResultsGrid.svelte
@@ -66,11 +66,13 @@
           type={item.type}
           media={item}
           style="cover"
+          source="search"
           tag={$mode === "media" ? mediaResultTag : undefined}
         />
       {:else}
         <DefaultPersonItem
           person={item}
+          source="search"
           subtitle={item.birthday
             ? toHumanDay(item.birthday, getLocale(), "short")
             : undefined}

--- a/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
+++ b/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
@@ -27,7 +27,7 @@
             class="trakt-item-wrapper"
             class:has-offset={!isOddColumn(index)}
           >
-            <DefaultMediaItem {type} media={item} />
+            <DefaultMediaItem {type} media={item} source="trending" />
           </div>
         {/each}
       </div>

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -60,7 +60,7 @@
   --height-list={mediaListHeightResolver($defaultVariant)}
 >
   {#snippet item(media)}
-    <DefaultMediaItem {type} {media} />
+    <DefaultMediaItem {type} {media} source="credits" />
   {/snippet}
 
   {#snippet dynamicActions()}

--- a/projects/client/src/lib/sections/lists/FavoritesList.svelte
+++ b/projects/client/src/lib/sections/lists/FavoritesList.svelte
@@ -50,7 +50,11 @@
   --height-list={mediaListHeightResolver($defaultVariant)}
 >
   {#snippet item(media)}
-    <DefaultMediaItem type={media.item.type} media={media.item}>
+    <DefaultMediaItem
+      type={media.item.type}
+      media={media.item}
+      source="favorites"
+    >
       {#snippet popupActions()}
         <FavoriteAction
           style="dropdown-item"

--- a/projects/client/src/lib/sections/lists/RelatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedList.svelte
@@ -21,6 +21,6 @@
   {title}
 >
   {#snippet item(media)}
-    <DefaultMediaItem {type} {media} />
+    <DefaultMediaItem {type} {media} source="related" />
   {/snippet}
 </MediaList>

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -12,4 +12,11 @@
   <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
 {/snippet}
 
-<DefaultMediaItem {type} {media} {tag} {style} canDeemphasize />
+<DefaultMediaItem
+  {type}
+  {media}
+  {tag}
+  {style}
+  source="anticipated"
+  canDeemphasize
+/>

--- a/projects/client/src/lib/sections/lists/components/DefaultPersonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultPersonItem.svelte
@@ -3,17 +3,28 @@
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import PersonCard from "$lib/components/people/card/PersonCard.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
-  const { person, subtitle }: { person: PersonSummary; subtitle?: string } =
-    $props();
+  const {
+    person,
+    subtitle,
+    source,
+  }: { person: PersonSummary; subtitle?: string; source?: string } = $props();
+
+  const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 </script>
 
 <PersonCard>
-  <Link focusable={false} href={UrlBuilder.people(person.slug)}>
+  <Link
+    focusable={false}
+    href={UrlBuilder.people(person.slug)}
+    onclick={() => source && track({ source, type: "person" })}
+  >
     <CardCover
       title={person.name}
       src={person.headshot.url.thumb}

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -6,6 +6,8 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
@@ -21,8 +23,11 @@
     tag,
     action,
     popupActions,
+    source,
     ...rest
   }: MediaCardProps = $props();
+
+  const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 
   const defaultVariant = $derived(useDefaultCardVariant(type));
   const variant = $derived(rest.variant ?? $defaultVariant);
@@ -41,7 +46,11 @@
     </CardActionBar>
   {/if}
 
-  <Link focusable={false} href={UrlBuilder.media(type, media.slug)}>
+  <Link
+    focusable={false}
+    href={UrlBuilder.media(type, media.slug)}
+    onclick={() => source && track({ source, type: media.type })}
+  >
     <CardCover
       title={media.title}
       src={mediaCoverImageUrl}

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -18,6 +18,7 @@ type BaseItemProps<T> = MediaItemVariant<T> & {
   action?: Snippet;
   popupActions?: Snippet;
   style?: 'cover' | 'summary';
+  source?: string;
 };
 
 export type MediaCardProps<T = MediaInputDefault> = BaseItemProps<T> & {

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -7,6 +7,8 @@
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import Link from "$lib/components/link/Link.svelte";
   import GenreList from "$lib/components/summary/GenreList.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
@@ -24,8 +26,11 @@
     badge,
     popupActions,
     media,
+    source,
     ...rest
   }: MediaCardProps | EpisodeCardProps = $props();
+
+  const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 
   const toEpisodeCover = (episode: EpisodeEntry) => {
     switch (episode.type) {
@@ -56,7 +61,11 @@
     </CardActionBar>
   {/if}
 
-  <Link href={UrlBuilder.media(media.type, media.slug)} color="inherit">
+  <Link
+    href={UrlBuilder.media(media.type, media.slug)}
+    color="inherit"
+    onclick={() => source && track({ source, type: media.type })}
+  >
     {#if rest.type === "episode"}
       <CardCover
         {badge}

--- a/projects/client/src/lib/sections/lists/popular/PopularListItem.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularListItem.svelte
@@ -7,4 +7,11 @@
     $props();
 </script>
 
-<DefaultMediaItem {type} {media} {style} {popupActions} canDeemphasize />
+<DefaultMediaItem
+  {type}
+  {media}
+  {style}
+  {popupActions}
+  source="popular"
+  canDeemphasize
+/>

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
@@ -6,4 +6,4 @@
   const { type, media, style }: MediaCardProps<RecommendedEntry> = $props();
 </script>
 
-<DefaultMediaItem {type} {media} {style} canDeemphasize />
+<DefaultMediaItem {type} {media} {style} source="recommended" canDeemphasize />

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -12,4 +12,11 @@
   <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
 {/snippet}
 
-<DefaultMediaItem {type} {media} {tag} {style} canDeemphasize />
+<DefaultMediaItem
+  {type}
+  {media}
+  {tag}
+  {style}
+  source="trending"
+  canDeemphasize
+/>

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistItem.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistItem.svelte
@@ -25,4 +25,5 @@
   {media}
   {style}
   action={media.status === "released" ? action : undefined}
+  source="watchlist"
 />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Summary drilldown telemetry for media & person cards
  - To follow: episode/activity items