### PR TITLE
Feat/episode summary

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -2,12 +2,16 @@
   import * as m from "$lib/features/i18n/messages";
 
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import SeasonList from "$lib/sections/lists/season/SeasonList.svelte";
   import CastList from "../lists/CastList.svelte";
   import MediaWatchHistoryList from "../lists/history/MediaWatchHistoryList.svelte";
   import RelatedList from "../lists/RelatedList.svelte";
   import Comments from "./components/comments/Comments.svelte";
   import EpisodeSummary from "./components/episode/EpisodeSummary.svelte";
+  import EpisodeSummaryV2 from "./components/episode/v2/EpisodeSummary.svelte";
   import type { EpisodeSummaryProps } from "./components/EpisodeSummaryProps";
 
   const {
@@ -32,7 +36,33 @@
   type="show"
 />
 
-<EpisodeSummary {episode} {show} {showIntl} {episodeIntl} {streamOn} {crew} />
+<RenderFor audience="all" device={["mobile"]}>
+  <RenderForFeature flag={FeatureFlag.SummaryV2}>
+    {#snippet enabled()}
+      <EpisodeSummaryV2
+        {episode}
+        {show}
+        {showIntl}
+        {episodeIntl}
+        {streamOn}
+        {crew}
+      />
+    {/snippet}
+
+    <EpisodeSummary
+      {episode}
+      {show}
+      {showIntl}
+      {episodeIntl}
+      {streamOn}
+      {crew}
+    />
+  </RenderForFeature>
+</RenderFor>
+
+<RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
+  <EpisodeSummary {episode} {show} {showIntl} {episodeIntl} {streamOn} {crew} />
+</RenderFor>
 
 <CastList title={m.list_title_actors()} cast={crew.cast} slug={show.slug} />
 

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -2,33 +2,13 @@
   import * as m from "$lib/features/i18n/messages";
 
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
-  import Link from "$lib/components/link/Link.svelte";
-  import GenreList from "$lib/components/summary/GenreList.svelte";
-  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
-  import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import SeasonList from "$lib/sections/lists/season/SeasonList.svelte";
-  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
-  import { useWatchCount } from "$lib/stores/useWatchCount";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CastList from "../lists/CastList.svelte";
   import MediaWatchHistoryList from "../lists/history/MediaWatchHistoryList.svelte";
   import RelatedList from "../lists/RelatedList.svelte";
-  import CheckInAction from "../media-actions/check-in/CheckInAction.svelte";
   import Comments from "./components/comments/Comments.svelte";
-  import MediaDetails from "./components/details/MediaDetails.svelte";
-  import MediaStreamingServices from "./components/details/MediaStreamingServices.svelte";
+  import EpisodeSummary from "./components/episode/EpisodeSummary.svelte";
   import type { EpisodeSummaryProps } from "./components/EpisodeSummaryProps";
-  import MediaMetaInfo from "./components/media/MediaMetaInfo.svelte";
-  import StreamOnOverlay from "./components/overlay/StreamOnOverlay.svelte";
-  import RateNow from "./components/rating/RateNow.svelte";
-  import StreamOnButton from "./components/stream/StreamOnButton.svelte";
-  import SummaryActions from "./components/summary/SummaryActions.svelte";
-  import SummaryContainer from "./components/summary/SummaryContainer.svelte";
-  import SummaryHeader from "./components/summary/SummaryHeader.svelte";
-  import SummaryOverview from "./components/summary/SummaryOverview.svelte";
-  import SummaryTitle from "./components/summary/SummaryTitle.svelte";
 
   const {
     episode,
@@ -39,38 +19,8 @@
     streamOn,
     crew,
   }: EpisodeSummaryProps = $props();
-  const type = "episode";
-
-  const title = $derived(episodeIntl.title ?? episode.title);
-  const overview = $derived(episodeIntl.overview ?? episode.overview);
-  const showTitle = $derived(showIntl.title ?? show.title);
-  const { watchCount } = $derived(useWatchCount({ show, episode, type }));
 </script>
 
-{#snippet mediaActions(size: "small" | "normal" = "normal")}
-  <RenderFor audience="authenticated" navigation="dpad">
-    <StreamOnButton
-      {streamOn}
-      {type}
-      {episode}
-      media={show}
-      style="normal"
-      size="normal"
-    />
-  </RenderFor>
-  <MarkAsWatchedAction
-    style="normal"
-    {type}
-    {title}
-    media={episode}
-    {show}
-    {size}
-    allowRewatch={$watchCount > 0}
-  />
-  <RenderFor audience="authenticated" navigation="dpad">
-    <RateNow type="episode" media={episode} {show} />
-  </RenderFor>
-{/snippet}
 <!-- 
   Episodes don't have their own colors, so we fallback to their show's color
   if available. This approach ensures visual consistency between a show and its
@@ -82,99 +32,7 @@
   type="show"
 />
 
-<SummaryContainer>
-  {#snippet poster()}
-    <SummaryPoster
-      src={show.poster.url.medium}
-      alt={title}
-      href={streamOn?.preferred?.link}
-    >
-      {#snippet hoverOverlay()}
-        <StreamOnOverlay service={streamOn?.preferred} />
-      {/snippet}
-      {#snippet actions()}
-        <RenderFor device={["tablet-lg", "desktop"]} audience="authenticated">
-          {@render mediaActions()}
-        </RenderFor>
-      {/snippet}
-    </SummaryPoster>
-  {/snippet}
-
-  <SummaryHeader>
-    {#snippet headerActions()}
-      <RenderFor audience="authenticated" navigation="default">
-        <CheckInAction
-          style="normal"
-          size="small"
-          {title}
-          {type}
-          {show}
-          {episode}
-        />
-      </RenderFor>
-      <ShareButton
-        {title}
-        textFactory={({ title }) =>
-          m.text_share_episode({
-            title,
-            show: showTitle,
-            season: episode.season,
-            episode: episode.number,
-          })}
-        source={{ id: "episode" }}
-      />
-    {/snippet}
-    <SummaryTitle {title} />
-    <Link href={UrlBuilder.show(show.slug)}>
-      <h6>{showTitle}</h6>
-    </Link>
-    <p class="meta-info">{m.text_season_episode_number(episode)}</p>
-    <GenreList genres={show.genres} />
-  </SummaryHeader>
-
-  <MediaMetaInfo
-    watchCount={$watchCount}
-    {streamOn}
-    {type}
-    {episode}
-    media={show}
-  />
-
-  <Spoiler media={episode} {show} {type}>
-    <SummaryOverview {title} {overview} />
-  </Spoiler>
-
-  <RenderFor audience="authenticated">
-    <SummaryActions>
-      {#snippet contextualActions()}
-        <RenderFor audience="authenticated" navigation="default">
-          <RateNow type="episode" media={episode} {show} />
-        </RenderFor>
-      {/snippet}
-
-      <RenderFor device={["tablet-sm"]} audience="authenticated">
-        {@render mediaActions()}
-      </RenderFor>
-
-      <RenderFor device={["mobile"]} audience="authenticated">
-        {@render mediaActions("small")}
-      </RenderFor>
-    </SummaryActions>
-  </RenderFor>
-</SummaryContainer>
-
-<RenderFor audience="all" navigation="default">
-  <SummaryContainer>
-    <MediaDetails {episode} {crew} type="episode" />
-
-    {#if streamOn}
-      <MediaStreamingServices
-        services={streamOn.services}
-        preferred={streamOn.preferred}
-      />
-    {/if}
-  </SummaryContainer>
-</RenderFor>
+<EpisodeSummary {episode} {show} {showIntl} {episodeIntl} {streamOn} {crew} />
 
 <CastList title={m.list_title_actors()} cast={crew.cast} slug={show.slug} />
 

--- a/projects/client/src/lib/sections/summary/components/_internal/SpoilerSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SpoilerSection.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
   import DropIcon from "$lib/components/icons/DropIcon.svelte";
   import { useMediaSpoiler } from "$lib/features/spoilers/useMediaSpoiler";
-  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { MediaStoreProps } from "$lib/models/MediaStoreProps";
   import { writable } from "svelte/store";
   import { slide } from "svelte/transition";
 
   const {
-    media,
     title,
     children,
-  }: { media: MediaEntry; title: string } & ChildrenProps = $props();
+    ...target
+  }: { title: string } & ChildrenProps & MediaStoreProps = $props();
 
-  const { isSpoilerHidden } = $derived(
-    useMediaSpoiler({ media, type: media.type }),
-  );
+  const { isSpoilerHidden } = $derived(useMediaSpoiler(target));
   const isExpanded = writable(false);
 
   // FIXME: i18n as design is finalized

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryActions.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  const { children }: ChildrenProps = $props();
+</script>
+
+<div class="trakt-summary-actions">
+  {@render children()}
+</div>
+
+<style>
+  .trakt-summary-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-xs);
+
+    position: relative;
+
+    height: var(--ni-56);
+    width: var(--ni-272);
+
+    padding: var(--ni-8) var(--ni-10);
+    box-sizing: border-box;
+
+    background-color: var(--color-card-background);
+    border-radius: var(--border-radius-l);
+    box-shadow: var(--popup-shadow);
+
+    :global(.trakt-button) {
+      flex-grow: 1;
+
+      flex-direction: row-reverse;
+      justify-content: flex-end;
+    }
+
+    :global(.trakt-popup-menu-button) {
+      color: var(--color-text-primary);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryRateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryRateNow.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { RateNowProps } from "../rating/models/RateNowProps";
+  import RateNow from "../rating/RateNow.svelte";
+
+  const { ...target }: RateNowProps = $props();
+</script>
+
+<div class="trakt-summary-rate-now">
+  <RateNow {...target} isAlwaysVisible />
+</div>
+
+<style>
+  /* FIXME: When ratings are redesigned, remove this */
+  .trakt-summary-rate-now {
+    :global(h6) {
+      display: none;
+    }
+
+    :global(svg) {
+      --icon-color: var(--color-text-primary);
+    }
+
+    :global(.is-current-rating svg) {
+      --icon-fill-color: var(--color-text-primary);
+    }
+
+    :global(.trakt-action-button[disabled]) {
+      background-color: transparent;
+      opacity: 0.3;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import GenreList from "$lib/components/summary/GenreList.svelte";
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import CheckInAction from "$lib/sections/media-actions/check-in/CheckInAction.svelte";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { useWatchCount } from "$lib/stores/useWatchCount";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import MediaDetails from "../details/MediaDetails.svelte";
+  import MediaStreamingServices from "../details/MediaStreamingServices.svelte";
+  import type { EpisodeSummaryProps } from "./../EpisodeSummaryProps";
+  import MediaMetaInfo from "./../media/MediaMetaInfo.svelte";
+  import StreamOnOverlay from "./../overlay/StreamOnOverlay.svelte";
+  import RateNow from "./../rating/RateNow.svelte";
+  import StreamOnButton from "./../stream/StreamOnButton.svelte";
+  import SummaryActions from "./../summary/SummaryActions.svelte";
+  import SummaryContainer from "./../summary/SummaryContainer.svelte";
+  import SummaryHeader from "./../summary/SummaryHeader.svelte";
+  import SummaryOverview from "./../summary/SummaryOverview.svelte";
+  import SummaryTitle from "./../summary/SummaryTitle.svelte";
+
+  const {
+    episode,
+    show,
+    showIntl,
+    episodeIntl,
+    streamOn,
+    crew,
+  }: Omit<EpisodeSummaryProps, "seasons"> = $props();
+  const type = "episode";
+
+  const title = $derived(episodeIntl.title ?? episode.title);
+  const overview = $derived(episodeIntl.overview ?? episode.overview);
+  const showTitle = $derived(showIntl.title ?? show.title);
+  const { watchCount } = $derived(useWatchCount({ show, episode, type }));
+</script>
+
+{#snippet mediaActions(size: "small" | "normal" = "normal")}
+  <RenderFor audience="authenticated" navigation="dpad">
+    <StreamOnButton
+      {streamOn}
+      {type}
+      {episode}
+      media={show}
+      style="normal"
+      size="normal"
+    />
+  </RenderFor>
+  <MarkAsWatchedAction
+    style="normal"
+    {type}
+    {title}
+    media={episode}
+    {show}
+    {size}
+    allowRewatch={$watchCount > 0}
+  />
+  <RenderFor audience="authenticated" navigation="dpad">
+    <RateNow type="episode" media={episode} {show} />
+  </RenderFor>
+{/snippet}
+
+<SummaryContainer>
+  {#snippet poster()}
+    <SummaryPoster
+      src={show.poster.url.medium}
+      alt={title}
+      href={streamOn?.preferred?.link}
+    >
+      {#snippet hoverOverlay()}
+        <StreamOnOverlay service={streamOn?.preferred} />
+      {/snippet}
+      {#snippet actions()}
+        <RenderFor device={["tablet-lg", "desktop"]} audience="authenticated">
+          {@render mediaActions()}
+        </RenderFor>
+      {/snippet}
+    </SummaryPoster>
+  {/snippet}
+
+  <SummaryHeader>
+    {#snippet headerActions()}
+      <RenderFor audience="authenticated" navigation="default">
+        <CheckInAction
+          style="normal"
+          size="small"
+          {title}
+          {type}
+          {show}
+          {episode}
+        />
+      </RenderFor>
+      <ShareButton
+        {title}
+        textFactory={({ title }) =>
+          m.text_share_episode({
+            title,
+            show: showTitle,
+            season: episode.season,
+            episode: episode.number,
+          })}
+        source={{ id: "episode" }}
+      />
+    {/snippet}
+    <SummaryTitle {title} />
+    <Link href={UrlBuilder.show(show.slug)}>
+      <h6>{showTitle}</h6>
+    </Link>
+    <p class="meta-info">{m.text_season_episode_number(episode)}</p>
+    <GenreList genres={show.genres} />
+  </SummaryHeader>
+
+  <MediaMetaInfo
+    watchCount={$watchCount}
+    {streamOn}
+    {type}
+    {episode}
+    media={show}
+  />
+
+  <Spoiler media={episode} {show} {type}>
+    <SummaryOverview {title} {overview} />
+  </Spoiler>
+
+  <RenderFor audience="authenticated">
+    <SummaryActions>
+      {#snippet contextualActions()}
+        <RenderFor audience="authenticated" navigation="default">
+          <RateNow type="episode" media={episode} {show} />
+        </RenderFor>
+      {/snippet}
+
+      <RenderFor device={["tablet-sm"]} audience="authenticated">
+        {@render mediaActions()}
+      </RenderFor>
+
+      <RenderFor device={["mobile"]} audience="authenticated">
+        {@render mediaActions("small")}
+      </RenderFor>
+    </SummaryActions>
+  </RenderFor>
+</SummaryContainer>
+
+<RenderFor audience="all" navigation="default">
+  <SummaryContainer>
+    <MediaDetails {episode} {crew} type="episode" />
+
+    {#if streamOn}
+      <MediaStreamingServices
+        services={streamOn.services}
+        preferred={streamOn.preferred}
+      />
+    {/if}
+  </SummaryContainer>
+</RenderFor>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import RatingList from "$lib/components/summary/RatingList.svelte";
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { useWatchCount } from "$lib/stores/useWatchCount";
+  import SpoilerSection from "../../_internal/SpoilerSection.svelte";
+  import Summary from "../../_internal/Summary.svelte";
+  import SummaryRateNow from "../../_internal/SummaryRateNow.svelte";
+  import MediaDetails from "../../details/MediaDetails.svelte";
+  import { useMediaMetaInfo } from "../../media/useMediaMetaInfo";
+  import SummaryTitle from "../../media/v2/_internal/SummaryTitle.svelte";
+  import type { EpisodeSummaryProps } from "./../../EpisodeSummaryProps";
+  import EpisodeActions from "./_internal/EpisodeActions.svelte";
+  import EpisodeSideActions from "./_internal/EpisodeSideActions.svelte";
+  import EpisodeTitle from "./_internal/EpisodeTitle.svelte";
+
+  const {
+    episode,
+    show,
+    showIntl,
+    episodeIntl,
+    streamOn,
+    crew,
+  }: Omit<EpisodeSummaryProps, "seasons"> = $props();
+  const type = "episode";
+
+  const title = $derived(episodeIntl.title ?? episode.title);
+  const overview = $derived(episodeIntl.overview ?? episode.overview);
+  const showTitle = $derived(showIntl.title ?? show.title);
+  const { watchCount } = $derived(useWatchCount({ show, episode, type }));
+  const { ratings } = $derived(
+    useMediaMetaInfo({ type, episode, media: show }),
+  );
+</script>
+
+<Summary>
+  {#snippet poster()}
+    <SummaryPoster
+      src={show.poster.url.medium}
+      alt={title}
+      href={streamOn?.preferred?.link}
+    />
+  {/snippet}
+
+  {#snippet sideActions()}
+    <EpisodeSideActions {title} {showTitle} {episode} />
+  {/snippet}
+
+  {#snippet meta()}
+    <RatingList ratings={$ratings} airDate={episode.airDate} />
+    <EpisodeTitle {episode} {show} {showIntl} />
+    <SummaryTitle {title} genres={show.genres} year={episode.year} />
+
+    <RenderFor audience="authenticated">
+      <EpisodeActions {episode} {show} {streamOn} {title} {showTitle} />
+      <SummaryRateNow {type} media={episode} {show} />
+    </RenderFor>
+  {/snippet}
+
+  <SpoilerSection media={episode} {show} {type} title="description">
+    <p class="secondary">{overview}</p>
+  </SpoilerSection>
+
+  <MediaDetails {episode} {crew} {type} />
+</Summary>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeActions.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import type { StreamOn } from "$lib/requests/models/StreamOn";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { useWatchCount } from "$lib/stores/useWatchCount";
+  import SummaryActions from "../../../_internal/SummaryActions.svelte";
+  import { TrackIntlProvider } from "../../../media/v2/_internal/TrackIntlProvider";
+  import EpisodeActionsPopupMenu from "./EpisodeActionsPopupMenu.svelte";
+
+  const {
+    episode,
+    show,
+    title,
+    showTitle,
+    streamOn,
+  }: {
+    episode: EpisodeEntry;
+    show: ShowEntry;
+    title: string;
+    showTitle: string;
+    streamOn?: StreamOn;
+  } = $props();
+
+  const { watchCount } = $derived(
+    useWatchCount({ show, episode, type: "episode" }),
+  );
+</script>
+
+<SummaryActions>
+  <MarkAsWatchedAction
+    style="normal"
+    type="episode"
+    {title}
+    media={episode}
+    {show}
+    size="small"
+    allowRewatch={$watchCount > 0}
+    i18n={TrackIntlProvider}
+  />
+
+  <EpisodeActionsPopupMenu {episode} {show} {title} {showTitle} {streamOn} />
+</SummaryActions>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeActionsPopupMenu.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeActionsPopupMenu.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import type { StreamOn } from "$lib/requests/models/StreamOn";
+  import CheckInAction from "$lib/sections/media-actions/check-in/CheckInAction.svelte";
+  import StreamOnButton from "../../../stream/StreamOnButton.svelte";
+  import EpisodeSideActions from "./EpisodeSideActions.svelte";
+
+  const {
+    episode,
+    show,
+    title,
+    showTitle,
+    streamOn,
+  }: {
+    episode: EpisodeEntry;
+    show: ShowEntry;
+    title: string;
+    showTitle: string;
+    streamOn?: StreamOn;
+  } = $props();
+</script>
+
+<PopupMenu label={m.button_label_popup_menu({ title })} size="normal">
+  {#snippet items()}
+    <StreamOnButton
+      {streamOn}
+      {episode}
+      media={show}
+      type="episode"
+      style="dropdown-item"
+      size="small"
+    />
+
+    <CheckInAction
+      {show}
+      {episode}
+      {title}
+      size="small"
+      style="dropdown-item"
+      type="episode"
+    />
+
+    <EpisodeSideActions {title} {showTitle} {episode} style="dropdown-item" />
+  {/snippet}
+</PopupMenu>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeSideActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeSideActions.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+
+  const {
+    title,
+    showTitle,
+    episode,
+    style = "action",
+  }: {
+    title: string;
+    showTitle: string;
+    episode: EpisodeEntry;
+    style?: "action" | "dropdown-item";
+  } = $props();
+</script>
+
+<ShareButton
+  {title}
+  {style}
+  textFactory={({ title }) =>
+    m.text_share_episode({
+      title,
+      show: showTitle,
+      season: episode.season,
+      episode: episode.number,
+    })}
+  source={{ id: "episode" }}
+/>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodeTitle.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+
+  import Link from "$lib/components/link/Link.svelte";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { MediaIntl } from "$lib/requests/models/MediaIntl";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  const {
+    episode,
+    show,
+    showIntl,
+  }: {
+    episode: EpisodeEntry;
+    show: ShowEntry;
+    showIntl: MediaIntl;
+  } = $props();
+
+  const showTitle = $derived(showIntl.title ?? show.title);
+</script>
+
+<div class="trakt-summary-episode-title">
+  <Link href={UrlBuilder.show(show.slug)}>
+    <h6>{showTitle}</h6>
+  </Link>
+  <p class="meta-info">{m.text_season_episode_number(episode)}</p>
+</div>
+
+<style>
+  .trakt-summary-episode-title {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -7,14 +7,14 @@
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaStudio } from "$lib/requests/models/MediaStudio";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import SpoilerSection from "../../_internal/SpoilerSection.svelte";
   import Summary from "../../_internal/Summary.svelte";
+  import SummaryRateNow from "../../_internal/SummaryRateNow.svelte";
   import MediaDetails from "../../details/MediaDetails.svelte";
-  import RateNow from "../../rating/RateNow.svelte";
   import type { MediaSummaryProps } from "../MediaSummaryProps";
   import { useMediaMetaInfo } from "../useMediaMetaInfo";
   import MediaActions from "./_internal/MediaActions.svelte";
   import SideActions from "./_internal/SideActions.svelte";
-  import SpoilerSection from "./_internal/SpoilerSection.svelte";
   import SummaryTitle from "./_internal/SummaryTitle.svelte";
 
   const {
@@ -56,37 +56,13 @@
     <RenderFor audience="authenticated">
       <MediaActions {media} {streamOn} {title} />
 
-      <div class="trakt-summary-rate-now">
-        <RateNow {type} {media} isAlwaysVisible />
-      </div>
+      <SummaryRateNow {type} {media} />
     </RenderFor>
   {/snippet}
 
-  <SpoilerSection {media} title="description">
+  <SpoilerSection {media} type={media.type} title="description">
     <p class="secondary">{intl.overview ?? media.overview}</p>
   </SpoilerSection>
 
   <MediaDetails {media} {studios} {crew} {type} />
 </Summary>
-
-<style>
-  /* FIXME: When ratings are redesigned, remove this */
-  .trakt-summary-rate-now {
-    :global(h6) {
-      display: none;
-    }
-
-    :global(svg) {
-      --icon-color: var(--color-text-primary);
-    }
-
-    :global(.is-current-rating svg) {
-      --icon-fill-color: var(--color-text-primary);
-    }
-
-    :global(.trakt-action-button[disabled]) {
-      background-color: transparent;
-      opacity: 0.3;
-    }
-  }
-</style>

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaActions.svelte
@@ -6,6 +6,7 @@
   import ListDropdown from "$lib/sections/summary/components/list-dropdown/ListDropdown.svelte";
   import type { ListDropdownProps } from "$lib/sections/summary/components/list-dropdown/ListDropdownProps";
   import { useWatchCount } from "$lib/stores/useWatchCount";
+  import SummaryActions from "../../../_internal/SummaryActions.svelte";
   import MediaActionsPopupMenu from "./MediaActionsPopupMenu.svelte";
   import { TrackIntlProvider } from "./TrackIntlProvider";
 
@@ -33,40 +34,8 @@
   });
 </script>
 
-<div class="trakt-media-actions">
+<SummaryActions>
   <MarkAsWatchedAction {...markAsWatchedProps} i18n={TrackIntlProvider} />
   <ListDropdown {...listProps} style="popup" />
   <MediaActionsPopupMenu {media} {streamOn} {title} />
-</div>
-
-<style>
-  .trakt-media-actions {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--gap-xs);
-
-    position: relative;
-
-    height: var(--ni-56);
-    width: var(--ni-272);
-
-    padding: var(--ni-8) var(--ni-10);
-    box-sizing: border-box;
-
-    background-color: var(--color-card-background);
-    border-radius: var(--border-radius-l);
-    box-shadow: var(--popup-shadow);
-
-    :global(.trakt-button) {
-      flex-grow: 1;
-
-      flex-direction: row-reverse;
-      justify-content: flex-end;
-    }
-
-    :global(.trakt-popup-menu-button) {
-      color: var(--color-text-primary);
-    }
-  }
-</style>
+</SummaryActions>

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -2,28 +2,12 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { SimpleRating } from "$lib/models/SimpleRating";
-  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
-  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
-  import type { MediaType } from "$lib/requests/models/MediaType";
-  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import FavoriteAction from "$lib/sections/media-actions/favorite/FavoriteAction.svelte";
   import { fade } from "svelte/transition";
   import RateActionButton from "./_internal/RateActionButton.svelte";
   import { useIsRateable } from "./_internal/useIsRateable";
+  import type { RateNowProps } from "./models/RateNowProps";
   import { useRatings } from "./useRatings";
-
-  type RateableEpisode = {
-    type: "episode";
-    media: EpisodeEntry;
-    show: ShowEntry;
-  };
-
-  type RateableMedia = {
-    type: MediaType;
-    media: MediaEntry;
-  };
-
-  type RateNowProps = RateableEpisode | RateableMedia;
 
   const {
     isAlwaysVisible = false,

--- a/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
@@ -1,0 +1,17 @@
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
+
+type RateableEpisode = {
+  type: 'episode';
+  media: EpisodeEntry;
+  show: ShowEntry;
+};
+
+type RateableMedia = {
+  type: MediaType;
+  media: MediaEntry;
+};
+
+export type RateNowProps = RateableEpisode | RateableMedia;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Refactor: extract some common summary components.
- Use the new mobile summary designs also for the episode summary.

## 👀 Examples 👀

Before/after:
<img width="428" height="929" alt="Screenshot 2025-09-24 at 12 31 09" src="https://github.com/user-attachments/assets/4009f10c-4168-43da-9263-9262d45bcd38" />

<img width="428" height="929" alt="Screenshot 2025-09-24 at 12 31 14" src="https://github.com/user-attachments/assets/897d1abc-ccf8-47c2-a6df-69c80131faf4" />
