### PR TITLE
fix(tags): use correct tags in search results grid

### DIFF
--- a/projects/client/src/lib/components/media/tags/MediaTypeTag.svelte
+++ b/projects/client/src/lib/components/media/tags/MediaTypeTag.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
+  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import type { TagType } from "./models/TagType";
+  import type { TagIntl } from "./TagIntl";
+
+  const {
+    mediaType,
+    i18n,
+    type = "text",
+  }: { mediaType: MediaType; i18n: TagIntl; type?: TagType } = $props();
+</script>
+
+{#snippet icon()}
+  {#if mediaType === "movie"}
+    <MovieIcon />
+  {:else if mediaType === "show"}
+    <ShowIcon />
+  {/if}
+{/snippet}
+
+{#snippet content()}
+  <p class="meta-info capitalize no-wrap">
+    {i18n.mediaTypeLabel(mediaType)}
+  </p>
+{/snippet}
+
+{#if type === "text"}
+  <TextTag {icon}>
+    {@render content()}
+  </TextTag>
+{:else}
+  <StemTag {icon}>
+    {@render content()}
+  </StemTag>
+{/if}

--- a/projects/client/src/lib/components/media/tags/TagIntl.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntl.ts
@@ -1,3 +1,5 @@
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+
 export type TagIntl = {
   toDuration: (duration: number) => string;
   toEpisodeCount: (count: number) => string;
@@ -10,4 +12,5 @@ export type TagIntl = {
   watchCountLabel: () => string;
   trendLabel: (delta: number) => string;
   postCredits: (count: number) => string;
+  mediaTypeLabel: (type: MediaType) => string;
 };

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -6,6 +6,7 @@ import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 import { toHumanETA } from '$lib/utils/formatting/date/toHumanETA.ts';
 import { toRelativeHumanDay } from '$lib/utils/formatting/date/toRelativeHumanDay.ts';
 import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
+import { toTranslatedValue } from '$lib/utils/formatting/string/toTranslatedValue.ts';
 import type { TagIntl } from './TagIntl.ts';
 
 export const TagIntlProvider: TagIntl = {
@@ -25,4 +26,5 @@ export const TagIntlProvider: TagIntl = {
     delta ? toHumanNumber(Math.abs(delta), languageTag()) : '—',
   postCredits: (count) =>
     `${m.header_post_credits()} · ${toHumanNumber(count, languageTag())}`,
+  mediaTypeLabel: (type) => toTranslatedValue('type', type),
 };

--- a/projects/client/src/lib/features/search/SearchResultsGrid.svelte
+++ b/projects/client/src/lib/features/search/SearchResultsGrid.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
-  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
-  import InfoTag from "$lib/components/media/tags/InfoTag.svelte";
+  import MediaTypeTag from "$lib/components/media/tags/MediaTypeTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { getLocale } from "$lib/features/i18n";
   import { type MediaEntry } from "$lib/requests/models/MediaEntry";
@@ -11,7 +9,6 @@
   import DefaultMediaItem from "$lib/sections/lists/components/DefaultMediaItem.svelte";
   import DefaultPersonItem from "$lib/sections/lists/components/DefaultPersonItem.svelte";
   import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
-  import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
   import type { Snippet } from "svelte";
   import { useSearch } from "./useSearch";
 
@@ -33,19 +30,7 @@
 </script>
 
 {#snippet mediaTag(item: MediaEntry)}
-  <InfoTag>
-    {#snippet icon()}
-      {#if item.type === "movie"}
-        <MovieIcon />
-      {/if}
-
-      {#if item.type === "show"}
-        <ShowIcon />
-      {/if}
-    {/snippet}
-    {toTranslatedValue("type", item.type)}
-  </InfoTag>
-
+  <MediaTypeTag i18n={TagIntlProvider} mediaType={item.type} type="text" />
   <AirDateTag i18n={TagIntlProvider} airDate={item.airDate} />
 {/snippet}
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Extracts the media tag type as a separate tag component.
- Fixes the tags in the search results grid.

## 👀 Examples 👀
Before:

<img width="745" height="810" alt="Screenshot 2025-10-08 at 13 33 53" src="https://github.com/user-attachments/assets/f2b15925-5123-41c5-a6cb-e3f5d09b36e8" />

After:
<img width="745" height="810" alt="Screenshot 2025-10-08 at 13 33 59" src="https://github.com/user-attachments/assets/f31d167c-e18e-4a22-a492-b87165ce9564" />
