### PR TITLE
fix(summary): fade in poster tags

### DIFF
--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -34,7 +34,13 @@
   const { ratings } = $derived(
     useMediaMetaInfo({ type, episode, media: show }),
   );
+
+  const hasTags = $derived(postCreditsCount > 0 || $watchCount > 0);
 </script>
+
+{#snippet tags()}
+  <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
+{/snippet}
 
 <Summary>
   {#snippet poster()}
@@ -42,11 +48,8 @@
       src={show.poster.url.medium}
       alt={title}
       href={streamOn?.preferred?.link}
-    >
-      {#snippet tags()}
-        <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
-      {/snippet}
-    </SummaryPoster>
+      tags={hasTags ? tags : undefined}
+    />
   {/snippet}
 
   {#snippet sideActions()}

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -36,7 +36,13 @@
   const title = $derived(intl?.title ?? media?.title ?? "");
   const { watchCount } = $derived(useWatchCount({ media, type: media.type }));
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
+
+  const hasTags = $derived(postCreditsCount > 0 || $watchCount > 0);
 </script>
+
+{#snippet tags()}
+  <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
+{/snippet}
 
 <CoverImageSetter src={media.cover.url.medium} colors={media.colors} {type} />
 
@@ -46,11 +52,8 @@
       src={media.poster.url.medium}
       alt={title}
       href={streamOn?.preferred?.link ?? media.trailer}
-    >
-      {#snippet tags()}
-        <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
-      {/snippet}
-    </SummaryPoster>
+      tags={hasTags ? tags : undefined}
+    />
   {/snippet}
 
   {#snippet sideActions()}


### PR DESCRIPTION
## ♪ Note ♪

- Only pass in the summary poster tags if there should be any so it can transition in.

## 👀 Example 👀

https://github.com/user-attachments/assets/acef87c3-10ac-4c45-9d86-1e1afbfece5c

