### PR TITLE
feat(card): use text only tags in media and episode summary cards

### DIFF
--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -5,26 +5,36 @@
   type ShowProgressTagProps = {
     total: number;
     progress: number;
+    isTextOnly?: boolean;
   } & ChildrenProps;
 
-  const { children, total, progress }: ShowProgressTagProps = $props();
+  const {
+    children,
+    total,
+    progress,
+    isTextOnly = false,
+  }: ShowProgressTagProps = $props();
   const percentage = $derived(stretchedPercentage({ value: progress, total }));
 </script>
 
-<div
-  class="show-progress-tag"
-  style:--progress-width={`${percentage}%`}
-  role="progressbar"
-  aria-valuenow={progress}
-  aria-valuemin={0}
-  aria-valuemax={total}
->
-  <TagContent>
-    <p class="meta-info capitalize tag-label">
-      {@render children()}
-    </p>
-  </TagContent>
-</div>
+{#if isTextOnly}
+  <p class="meta-info capitalize secondary no-wrap">{@render children()}</p>
+{:else}
+  <div
+    class="show-progress-tag"
+    style:--progress-width={`${percentage}%`}
+    role="progressbar"
+    aria-valuenow={progress}
+    aria-valuemin={0}
+    aria-valuemax={total}
+  >
+    <TagContent>
+      <p class="meta-info capitalize tag-label">
+        {@render children()}
+      </p>
+    </TagContent>
+  </div>
+{/if}
 
 <style lang="scss">
   @use "$style/scss/mixins/index.scss" as *;

--- a/projects/client/src/lib/components/media/tags/ActivityTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ActivityTag.svelte
@@ -5,14 +5,24 @@
   const {
     activityDate,
     i18n,
+    isTextOnly = false,
   }: {
     activityDate: Date;
     i18n: TagIntl;
+    isTextOnly?: boolean;
   } = $props();
 </script>
 
-<StemTag>
-  <p class="meta-info capitalize no-wrap">
+{#snippet content(isSecondary: boolean)}
+  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
     {i18n.toActivityDate(activityDate)}
   </p>
-</StemTag>
+{/snippet}
+
+{#if isTextOnly}
+  {@render content(true)}
+{:else}
+  <StemTag>
+    {@render content(false)}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/media/tags/AirDateTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.svelte
@@ -6,18 +6,28 @@
   const {
     airDate,
     i18n,
+    isTextOnly = false,
   }: {
     airDate: Date;
     i18n: TagIntl;
+    isTextOnly?: boolean;
   } = $props();
 </script>
 
-<StemTag>
-  <p class="meta-info capitalize no-wrap">
+{#snippet content(isSecondary: boolean)}
+  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
     {#if isMaxDate(airDate)}
       {i18n.tbaLabel()}
     {:else}
       {i18n.toReleaseEstimate(airDate)}
     {/if}
   </p>
-</StemTag>
+{/snippet}
+
+{#if isTextOnly}
+  {@render content(true)}
+{:else}
+  <StemTag>
+    {@render content(false)}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/media/tags/DurationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/DurationTag.svelte
@@ -5,14 +5,24 @@
   const {
     runtime,
     i18n,
+    isTextOnly = false,
   }: {
     runtime: number;
     i18n: TagIntl;
+    isTextOnly?: boolean;
   } = $props();
 </script>
 
-<StemTag>
-  <p class="meta-info capitalize no-wrap">
+{#snippet content(isSecondary: boolean)}
+  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
     {i18n.toDuration(runtime)}
   </p>
-</StemTag>
+{/snippet}
+
+{#if isTextOnly}
+  {@render content(true)}
+{:else}
+  <StemTag>
+    {@render content(false)}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
+++ b/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
@@ -5,14 +5,24 @@
   const {
     count,
     i18n,
+    isTextOnly = false,
   }: {
     count: number;
     i18n: TagIntl;
+    isTextOnly?: boolean;
   } = $props();
 </script>
 
-<StemTag>
-  <p class="meta-info capitalize no-wrap">
+{#snippet content(isSecondary: boolean)}
+  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
     {i18n.toEpisodeCount(count)}
   </p>
-</StemTag>
+{/snippet}
+
+{#if isTextOnly}
+  {@render content(true)}
+{:else}
+  <StemTag>
+    {@render content(false)}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -18,11 +18,12 @@
     type,
     media,
     style,
-    tag,
+    tag: externalTag,
     canDeemphasize,
     ...rest
-  }: MediaCardProps<MediaInputDefault> & { canDeemphasize?: boolean } =
-    $props();
+  }: MediaCardProps<MediaInputDefault> & {
+    canDeemphasize?: boolean;
+  } = $props();
 
   const { isWatched } = $derived(useIsWatched({ type, media }));
   const { isWatchlisted } = $derived(useIsWatchlisted({ type, media }));
@@ -30,17 +31,47 @@
   const isDeemphasized = $derived(
     canDeemphasize && ($isWatched || $isWatchlisted),
   );
+
+  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet defaultTag()}
   {#if "episode" in media}
-    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
-    <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
+    <AirDateTag
+      i18n={TagIntlProvider}
+      airDate={media.airDate}
+      isTextOnly={isSummary}
+    />
+    <EpisodeCountTag
+      i18n={TagIntlProvider}
+      count={media.episode.count}
+      isTextOnly={isSummary}
+    />
   {:else if type === "movie" && rest.variant !== "activity"}
-    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+    <AirDateTag
+      i18n={TagIntlProvider}
+      airDate={media.airDate}
+      isTextOnly={isSummary}
+    />
     {#if media.airDate < new Date()}
-      <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
+      <DurationTag
+        i18n={TagIntlProvider}
+        runtime={media.runtime}
+        isTextOnly={isSummary}
+      />
     {/if}
+  {/if}
+
+  {#if isSummary && media.certification}
+    <span class="secondary meta-info">{media.certification}</span>
+  {/if}
+{/snippet}
+
+{#snippet tag()}
+  {#if isSummary || !externalTag}
+    {@render defaultTag()}
+  {:else}
+    {@render externalTag()}
   {/if}
 {/snippet}
 
@@ -75,14 +106,7 @@
 
 <MediaSwipe {type} {media} {style}>
   <trakt-default-media-item class:is-deemphasized={isDeemphasized}>
-    <MediaItem
-      {type}
-      {media}
-      {style}
-      tag={tag ?? defaultTag}
-      {...rest}
-      {popupActions}
-    />
+    <MediaItem {type} {media} {style} {tag} {...rest} {popupActions} />
   </trakt-default-media-item>
 </MediaSwipe>
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -21,6 +21,8 @@
   const runtime = $derived(
     isNaN(props.episode.runtime) ? props.show.runtime : props.episode.runtime,
   );
+
+  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet action()}
@@ -43,33 +45,49 @@
   {#if props.tag}
     {@render props.tag()}
   {:else}
-    <div class="trakt-episode-tag">
+    <div class="trakt-episode-tag" class:is-summary={isSummary}>
       {#if ["next", "default"].includes(props.variant)}
-        <DurationTag i18n={TagIntlProvider} {runtime} />
+        <DurationTag i18n={TagIntlProvider} {runtime} isTextOnly={isSummary} />
       {/if}
 
       {#if props.variant === "next"}
+        {#if isSummary}
+          <span class="secondary meta-info">·</span>
+        {/if}
         <ShowProgressTag
           total={props.episode.total}
           progress={props.episode.completed}
+          isTextOnly={isSummary}
         >
           <div class="show-progress">
             <span class="ellipsis">
               {EpisodeIntlProvider.remainingText(props.episode.remaining)}
             </span>
             <span class="no-wrap">
-              {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
+              {#if isSummary}
+                ({EpisodeIntlProvider.durationText(props.episode.minutesLeft)})
+              {:else}
+                {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
+              {/if}
             </span>
           </div>
         </ShowProgressTag>
       {/if}
 
       {#if props.variant === "upcoming"}
-        <AirDateTag i18n={TagIntlProvider} airDate={props.episode.airDate} />
+        <AirDateTag
+          i18n={TagIntlProvider}
+          airDate={props.episode.airDate}
+          isTextOnly={isSummary}
+        />
       {/if}
 
       {#if props.variant === "activity"}
-        <ActivityTag i18n={TagIntlProvider} activityDate={props.date} />
+        <ActivityTag
+          i18n={TagIntlProvider}
+          activityDate={props.date}
+          isTextOnly={isSummary}
+        />
       {/if}
     </div>
   {/if}
@@ -139,6 +157,14 @@
 
     :global(.trakt-tag) {
       background: var(--color-background-cover-tag);
+    }
+
+    &.is-summary {
+      gap: var(--gap-xs);
+
+      .show-progress {
+        gap: var(--gap-micro);
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -170,7 +170,11 @@
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
-
     flex-grow: 1;
+  }
+
+  .trakt-summary-card-tags > :global(:not(:last-child))::after {
+    content: "·";
+    margin-left: var(--gap-xs);
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Updates the tags in summary cards to match new design.
- This is pt1., pt2 will be the activity summary cards.

## 👀 Examples 👀

Before/after:
<img width="427" height="926" alt="upnext_before" src="https://github.com/user-attachments/assets/40e346d5-ae0d-441c-82e4-11dc897c5a31" />

<img width="427" height="926" alt="upnext_after" src="https://github.com/user-attachments/assets/30aa8871-b74e-4744-939b-f9e542c911f8" />

Before/after:
<img width="427" height="926" alt="released_before" src="https://github.com/user-attachments/assets/263114c9-8d46-4145-a716-670b5e8bcbb5" />

<img width="427" height="926" alt="released_after" src="https://github.com/user-attachments/assets/1f748d5b-9781-4077-b040-f32f5d7619af" />

Before/after:
<img width="427" height="926" alt="recommended_before" src="https://github.com/user-attachments/assets/1f89391b-9ae0-4278-a79d-c8695cc2b33d" />

<img width="427" height="926" alt="recommended_after" src="https://github.com/user-attachments/assets/f9e2a4af-8c94-42f2-99b2-88845fe6793e" />
