### PR TITLE
fix(navbar): spacing when top navbar is hidden

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/TopNavbar.svelte
@@ -59,6 +59,7 @@
     transition: height calc(2 * var(--transition-increment)) ease-in-out;
 
     &.is-hidden {
+      margin: 0;
       height: calc(var(--gap-m) + env(safe-area-inset-top));
     }
   }


### PR DESCRIPTION
## 👀 Example 👀

Before:
<img width="446" height="980" alt="Screenshot 2025-09-26 at 14 18 21" src="https://github.com/user-attachments/assets/02b46cb2-57f3-4524-a31c-e60aa00d8092" />

After:
<img width="446" height="980" alt="Screenshot 2025-09-26 at 14 18 13" src="https://github.com/user-attachments/assets/6eeed2f6-fbb5-4dfe-a8a4-5d06194ee140" />
