### PR TITLE
fix(tags): use correct tag type in episode and calendar cards

### DIFF
--- a/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
@@ -31,7 +31,7 @@
 </script>
 
 {#snippet tag()}
-  <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+  <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} type="tag" />
 {/snippet}
 
 <LandscapeCard>

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -73,7 +73,11 @@
       {/if}
 
       {#if props.variant === "activity"}
-        <ActivityTag i18n={TagIntlProvider} activityDate={props.date} />
+        <ActivityTag
+          i18n={TagIntlProvider}
+          activityDate={props.date}
+          type="tag"
+        />
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
## ♪ Note ♪

- Forgot some places to set the tag type

## 👀 Example 👀

Before:
<img width="842" height="456" alt="Screenshot 2025-10-08 at 16 18 25" src="https://github.com/user-attachments/assets/745c5269-725f-4fdd-80d4-8ba8f914c2e0" />

After:
<img width="745" height="456" alt="Screenshot 2025-10-08 at 16 18 02" src="https://github.com/user-attachments/assets/010e776c-4e84-48de-aa16-452403d8bedf" />
