### PR TITLE
Feat/toast fade

### DIFF
--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -16,7 +16,7 @@
   const type = $derived(props.type);
   const id = $derived(props.media.id);
 
-  const { isRating, currentRating, addRating } = $derived(
+  const { pendingRating, currentRating, addRating } = $derived(
     useRatings({
       type,
       id,
@@ -39,8 +39,10 @@
         <RateActionButton
           style="ghost"
           rating={simpleRating}
-          isCurrentRating={$currentRating === simpleRating}
-          isDisabled={$isRating || !$isRateable}
+          isCurrentRating={$pendingRating
+            ? $pendingRating === simpleRating
+            : $currentRating === simpleRating}
+          isDisabled={Boolean($pendingRating) || !$isRateable}
           onAddRating={(rating: SimpleRating) => {
             if ($currentRating === rating) {
               return;

--- a/projects/client/src/lib/sections/summary/components/rating/UserRating.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/UserRating.svelte
@@ -10,7 +10,7 @@
   const iconColor = $derived(
     rating === SimpleRating.Great ? "var(--red-500)" : "var(--shade-10)",
   );
-  const iconFillColor = $derived(isCurrentRating ? iconColor : "none");
+  const iconFillColor = $derived(isCurrentRating ? iconColor : "transparent");
 </script>
 
 <RateIcon {rating} --icon-color={iconColor} --icon-fill-color={iconFillColor} />

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
@@ -26,7 +26,7 @@ describe('useRatings', () => {
   });
 
   it('should indicate while rating is in progress', async () => {
-    const { isRating, addRating } = await renderStore(() =>
+    const { pendingRating, addRating } = await renderStore(() =>
       useRatings({
         type: 'movie',
         id: MovieHereticMappedMock.id,
@@ -34,18 +34,18 @@ describe('useRatings', () => {
     );
 
     addRating(SimpleRating.Bad);
-    expect(get(isRating)).toBe(true);
+    expect(get(pendingRating)).toBe(SimpleRating.Bad);
   });
 
   it('should not indicate that rating is in progress', async () => {
-    const { isRating } = await renderStore(() =>
+    const { pendingRating } = await renderStore(() =>
       useRatings({
         type: 'movie',
         id: MovieHereticMappedMock.id,
       })
     );
 
-    expect(get(isRating)).toBe(false);
+    expect(get(pendingRating)).toBe(null);
   });
 
   it('should return the current rating', async () => {

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
@@ -46,7 +46,7 @@ function toRatingPayload(
 }
 
 export function useRatings({ type, id }: WatchlistStoreProps) {
-  const isRating = writable(false);
+  const pendingRating = writable<null | SimpleRating>(null);
   const { ratings } = useUser();
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Rate);
@@ -82,7 +82,7 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
   );
 
   const addRating = async (simpleRating: SimpleRating) => {
-    isRating.set(true);
+    pendingRating.set(simpleRating);
     track({
       action: get(currentRating) ? 'changed' : 'added',
       rating: simpleRating,
@@ -93,12 +93,12 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
     });
     await invalidate(InvalidateAction.Rated(type));
 
-    isRating.set(false);
+    pendingRating.set(null);
     dismiss(id, type);
   };
 
   return {
-    isRating,
+    pendingRating,
     currentRating,
     addRating,
   };

--- a/projects/client/src/lib/sections/toast/Toast.svelte
+++ b/projects/client/src/lib/sections/toast/Toast.svelte
@@ -25,7 +25,7 @@
 </script>
 
 {#if $nowPlaying}
-  <NowPlayingToast />
+  <NowPlayingToast nowPlaying={$nowPlaying} />
 {:else if $lastWatched}
   <RateNowToast lastWatched={$lastWatched} />
 {/if}

--- a/projects/client/src/lib/sections/toast/_internal/NowPlayingToast.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/NowPlayingToast.svelte
@@ -2,48 +2,48 @@
   import { languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useNowPlaying } from "$lib/features/toast/useNowPlaying";
+  import type { NowPlayingItem } from "$lib/requests/models/NowPlayingItem";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { getToastTitle } from "./getToastTitle";
   import ProgressBar from "./ProgressBar.svelte";
   import StopButton from "./StopButton.svelte";
   import ToastBase from "./ToastBase.svelte";
 
-  const { nowPlaying, remainingMinutes, progress } = useNowPlaying();
+  const { nowPlaying }: { nowPlaying: NowPlayingItem } = $props();
 
-  const title = $derived(getToastTitle($nowPlaying));
+  const { remainingMinutes, progress } = useNowPlaying();
+  const title = $derived(getToastTitle(nowPlaying));
 </script>
 
-{#if $nowPlaying}
-  <ToastBase item={$nowPlaying}>
-    <div class="trakt-now-playing-header">
-      {#if $nowPlaying.media.postCredits.length > 0}
-        <div class="trakt-post-credits-label">
-          <span class="meta-info post-credits-count">
-            {$nowPlaying.media.postCredits.length}
-          </span>
-          <span class="meta-info">{m.header_post_credits()}</span>
-        </div>
-      {:else}
-        <div class="trakt-now-playing-label">
-          {m.header_now_playing()}
-        </div>
-      {/if}
-      <StopButton nowPlaying={$nowPlaying} {title} />
-    </div>
-    <div class="trakt-now-playing-status">
-      <h5 class="trakt-now-playing-title ellipsis">
-        {title}
-      </h5>
-      <div class="trakt-now-playing-remaining">
-        <span class="meta-info">
-          {toHumanDuration({ minutes: $remainingMinutes }, languageTag())}
+<ToastBase item={nowPlaying}>
+  <div class="trakt-now-playing-header">
+    {#if nowPlaying.media.postCredits.length > 0}
+      <div class="trakt-post-credits-label">
+        <span class="meta-info post-credits-count">
+          {nowPlaying.media.postCredits.length}
         </span>
-        <span class="meta-info">{m.text_remaining()}</span>
+        <span class="meta-info">{m.header_post_credits()}</span>
       </div>
+    {:else}
+      <div class="trakt-now-playing-label">
+        {m.header_now_playing()}
+      </div>
+    {/if}
+    <StopButton {nowPlaying} {title} />
+  </div>
+  <div class="trakt-now-playing-status">
+    <h5 class="trakt-now-playing-title ellipsis">
+      {title}
+    </h5>
+    <div class="trakt-now-playing-remaining">
+      <span class="meta-info">
+        {toHumanDuration({ minutes: $remainingMinutes }, languageTag())}
+      </span>
+      <span class="meta-info">{m.text_remaining()}</span>
     </div>
-    <ProgressBar progress={$progress} />
-  </ToastBase>
-{/if}
+  </div>
+  <ProgressBar progress={$progress} />
+</ToastBase>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;

--- a/projects/client/src/lib/sections/toast/_internal/RateNowToast.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/RateNowToast.svelte
@@ -4,7 +4,6 @@
   import * as m from "$lib/features/i18n/messages";
   import type { LastWatchedItem } from "$lib/features/toast/models/LastWatchedItem";
   import { useLastWatched } from "$lib/features/toast/useLastWatched";
-  import { useIsRateable } from "$lib/sections/summary/components/rating/_internal/useIsRateable";
   import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
   import { getToastTitle } from "./getToastTitle";
   import ToastBase from "./ToastBase.svelte";
@@ -14,27 +13,24 @@
   const { dismiss } = useLastWatched();
 
   const title = $derived(getToastTitle(lastWatched));
-  const { isRateable } = $derived(useIsRateable(lastWatched));
 </script>
 
-{#if $isRateable}
-  <ToastBase item={lastWatched}>
-    <div class="trakt-rate-now-header">
-      <p class="smaller ellipsis">{title}</p>
-      <ActionButton
-        onclick={() => dismiss(lastWatched.media.id, lastWatched.type)}
-        label={m.button_label_dismiss()}
-        style="ghost"
-        size="small"
-      >
-        <CloseIcon />
-      </ActionButton>
-    </div>
-    <div class="trakt-rate-now-container">
-      <RateNow {...lastWatched} />
-    </div>
-  </ToastBase>
-{/if}
+<ToastBase item={lastWatched}>
+  <div class="trakt-rate-now-header">
+    <p class="smaller ellipsis">{title}</p>
+    <ActionButton
+      onclick={() => dismiss(lastWatched.media.id, lastWatched.type)}
+      label={m.button_label_dismiss()}
+      style="ghost"
+      size="small"
+    >
+      <CloseIcon />
+    </ActionButton>
+  </div>
+  <div class="trakt-rate-now-container">
+    <RateNow {...lastWatched} />
+  </div>
+</ToastBase>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
@@ -61,6 +57,10 @@
 
     :global(svg) {
       --icon-color: var(--color-foreground);
+    }
+
+    :global(.is-current-rating svg) {
+      --icon-fill-color: var(--color-foreground);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/toast/_internal/ToastBase.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/ToastBase.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { LastWatchedItem } from "$lib/features/toast/models/LastWatchedItem";
   import type { NowPlayingItem } from "$lib/requests/models/NowPlayingItem";
+  import { fade } from "svelte/transition";
   import ToastItemCard from "./ToastItemCard.svelte";
   import { useFooterHeight } from "./useFooterHeight";
   import { useScrollDistance } from "./useScrollDistance";
@@ -16,6 +17,7 @@
 <div
   class="trakt-toast-base"
   style="--distance-from-bottom: {$distanceFromBottom}px; --footer-height: {$footerHeight}px"
+  transition:fade={{ duration: 300 }}
 >
   <ToastItemCard {item} />
   <div class="trakt-toast-content">

--- a/projects/client/src/style/color-mix/index.scss
+++ b/projects/client/src/style/color-mix/index.scss
@@ -21,7 +21,7 @@ $cm-background-navbar-percentages: 80, 90;
       var(--shade-700) 75%,
       transparent);
 
-  --cm-background-now-playing: color-mix(in srgb, var(--color-now-playing-background-base) 70%, transparent 30%);
+  --cm-background-now-playing: color-mix(in srgb, var(--color-toast-background-base) 70%, transparent 30%);
 
   --cm-inactive-gesture: color-mix(in srgb,
       var(--color-foreground) 35%,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Toast is now faded in/out.
- After rating, the pending rating is shown as the active rating.
- Some small fixes:
  - Rate icons are now transitioned.
  - Toast uses the correct background color.

## 👀 Example 👀

https://github.com/user-attachments/assets/d70fdc02-4b11-4979-a843-b00c39291466

