### PR TITLE
Feat/text tags

### DIFF
--- a/projects/client/src/lib/components/media/tags/ActivityTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ActivityTag.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { TagType } from "./models/TagType";
   import type { TagIntl } from "./TagIntl";
 
   const {
     activityDate,
     i18n,
-    isTextOnly = false,
+    type = "tag",
   }: {
     activityDate: Date;
     i18n: TagIntl;
-    isTextOnly?: boolean;
+    type?: TagType;
   } = $props();
 </script>
 
@@ -20,7 +21,7 @@
   </p>
 {/snippet}
 
-{#if isTextOnly}
+{#if type === "text"}
   <TextTag>
     {@render content()}
   </TextTag>

--- a/projects/client/src/lib/components/media/tags/ActivityTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ActivityTag.svelte
@@ -7,7 +7,7 @@
   const {
     activityDate,
     i18n,
-    type = "tag",
+    type = "text",
   }: {
     activityDate: Date;
     i18n: TagIntl;

--- a/projects/client/src/lib/components/media/tags/AirDateTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.svelte
@@ -8,7 +8,7 @@
   const {
     airDate,
     i18n,
-    type = "tag",
+    type = "text",
   }: {
     airDate: Date;
     i18n: TagIntl;

--- a/projects/client/src/lib/components/media/tags/AirDateTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.svelte
@@ -2,16 +2,17 @@
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import { isMaxDate } from "$lib/utils/date/isMaxDate";
+  import type { TagType } from "./models/TagType";
   import type { TagIntl } from "./TagIntl";
 
   const {
     airDate,
     i18n,
-    isTextOnly = false,
+    type = "tag",
   }: {
     airDate: Date;
     i18n: TagIntl;
-    isTextOnly?: boolean;
+    type?: TagType;
   } = $props();
 </script>
 
@@ -25,7 +26,7 @@
   </p>
 {/snippet}
 
-{#if isTextOnly}
+{#if type === "text"}
   <TextTag>
     {@render content()}
   </TextTag>

--- a/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
@@ -8,7 +8,7 @@
   const {
     score,
     i18n,
-    type = "tag",
+    type = "text",
   }: {
     score: number;
     i18n: TagIntl;

--- a/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
@@ -2,16 +2,17 @@
   import AnticipatedIcon from "$lib/components/icons/AnticipatedIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { TagType } from "./models/TagType";
   import type { TagIntl } from "./TagIntl";
 
   const {
     score,
     i18n,
-    isTextOnly = false,
+    type = "tag",
   }: {
     score: number;
     i18n: TagIntl;
-    isTextOnly?: boolean;
+    type?: TagType;
   } = $props();
 </script>
 
@@ -25,7 +26,7 @@
   </p>
 {/snippet}
 
-{#if isTextOnly}
+{#if type === "text"}
   <TextTag {icon}>
     {@render content()}
   </TextTag>

--- a/projects/client/src/lib/components/media/tags/CertificationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/CertificationTag.svelte
@@ -5,7 +5,7 @@
 
   const {
     certification,
-    type = "tag",
+    type = "text",
   }: {
     certification: string;
     type?: TagType;

--- a/projects/client/src/lib/components/media/tags/CertificationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/CertificationTag.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { TagType } from "./models/TagType";
+
+  const {
+    certification,
+    type = "tag",
+  }: {
+    certification: string;
+    type?: TagType;
+  } = $props();
+</script>
+
+{#snippet content()}
+  <p class="meta-info capitalize no-wrap">
+    {certification}
+  </p>
+{/snippet}
+
+{#if type === "text"}
+  <TextTag>
+    {@render content()}
+  </TextTag>
+{:else}
+  <StemTag>
+    {@render content()}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/media/tags/DurationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/DurationTag.svelte
@@ -7,7 +7,7 @@
   const {
     runtime,
     i18n,
-    type = "tag",
+    type = "text",
   }: {
     runtime: number;
     i18n: TagIntl;

--- a/projects/client/src/lib/components/media/tags/DurationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/DurationTag.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { TagType } from "./models/TagType";
   import type { TagIntl } from "./TagIntl";
 
   const {
     runtime,
     i18n,
-    isTextOnly = false,
+    type = "tag",
   }: {
     runtime: number;
     i18n: TagIntl;
-    isTextOnly?: boolean;
+    type?: TagType;
   } = $props();
 </script>
 
@@ -20,7 +21,7 @@
   </p>
 {/snippet}
 
-{#if isTextOnly}
+{#if type === "text"}
   <TextTag>
     {@render content()}
   </TextTag>

--- a/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
+++ b/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { TagType } from "./models/TagType";
   import type { TagIntl } from "./TagIntl";
 
   const {
     count,
     i18n,
-    isTextOnly = false,
+    type = "tag",
   }: {
     count: number;
     i18n: TagIntl;
-    isTextOnly?: boolean;
+    type?: TagType;
   } = $props();
 </script>
 
@@ -20,7 +21,7 @@
   </p>
 {/snippet}
 
-{#if isTextOnly}
+{#if type === "text"}
   <TextTag>
     {@render content()}
   </TextTag>

--- a/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
+++ b/projects/client/src/lib/components/media/tags/EpisodeCountTag.svelte
@@ -7,7 +7,7 @@
   const {
     count,
     i18n,
-    type = "tag",
+    type = "text",
   }: {
     count: number;
     i18n: TagIntl;

--- a/projects/client/src/lib/components/media/tags/WatchersTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchersTag.svelte
@@ -8,7 +8,7 @@
   const {
     watchers,
     i18n,
-    type = "tag",
+    type = "text",
   }: {
     watchers: number;
     i18n: TagIntl;

--- a/projects/client/src/lib/components/media/tags/WatchersTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchersTag.svelte
@@ -2,16 +2,17 @@
   import UserIcon from "$lib/components/icons/UserIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { TagType } from "./models/TagType";
   import type { TagIntl } from "./TagIntl";
 
   const {
     watchers,
     i18n,
-    isTextOnly = false,
+    type = "tag",
   }: {
     watchers: number;
     i18n: TagIntl;
-    isTextOnly?: boolean;
+    type?: TagType;
   } = $props();
 </script>
 
@@ -25,7 +26,7 @@
   </p>
 {/snippet}
 
-{#if isTextOnly}
+{#if type === "text"}
   <TextTag {icon}>
     {@render content()}
   </TextTag>

--- a/projects/client/src/lib/components/media/tags/models/TagType.ts
+++ b/projects/client/src/lib/components/media/tags/models/TagType.ts
@@ -1,0 +1,1 @@
+export type TagType = 'tag' | 'text';

--- a/projects/client/src/lib/components/tags/TagBar.svelte
+++ b/projects/client/src/lib/components/tags/TagBar.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  const { children }: ChildrenProps = $props();
+</script>
+
+<div class="trakt-tag-bar">
+  {@render children()}
+</div>
+
+<style>
+  .trakt-tag-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xxs);
+
+    :global(:not(:last-child))::after {
+      content: "·";
+
+      font-size: var(--ni-16);
+      line-height: var(--ni-12);
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/tags/TextTag.svelte
+++ b/projects/client/src/lib/components/tags/TextTag.svelte
@@ -15,7 +15,7 @@
     align-items: center;
     gap: var(--gap-xxs);
 
-    color: var(--color-text-secondary);
+    color: var(--color-text-primary);
     font-size: var(--ni-12);
 
     :global(svg) {

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -6,16 +6,10 @@
   import type { AnticipatedEntry } from "./useAnticipatedList";
 
   const { type, media, style }: MediaCardProps<AnticipatedEntry> = $props();
-
-  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet tag()}
-  <AnticipatedTag
-    i18n={TagIntlProvider}
-    score={media.score}
-    type={isSummary ? "text" : "tag"}
-  />
+  <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
 {/snippet}
 
 <DefaultMediaItem

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -14,7 +14,7 @@
   <AnticipatedTag
     i18n={TagIntlProvider}
     score={media.score}
-    isTextOnly={isSummary}
+    type={isSummary ? "text" : "tag"}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -40,24 +40,24 @@
     <AirDateTag
       i18n={TagIntlProvider}
       airDate={media.airDate}
-      isTextOnly={isSummary}
+      type={isSummary ? "text" : "tag"}
     />
     <EpisodeCountTag
       i18n={TagIntlProvider}
       count={media.episode.count}
-      isTextOnly={isSummary}
+      type={isSummary ? "text" : "tag"}
     />
   {:else if type === "movie" && rest.variant !== "activity"}
     <AirDateTag
       i18n={TagIntlProvider}
       airDate={media.airDate}
-      isTextOnly={isSummary}
+      type={isSummary ? "text" : "tag"}
     />
     {#if media.airDate < new Date()}
       <DurationTag
         i18n={TagIntlProvider}
         runtime={media.runtime}
-        isTextOnly={isSummary}
+        type={isSummary ? "text" : "tag"}
       />
     {/if}
   {/if}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
+  import CertificationTag from "$lib/components/media/tags/CertificationTag.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
@@ -63,7 +64,7 @@
   {/if}
 
   {#if isSummary && media.certification}
-    <span class="secondary meta-info">{media.certification}</span>
+    <CertificationTag certification={media.certification} />
   {/if}
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -4,6 +4,7 @@
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import TagBar from "$lib/components/tags/TagBar.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaInputDefault } from "$lib/models/MediaInput";
   import CheckInAction from "$lib/sections/media-actions/check-in/CheckInAction.svelte";
@@ -38,28 +39,12 @@
 
 {#snippet defaultTag()}
   {#if "episode" in media}
-    <AirDateTag
-      i18n={TagIntlProvider}
-      airDate={media.airDate}
-      type={isSummary ? "text" : "tag"}
-    />
-    <EpisodeCountTag
-      i18n={TagIntlProvider}
-      count={media.episode.count}
-      type={isSummary ? "text" : "tag"}
-    />
+    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+    <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
   {:else if type === "movie" && rest.variant !== "activity"}
-    <AirDateTag
-      i18n={TagIntlProvider}
-      airDate={media.airDate}
-      type={isSummary ? "text" : "tag"}
-    />
+    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
     {#if media.airDate < new Date()}
-      <DurationTag
-        i18n={TagIntlProvider}
-        runtime={media.runtime}
-        type={isSummary ? "text" : "tag"}
-      />
+      <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
     {/if}
   {/if}
 
@@ -69,14 +54,16 @@
 {/snippet}
 
 {#snippet tag()}
-  {#if isSummary}
-    {@render externalTag?.()}
-    {@render defaultTag()}
-  {:else if externalTag}
-    {@render externalTag()}
-  {:else}
-    {@render defaultTag()}
-  {/if}
+  <TagBar>
+    {#if isSummary}
+      {@render externalTag?.()}
+      {@render defaultTag()}
+    {:else if externalTag}
+      {@render externalTag()}
+    {:else}
+      {@render defaultTag()}
+    {/if}
+  </TagBar>
 {/snippet}
 
 {#snippet popupActions()}

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -45,7 +45,7 @@
   {:else}
     <div class="trakt-episode-tag">
       {#if ["next", "default"].includes(props.variant)}
-        <DurationTag i18n={TagIntlProvider} {runtime} />
+        <DurationTag i18n={TagIntlProvider} {runtime} type="tag" />
       {/if}
 
       {#if props.variant === "next"}
@@ -65,7 +65,11 @@
       {/if}
 
       {#if props.variant === "upcoming"}
-        <AirDateTag i18n={TagIntlProvider} airDate={props.episode.airDate} />
+        <AirDateTag
+          i18n={TagIntlProvider}
+          airDate={props.episode.airDate}
+          type="tag"
+        />
       {/if}
 
       {#if props.variant === "activity"}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -7,12 +7,18 @@
 
   const props: MediaCardProps = $props();
   const style = $derived(props.style ?? "cover");
+
+  const isCover = $derived(style === "cover");
 </script>
 
 {#snippet coverTag()}
   <div class="trakt-media-tag">
     {#if props.variant === "activity"}
-      <ActivityTag i18n={TagIntlProvider} activityDate={props.date} />
+      <ActivityTag
+        i18n={TagIntlProvider}
+        activityDate={props.date}
+        type={isCover ? "tag" : "text"}
+      />
     {/if}
   </div>
 {/snippet}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -172,12 +172,4 @@
     gap: var(--gap-xs);
     flex-grow: 1;
   }
-
-  .trakt-summary-card-tags > :global(:not(:last-child))::after {
-    content: "·";
-    margin-left: var(--gap-xs);
-
-    font-size: var(--ni-16);
-    line-height: var(--ni-12);
-  }
 </style>

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -14,7 +14,7 @@
   <WatchersTag
     i18n={TagIntlProvider}
     watchers={media.watchers}
-    isTextOnly={isSummary}
+    type={isSummary ? "text" : "tag"}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -6,16 +6,10 @@
   import type { TrendingEntry } from "./useTrendingList";
 
   const { type, media, style }: MediaCardProps<TrendingEntry> = $props();
-
-  const isSummary = $derived(style === "summary");
 </script>
 
 {#snippet tag()}
-  <WatchersTag
-    i18n={TagIntlProvider}
-    watchers={media.watchers}
-    type={isSummary ? "text" : "tag"}
-  />
+  <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
 {/snippet}
 
 <DefaultMediaItem

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import AirDate from "$lib/components/media/tags/AirDateTag.svelte";
-  import InfoTag from "$lib/components/media/tags/InfoTag.svelte";
+  import CertificationTag from "$lib/components/media/tags/CertificationTag.svelte";
   import PlaysTag from "$lib/components/media/tags/PlaysTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import WatchCountTag from "$lib/components/media/tags/WatchCountTag.svelte";
@@ -34,9 +34,7 @@
       {/if}
 
       {#if media.certification}
-        <InfoTag>
-          {media.certification}
-        </InfoTag>
+        <CertificationTag certification={media.certification} />
       {/if}
 
       {#if media.year}

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -34,11 +34,11 @@
       {/if}
 
       {#if media.certification}
-        <CertificationTag certification={media.certification} />
+        <CertificationTag certification={media.certification} type="tag" />
       {/if}
 
       {#if media.year}
-        <AirDate i18n={TagIntlProvider} airDate={media.airDate} />
+        <AirDate i18n={TagIntlProvider} airDate={media.airDate} type="tag" />
       {/if}
 
       <!-- FIXME: re-enable watchers once we have better watching stats -->


### PR DESCRIPTION
## 🎶 Notes 🎶

- Text tags are now leading, resulting in a cleaner look, and more consistency after clicking on `more`
- Refactors:
  - Use a `type` for the tags instead of `isTextOnly`.
  - Extracts certification tag.

## 👀 Examples 👀
Before/after:
<img width="427" height="927" alt="Screenshot 2025-10-08 at 11 48 18" src="https://github.com/user-attachments/assets/fba217c8-98b0-421e-9e60-b1e15b5242e3" />

<img width="427" height="927" alt="Screenshot 2025-10-08 at 11 48 02" src="https://github.com/user-attachments/assets/3c635301-7fd2-415e-a3c0-e3f4ed218cf1" />

Before/after:
<img width="427" height="927" alt="Screenshot 2025-10-08 at 11 48 40" src="https://github.com/user-attachments/assets/ae28872b-444b-47d2-a56d-e99e415b1dd5" />

<img width="427" height="927" alt="Screenshot 2025-10-08 at 11 48 37" src="https://github.com/user-attachments/assets/a4650694-c2a4-4733-9be3-bb445f4f8000" />
