### PR TITLE
fix(summary): disable poster links on mobile version

### DIFF
--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -48,7 +48,6 @@
     <SummaryPoster
       src={show.poster.url.medium}
       alt={title}
-      href={streamOn?.preferred?.link}
       tags={hasTags ? tags : undefined}
     />
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -52,7 +52,6 @@
     <SummaryPoster
       src={media.poster.url.medium}
       alt={title}
-      href={streamOn?.preferred?.link ?? media.trailer}
       tags={hasTags ? tags : undefined}
     />
   {/snippet}


### PR DESCRIPTION
## ♪ Note ♪

- No links on mobile summary posters.