### PR TITLE
Episode: fix media card links

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -140,7 +140,7 @@
   });
 
   const href = $derived(
-    isShowContext && rest.type === "episode"
+    rest.type === "episode"
       ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
       : UrlBuilder.media(media.type, media.slug),
   );


### PR DESCRIPTION
Closes #2139

# Problem

On the Home page, episode cards in **Continue Watching** and **History** correctly open the specific episode. But on the **expanded/full-page** versions of those sections, clicking an episode incorrectly navigated to the show page instead.

# Cause

The home sections render the cover-style `EpisodeCard`, whose cover always links to the episode. The expanded pages render the summary-style `MediaSummaryCard`, which only linked to the episode when an explicit `context="show"` prop was passed — otherwise it fell back to the show URL:

```ts
const href = $derived(
  isShowContext && rest.type === "episode"
    ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
    : UrlBuilder.media(media.type, media.slug), // ← show page
);
```

Neither expanded path passes `context="show"`:

- Continue Watching expanded → `variant: "next"`
- History expanded → `variant: "activity"`

…so every episode there linked to the show.

# Fix

An episode card's primary click target should always be the episode, matching `EpisodeCard`. Dropped the `isShowContext` requirement from the `href` derivation in `MediaSummaryCard.svelte`:

```ts
const href = $derived(
  rest.type === "episode"
    ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
    : UrlBuilder.media(media.type, media.slug),
);
```

The title/display logic that legitimately depends on `isShowContext` (showing the show name in mixed lists) is untouched — only the link target changes.

# Scope

`MediaSummaryCard` is the shared chokepoint for all summary-style episode cards, so this one-line change also fixes episodes in **user lists** (summary view) and **upcoming/calendar** episodes rendered in summary/compact/minimal layouts. The cover-style `EpisodeCard` was already correct everywhere.

# Testing

- `svelte-check`: 0 errors, 0 warnings
- `deno fmt`: clean
- Verified episodes in expanded Continue Watching and History now route to `/shows/{slug}/seasons/{season}/episodes/{number}`
