### PR TITLE
refactor: remove unnecessary url replacement

### DIFF
--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -7,9 +7,6 @@ import { getMarker } from '../../utils/date/Marker.ts';
 
 const SESSION_STORAGE_REFRESH_KEY = 'trakt:is_refreshing';
 
-const stripHttpsOrHttp = (url: string): string =>
-  url.replace(/^https?:\/\//, '');
-
 function shouldReloadPage(expiresAt: number | Nil) {
   if (getUserManager()) {
     // FIXME: completely remove this refresh flow when fully switching to oidc-client-ts
@@ -39,14 +36,6 @@ export function createAuthenticatedFetch<
 
       if (token) {
         headers.set('Authorization', `Bearer ${token}`);
-      }
-
-      if (!input.toString().includes('watchnow')) {
-        input = input.toString()
-          .replaceAll(
-            stripHttpsOrHttp(TRAKT_TARGET_ENVIRONMENT),
-            stripHttpsOrHttp(TRAKT_TARGET_API_ENVIRONMENT),
-          );
       }
 
       const method = init?.method?.toUpperCase();


### PR DESCRIPTION
Removes the logic that replaced the URL in the request to the Trakt API.

We'll delegate this to the server.
