### PR TITLE
Fix/summary tag fixes

### DIFF
--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -5,36 +5,26 @@
   type ShowProgressTagProps = {
     total: number;
     progress: number;
-    isTextOnly?: boolean;
   } & ChildrenProps;
 
-  const {
-    children,
-    total,
-    progress,
-    isTextOnly = false,
-  }: ShowProgressTagProps = $props();
+  const { children, total, progress }: ShowProgressTagProps = $props();
   const percentage = $derived(stretchedPercentage({ value: progress, total }));
 </script>
 
-{#if isTextOnly}
-  <p class="meta-info capitalize secondary no-wrap">{@render children()}</p>
-{:else}
-  <div
-    class="show-progress-tag"
-    style:--progress-width={`${percentage}%`}
-    role="progressbar"
-    aria-valuenow={progress}
-    aria-valuemin={0}
-    aria-valuemax={total}
-  >
-    <TagContent>
-      <p class="meta-info capitalize tag-label">
-        {@render children()}
-      </p>
-    </TagContent>
-  </div>
-{/if}
+<div
+  class="show-progress-tag"
+  style:--progress-width={`${percentage}%`}
+  role="progressbar"
+  aria-valuenow={progress}
+  aria-valuemin={0}
+  aria-valuemax={total}
+>
+  <TagContent>
+    <p class="meta-info capitalize tag-label">
+      {@render children()}
+    </p>
+  </TagContent>
+</div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index.scss" as *;

--- a/projects/client/src/lib/components/media/tags/ActivityTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ActivityTag.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
   const {
@@ -13,16 +14,18 @@
   } = $props();
 </script>
 
-{#snippet content(isSecondary: boolean)}
-  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
+{#snippet content()}
+  <p class="meta-info capitalize no-wrap">
     {i18n.toActivityDate(activityDate)}
   </p>
 {/snippet}
 
 {#if isTextOnly}
-  {@render content(true)}
+  <TextTag>
+    {@render content()}
+  </TextTag>
 {:else}
   <StemTag>
-    {@render content(false)}
+    {@render content()}
   </StemTag>
 {/if}

--- a/projects/client/src/lib/components/media/tags/AirDateTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
   import { isMaxDate } from "$lib/utils/date/isMaxDate";
   import type { TagIntl } from "./TagIntl";
 
@@ -14,8 +15,8 @@
   } = $props();
 </script>
 
-{#snippet content(isSecondary: boolean)}
-  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
+{#snippet content()}
+  <p class="meta-info capitalize no-wrap">
     {#if isMaxDate(airDate)}
       {i18n.tbaLabel()}
     {:else}
@@ -25,9 +26,11 @@
 {/snippet}
 
 {#if isTextOnly}
-  {@render content(true)}
+  <TextTag>
+    {@render content()}
+  </TextTag>
 {:else}
   <StemTag>
-    {@render content(false)}
+    {@render content()}
   </StemTag>
 {/if}

--- a/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
@@ -1,22 +1,36 @@
 <script lang="ts">
   import AnticipatedIcon from "$lib/components/icons/AnticipatedIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
   const {
     score,
     i18n,
+    isTextOnly = false,
   }: {
     score: number;
     i18n: TagIntl;
+    isTextOnly?: boolean;
   } = $props();
 </script>
 
-<StemTag>
-  {#snippet icon()}
-    <AnticipatedIcon />
-  {/snippet}
+{#snippet icon()}
+  <AnticipatedIcon />
+{/snippet}
+
+{#snippet content()}
   <p class="meta-info capitalize no-wrap">
     {i18n.toAnticipatedCount(score)}
   </p>
-</StemTag>
+{/snippet}
+
+{#if isTextOnly}
+  <TextTag {icon}>
+    {@render content()}
+  </TextTag>
+{:else}
+  <StemTag {icon}>
+    {@render content()}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/media/tags/DurationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/DurationTag.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
   const {
@@ -13,16 +14,18 @@
   } = $props();
 </script>
 
-{#snippet content(isSecondary: boolean)}
-  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
+{#snippet content()}
+  <p class="meta-info capitalize no-wrap">
     {i18n.toDuration(runtime)}
   </p>
 {/snippet}
 
 {#if isTextOnly}
-  {@render content(true)}
+  <TextTag>
+    {@render content()}
+  </TextTag>
 {:else}
   <StemTag>
-    {@render content(false)}
+    {@render content()}
   </StemTag>
 {/if}

--- a/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
+++ b/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
   const {
@@ -13,16 +14,18 @@
   } = $props();
 </script>
 
-{#snippet content(isSecondary: boolean)}
-  <p class="meta-info capitalize no-wrap" class:secondary={isSecondary}>
+{#snippet content()}
+  <p class="meta-info capitalize no-wrap">
     {i18n.toEpisodeCount(count)}
   </p>
 {/snippet}
 
 {#if isTextOnly}
-  {@render content(true)}
+  <TextTag>
+    {@render content()}
+  </TextTag>
 {:else}
   <StemTag>
-    {@render content(false)}
+    {@render content()}
   </StemTag>
 {/if}

--- a/projects/client/src/lib/components/media/tags/WatchersTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchersTag.svelte
@@ -1,22 +1,36 @@
 <script lang="ts">
   import UserIcon from "$lib/components/icons/UserIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
   const {
     watchers,
     i18n,
+    isTextOnly = false,
   }: {
     watchers: number;
     i18n: TagIntl;
+    isTextOnly?: boolean;
   } = $props();
 </script>
 
-<StemTag>
-  {#snippet icon()}
-    <UserIcon />
-  {/snippet}
+{#snippet icon()}
+  <UserIcon />
+{/snippet}
+
+{#snippet content()}
   <p class="meta-info capitalize no-wrap">
     {i18n.toWatcherCount(watchers)}
   </p>
-</StemTag>
+{/snippet}
+
+{#if isTextOnly}
+  <TextTag {icon}>
+    {@render content()}
+  </TextTag>
+{:else}
+  <StemTag {icon}>
+    {@render content()}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/tags/TextTag.svelte
+++ b/projects/client/src/lib/components/tags/TextTag.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  const { children, icon }: ChildrenProps & { icon?: Snippet } = $props();
+</script>
+
+<div class="trakt-text-tag">
+  {@render icon?.()}
+  {@render children()}
+</div>
+
+<style>
+  .trakt-text-tag {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xxs);
+
+    color: var(--color-text-secondary);
+    font-size: var(--ni-12);
+
+    :global(svg) {
+      width: var(--ni-12);
+      height: var(--ni-12);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -6,10 +6,16 @@
   import type { AnticipatedEntry } from "./useAnticipatedList";
 
   const { type, media, style }: MediaCardProps<AnticipatedEntry> = $props();
+
+  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet tag()}
-  <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
+  <AnticipatedTag
+    i18n={TagIntlProvider}
+    score={media.score}
+    isTextOnly={isSummary}
+  />
 {/snippet}
 
 <DefaultMediaItem

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -68,10 +68,13 @@
 {/snippet}
 
 {#snippet tag()}
-  {#if isSummary || !externalTag}
+  {#if isSummary}
+    {@render externalTag?.()}
     {@render defaultTag()}
-  {:else}
+  {:else if externalTag}
     {@render externalTag()}
+  {:else}
+    {@render defaultTag()}
   {/if}
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -21,8 +21,6 @@
   const runtime = $derived(
     isNaN(props.episode.runtime) ? props.show.runtime : props.episode.runtime,
   );
-
-  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet action()}
@@ -45,49 +43,33 @@
   {#if props.tag}
     {@render props.tag()}
   {:else}
-    <div class="trakt-episode-tag" class:is-summary={isSummary}>
+    <div class="trakt-episode-tag">
       {#if ["next", "default"].includes(props.variant)}
-        <DurationTag i18n={TagIntlProvider} {runtime} isTextOnly={isSummary} />
+        <DurationTag i18n={TagIntlProvider} {runtime} />
       {/if}
 
       {#if props.variant === "next"}
-        {#if isSummary}
-          <span class="secondary meta-info">·</span>
-        {/if}
         <ShowProgressTag
           total={props.episode.total}
           progress={props.episode.completed}
-          isTextOnly={isSummary}
         >
           <div class="show-progress">
             <span class="ellipsis">
               {EpisodeIntlProvider.remainingText(props.episode.remaining)}
             </span>
             <span class="no-wrap">
-              {#if isSummary}
-                ({EpisodeIntlProvider.durationText(props.episode.minutesLeft)})
-              {:else}
-                {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
-              {/if}
+              {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
             </span>
           </div>
         </ShowProgressTag>
       {/if}
 
       {#if props.variant === "upcoming"}
-        <AirDateTag
-          i18n={TagIntlProvider}
-          airDate={props.episode.airDate}
-          isTextOnly={isSummary}
-        />
+        <AirDateTag i18n={TagIntlProvider} airDate={props.episode.airDate} />
       {/if}
 
       {#if props.variant === "activity"}
-        <ActivityTag
-          i18n={TagIntlProvider}
-          activityDate={props.date}
-          isTextOnly={isSummary}
-        />
+        <ActivityTag i18n={TagIntlProvider} activityDate={props.date} />
       {/if}
     </div>
   {/if}
@@ -157,14 +139,6 @@
 
     :global(.trakt-tag) {
       background: var(--color-background-cover-tag);
-    }
-
-    &.is-summary {
-      gap: var(--gap-xs);
-
-      .show-progress {
-        gap: var(--gap-micro);
-      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -176,5 +176,8 @@
   .trakt-summary-card-tags > :global(:not(:last-child))::after {
     content: "·";
     margin-left: var(--gap-xs);
+
+    font-size: var(--ni-16);
+    line-height: var(--ni-12);
   }
 </style>

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -6,10 +6,16 @@
   import type { TrendingEntry } from "./useTrendingList";
 
   const { type, media, style }: MediaCardProps<TrendingEntry> = $props();
+
+  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet tag()}
-  <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
+  <WatchersTag
+    i18n={TagIntlProvider}
+    watchers={media.watchers}
+    isTextOnly={isSummary}
+  />
 {/snippet}
 
 <DefaultMediaItem


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small refactor to extract common text tag.
- External tags are no longer hidden in summary card, i.e. summary should only add info, not replace.
- Episode items show the progress bar again.
- Increases legibility of the tag separator in summary cards.

## 👀 Examples 👀

<img width="427" height="928" alt="Screenshot 2025-10-07 at 15 40 25" src="https://github.com/user-attachments/assets/057fca5d-fa20-4bf8-8edf-e3d4844fdb15" />

Before/after:
<img width="427" height="928" alt="Screenshot 2025-10-07 at 15 41 16" src="https://github.com/user-attachments/assets/eb2bbf49-4b11-4d6e-bc51-9e7b87b5b58b" />

<img width="427" height="928" alt="Screenshot 2025-10-07 at 15 41 19" src="https://github.com/user-attachments/assets/85ae8b23-2d08-457b-8a66-952cc5a498eb" />
