### PR TITLE
feat(episode): include guest stars in episode credits

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1397,6 +1397,32 @@
       "default": "Cast & Crew",
       "description": "Subtitle for the people drawer when searching across cast and crew. This should be as short and concise as possible."
     },
+    "header_main_cast": {
+      "default": "Main Cast",
+      "description": "Header for the primary cast group in the people drawer. This should be as short and concise as possible."
+    },
+    "header_supporting_cast": {
+      "default": "Supporting Cast",
+      "description": "Header for the guest or supporting cast group in the people drawer. This should be as short and concise as possible."
+    },
+    "text_person_count": {
+      "default": "{count} person",
+      "description": "Text for a single person count.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "text_people_count": {
+      "default": "{count} people",
+      "description": "Text for a plural people count.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "button_label_view_all_trending_movies": {
       "default": "View all trending movies",
       "description": "Aria-label for the button that allows users to view all trending movies."

--- a/projects/client/src/lib/requests/_internal/mapToMediaCrew.spec.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCrew.spec.ts
@@ -25,15 +25,34 @@ describe('mapToMediaCrew', () => {
           },
         },
       ],
+      guest_stars: [
+        {
+          character: 'Guest Role',
+          characters: ['Guest Role'],
+          person: {
+            name: 'Guest Actor',
+            ids: { slug: 'guest-actor' },
+            images: {},
+          },
+        },
+      ],
     } as unknown as PeopleResponse;
+    const crew = mapToMediaCrew(response);
 
-    expect(mapToMediaCrew(response).cast).toMatchObject([
+    expect(crew.cast).toMatchObject([
       {
         characterName: 'Primary Role',
         characters: ['Primary Role', 'Secondary Role'],
       },
       {
         characterName: '',
+      },
+    ]);
+    expect(crew.guestStars).toMatchObject([
+      {
+        characterName: 'Guest Role',
+        key: 'guest-actor',
+        name: 'Guest Actor',
       },
     ]);
   });

--- a/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
@@ -6,11 +6,16 @@ import type {
 import type { CastResponse, CrewResponse, PeopleResponse } from '@trakt/api';
 import { mapToHeadshot } from './mapToHeadshot.ts';
 
+type PeopleResponseWithGuestStars = PeopleResponse & {
+  guest_stars?: CastResponse[] | null;
+};
+
 export const EMPTY_CREW: Readonly<MediaCrew> = {
   directors: [],
   writers: [],
   creators: [],
   cast: [],
+  guestStars: [],
 };
 
 function toMember(response: CrewResponse | CastResponse) {
@@ -48,14 +53,18 @@ function toCastMember(
 export function mapToMediaCrew(
   response: PeopleResponse,
 ): MediaCrew {
+  const people = response as PeopleResponseWithGuestStars;
+
   return {
-    directors: (response.crew?.directing ?? [])
+    directors: (people.crew?.directing ?? [])
       .map(toCrewMember),
-    writers: (response.crew?.writing ?? [])
+    writers: (people.crew?.writing ?? [])
       .map(toCrewMember),
-    creators: (response.crew?.['created by'] ?? [])
+    creators: (people.crew?.['created by'] ?? [])
       .map(toCrewMember),
-    cast: (response.cast ?? [])
+    cast: (people.cast ?? [])
+      .map(toCastMember),
+    guestStars: (people.guest_stars ?? [])
       .map(toCastMember),
   };
 }

--- a/projects/client/src/lib/requests/models/MediaCrew.ts
+++ b/projects/client/src/lib/requests/models/MediaCrew.ts
@@ -28,5 +28,6 @@ export const MediaCrewSchema = z.object({
   writers: z.array(CrewMemberSchema),
   creators: z.array(CrewMemberSchema),
   cast: z.array(CastMemberSchema),
+  guestStars: z.array(CastMemberSchema),
 });
 export type MediaCrew = z.infer<typeof MediaCrewSchema>;

--- a/projects/client/src/lib/requests/queries/episode/episodePeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodePeopleQuery.ts
@@ -22,7 +22,7 @@ const episodePeopleRequest = (
         episode,
       },
       query: {
-        extended: 'images',
+        extended: 'images,guest_stars' as 'images',
       },
     });
 

--- a/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
@@ -23,7 +23,7 @@
   let isDescriptionExpanded = $state(false);
 
   const episodeCount = $derived(
-    type === "movie" ? undefined : member.episodeCount,
+    type === "show" ? member.episodeCount : undefined,
   );
   const headshotUrl = $derived.by(() => {
     const url = member.headshot?.url.thumb;

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -37,6 +37,7 @@
   const currentSeasonOnly = $derived(
     seasons.filter((s) => s.number === episode.season),
   );
+  const actors = $derived([...crew.cast, ...crew.guestStars]);
 
   // The seasons drawer can switch seasons via the `season` search param
   // (set by the dropdown / poster links), independent of the episode's own
@@ -106,7 +107,7 @@
 
 <CastList
   title={m.list_title_actors()}
-  cast={crew.cast}
+  cast={actors}
   slug={show.slug}
   type="episode"
 />

--- a/projects/client/src/lib/sections/summary/components/cast/CastDrawerHost.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/cast/CastDrawerHost.spec.ts
@@ -1,4 +1,6 @@
 import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { EpisodeSiloPeopleMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloPeopleMappedMock.ts';
+import { MovieHereticPeopleMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts';
 import { ShowSiloPeopleMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts';
 import { fireEvent, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
@@ -57,7 +59,11 @@ describe('CastDrawerHost', () => {
       'overlay',
     );
     expect(screen.getByText('People')).toBeInTheDocument();
-    expect(screen.getByText('Cast')).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      name: `Cast ${crew.cast.length} people`,
+    })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Supporting Cast/ })).not
+      .toBeInTheDocument();
     expect(screen.getByText('Rebecca Ferguson')).toBeInTheDocument();
     expect(screen.getByText('Juliette Nichols'))
       .toBeInTheDocument();
@@ -83,12 +89,21 @@ describe('CastDrawerHost', () => {
     await waitFor(() => {
       expect(screen.getByText('Cast & Crew')).toBeInTheDocument();
     });
+    expect(screen.getByRole('heading', {
+      name: 'Cast 1 person',
+    })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Supporting Cast/ })).not
+      .toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Crew/ })).not
+      .toBeInTheDocument();
     expect(screen.getByText('Juliette Nichols (voice)')).toBeInTheDocument();
 
     await user.clear(searchInput);
 
     await waitFor(() => {
-      expect(screen.getByText('Cast')).toBeInTheDocument();
+      expect(screen.getByRole('heading', {
+        name: `Cast ${crew.cast.length} people`,
+      })).toBeInTheDocument();
     });
     expect(screen.getByText('Juliette Nichols (voice)')).toBeInTheDocument();
 
@@ -137,5 +152,79 @@ describe('CastDrawerHost', () => {
     });
     expect(screen.getByRole('button', { name: 'Cast' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Crew' })).toBeInTheDocument();
+  });
+
+  it('hides episode counts for episode credits', async () => {
+    renderComponent(CastDrawerHost, {
+      props: {
+        crew: EpisodeSiloPeopleMappedMock,
+        type: 'episode',
+        onClose: vi.fn(),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('searchbox', { name: 'Search people' }))
+        .toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('heading', {
+      name: `Main Cast ${EpisodeSiloPeopleMappedMock.cast.length} people`,
+    })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      name:
+        `Supporting Cast ${EpisodeSiloPeopleMappedMock.guestStars.length} person`,
+    })).toBeInTheDocument();
+    expect(screen.getByText('Sophie Thompson')).toBeInTheDocument();
+    expect(screen.queryByText('2 eps.')).not.toBeInTheDocument();
+  });
+
+  it('uses Cast as the episode cast header when only supporting cast is available', async () => {
+    const crew = {
+      ...EpisodeSiloPeopleMappedMock,
+      cast: [],
+    };
+
+    renderComponent(CastDrawerHost, {
+      props: {
+        crew,
+        type: 'episode',
+        onClose: vi.fn(),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('searchbox', { name: 'Search people' }))
+        .toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('heading', {
+      name: `Cast ${crew.guestStars.length} person`,
+    })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Main Cast/ })).not
+      .toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Supporting Cast/ })).not
+      .toBeInTheDocument();
+  });
+
+  it('uses Cast as the movie cast group header', async () => {
+    renderComponent(CastDrawerHost, {
+      props: {
+        crew: MovieHereticPeopleMappedMock,
+        type: 'movie',
+        onClose: vi.fn(),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('searchbox', { name: 'Search people' }))
+        .toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('heading', {
+      name: `Cast ${MovieHereticPeopleMappedMock.cast.length} people`,
+    })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Main Cast/ })).not
+      .toBeInTheDocument();
   });
 });

--- a/projects/client/src/lib/sections/summary/components/cast/CastDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/cast/CastDrawerHost.svelte
@@ -14,8 +14,16 @@
   import { fade } from "svelte/transition";
   import CreditMemberItem from "../../../lists/components/CreditMemberItem.svelte";
   import type { CreditMember } from "../../../lists/models/CreditMember";
+  import CreditGroupHeader from "./_internal/CreditGroupHeader.svelte";
 
   type CreditsType = "cast" | "crew";
+  type CreditGroupId = "main-cast" | "supporting-cast" | "crew";
+  type CreditGroup = {
+    id: CreditGroupId;
+    label: string;
+    members: CreditMember[];
+    showHeader: boolean;
+  };
 
   const creditOptions: ToggleOption<CreditsType>[] = [
     {
@@ -122,9 +130,32 @@
   };
   const toCreditMemberKey = (member: CreditMember) =>
     `${member.key}-${member.positions ? "cast" : "crew"}`;
+  const toCreditGroupHeaderId = (group: CreditGroup) =>
+    `cast-list-${type}-${isSearching ? "search" : creditsType}-${group.id}-header`;
 
-  const castMembers = $derived(
+  const filterCreditMembers = (members: CreditMember[]) => {
+    if (!isSearching) return members;
+
+    return members.filter(({ description, name }) =>
+      `${name} ${description}`.toLocaleLowerCase().includes(
+        normalizedSearchTerm,
+      )
+    );
+  };
+
+  const mainCastMembers = $derived(
     crew.cast.map(toCastCreditMember),
+  );
+  const supportingCastMembers = $derived(
+    type === "episode" ? crew.guestStars.map(toCastCreditMember) : [],
+  );
+  const castGroupLabel = $derived(
+    type === "episode" ? m.header_main_cast() : m.drawer_meta_info_cast(),
+  );
+  const supportingCastGroupLabel = $derived(
+    type === "episode" && mainCastMembers.length > 0
+      ? m.header_supporting_cast()
+      : m.drawer_meta_info_cast(),
   );
   const crewMembers = $derived(
     uniqueCrewMembers([
@@ -133,24 +164,44 @@
       ...crew.writers,
     ]).map(toCrewCreditMember),
   );
-  const allCredits = $derived([...castMembers, ...crewMembers]);
-  const selectedCredits = $derived.by(() => {
-    if (isSearching) return allCredits;
-    if (creditsType === "crew") return crewMembers;
-
-    return castMembers;
-  });
-  const visibleCredits = $derived.by(() => {
-    if (!isSearching) {
-      return selectedCredits;
+  const allCreditGroups = $derived<CreditGroup[]>([
+    {
+      id: "main-cast",
+      label: castGroupLabel,
+      members: mainCastMembers,
+      showHeader: true,
+    },
+    {
+      id: "supporting-cast",
+      label: supportingCastGroupLabel,
+      members: supportingCastMembers,
+      showHeader: true,
+    },
+    {
+      id: "crew",
+      label: m.drawer_meta_info_crew(),
+      members: crewMembers,
+      showHeader: isSearching,
+    },
+  ]);
+  const selectedCreditGroups = $derived.by(() => {
+    if (isSearching) return allCreditGroups;
+    if (creditsType === "crew") {
+      return allCreditGroups
+        .filter((group) => group.id === "crew")
+        .map((group) => ({ ...group, showHeader: false }));
     }
 
-    return selectedCredits.filter(({ description, name }) =>
-      `${name} ${description}`.toLocaleLowerCase().includes(
-        normalizedSearchTerm,
-      )
-    );
+    return allCreditGroups.filter((group) => group.id !== "crew");
   });
+  const visibleCreditGroups = $derived(
+    selectedCreditGroups
+      .map((group) => ({
+        ...group,
+        members: filterCreditMembers(group.members),
+      }))
+      .filter((group) => group.members.length > 0),
+  );
 </script>
 
 <Drawer
@@ -173,14 +224,33 @@
         />
       </label>
 
-      {#if visibleCredits.length > 0}
+      {#if visibleCreditGroups.length > 0}
         <div
           id={`cast-list-${type}-${isSearching ? "search" : creditsType}`}
           class="credit-list"
-          role="list"
         >
-          {#each visibleCredits as item (toCreditMemberKey(item))}
-            <CreditMemberItem member={item} {type} />
+          {#each visibleCreditGroups as group (group.id)}
+            <section class="credit-list-group">
+              {#if group.showHeader}
+                <CreditGroupHeader
+                  id={toCreditGroupHeaderId(group)}
+                  label={group.label}
+                  count={group.members.length}
+                />
+              {/if}
+
+              <div
+                class="credit-list-group-items"
+                role="list"
+                aria-labelledby={group.showHeader
+                  ? toCreditGroupHeaderId(group)
+                  : undefined}
+              >
+                {#each group.members as item (toCreditMemberKey(item))}
+                  <CreditMemberItem member={item} {type} />
+                {/each}
+              </div>
+            </section>
           {/each}
         </div>
       {:else}
@@ -240,9 +310,22 @@
       }
     }
 
-    .credit-list {
+    .credit-list,
+    .credit-list-group,
+    .credit-list-group-items {
       display: flex;
       flex-direction: column;
+    }
+
+    .credit-list {
+      gap: var(--gap-m);
+    }
+
+    .credit-list-group {
+      gap: var(--gap-xs);
+    }
+
+    .credit-list-group-items {
       gap: var(--gap-s);
     }
 

--- a/projects/client/src/lib/sections/summary/components/cast/_internal/CreditGroupHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/cast/_internal/CreditGroupHeader.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+
+  const {
+    id,
+    label,
+    count,
+  }: {
+    id: string;
+    label: string;
+    count: number;
+  } = $props();
+
+  const peopleCount = $derived(
+    count === 1
+      ? m.text_person_count({ count })
+      : m.text_people_count({ count }),
+  );
+</script>
+
+<div {id} class="trakt-list-header" role="heading" aria-level="2">
+  <div class="trakt-list-header-content">
+    <div class="trakt-list-title">
+      <div class="trakt-list-title-wrapper">
+        <span class="bold ellipsis">
+          {label}
+        </span>
+        <span class="small secondary ellipsis">
+          {peopleCount}
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style lang="scss">
+  .trakt-list-header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    margin: 0;
+    min-height: var(--ni-40);
+    height: var(--ni-40);
+
+    user-select: none;
+  }
+
+  .trakt-list-title,
+  .trakt-list-header-content,
+  .trakt-list-title-wrapper {
+    display: flex;
+    min-width: 0;
+  }
+
+  .trakt-list-title-wrapper {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .trakt-list-title {
+    align-items: center;
+    gap: var(--gap-xs);
+  }
+
+  .trakt-list-header-content {
+    justify-content: space-between;
+    width: 100%;
+  }
+</style>

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloPeopleMappedMock.ts
@@ -94,6 +94,21 @@ export const EpisodeSiloPeopleMappedMock: MediaCrew = {
       'name': 'Tim Robbins',
     },
   ],
+  'guestStars': [
+    {
+      'characterName': 'Gloria Hildebrandt',
+      'headshot': {
+        'url': {
+          'thumb':
+            'https://walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
+          'medium':
+            'https://walter-r2.trakt.tv/images/people/000/014/103/headshots/medium/2e92bf71ee.jpg.webp',
+        },
+      },
+      'key': 'sophie-thompson',
+      'name': 'Sophie Thompson',
+    },
+  ],
   'creators': [],
   'directors': [
     {

--- a/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloPeopleResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloPeopleResponseMock.ts
@@ -1,6 +1,10 @@
-import type { PeopleResponse } from '@trakt/api';
+import type { CastResponse, PeopleResponse } from '@trakt/api';
 
-export const EpisodeSiloPeopleResponseMock: PeopleResponse = {
+type PeopleResponseWithGuestStars = PeopleResponse & {
+  guest_stars: CastResponse[];
+};
+
+export const EpisodeSiloPeopleResponseMock: PeopleResponseWithGuestStars = {
   'cast': [
     {
       'character': 'Juliette Nichols',
@@ -187,6 +191,34 @@ export const EpisodeSiloPeopleResponseMock: PeopleResponse = {
       'images': {
         'headshot': [
           'walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+        ],
+      },
+    },
+  ],
+  'guest_stars': [
+    {
+      'character': 'Gloria Hildebrandt',
+      'characters': [
+        'Gloria Hildebrandt',
+      ],
+      'person': {
+        'name': 'Sophie Thompson',
+        'ids': {
+          'trakt': 14103,
+          'slug': 'sophie-thompson',
+          'imdb': 'nm0860749',
+          'tmdb': 10207,
+        },
+        'images': {
+          'headshot': [
+            'walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
+          ],
+          'fanart': [],
+        },
+      },
+      'images': {
+        'headshot': [
+          'walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
         ],
       },
     },

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
@@ -196,6 +196,7 @@ export const MovieHereticPeopleMappedMock: MediaCrew = {
       'name': 'Carolyn Adair',
     },
   ],
+  'guestStars': [],
   'directors': [
     {
       'key': 'scott-beck',

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
@@ -185,6 +185,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
       'name': 'Steve Zahn',
     },
   ],
+  'guestStars': [],
   'directors': [
     {
       'key': 'rhiannon-preece-towey',

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -88,7 +88,13 @@ export const shows = [
   ),
   http.get(
     `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/people`,
-    () => {
+    ({ request }) => {
+      if (
+        new URL(request.url).searchParams.get('extended') !== 'images'
+      ) {
+        return new HttpResponse(null, { status: 400 });
+      }
+
       return HttpResponse.json(ShowSiloPeopleResponseMock);
     },
   ),
@@ -148,7 +154,14 @@ export const shows = [
   ),
   http.get(
     `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/${EpisodeSiloResponseMock.season}/episodes/${EpisodeSiloResponseMock.number}/people`,
-    () => {
+    ({ request }) => {
+      if (
+        new URL(request.url).searchParams.get('extended') !==
+          'images,guest_stars'
+      ) {
+        return new HttpResponse(null, { status: 400 });
+      }
+
       return HttpResponse.json(EpisodeSiloPeopleResponseMock);
     },
   ),


### PR DESCRIPTION
## Summary
- Fetch **episode** people with `extended=images,guest_stars` and map `guest_stars`.
- Include **episode** guest stars in the Actors row by appending them after main cast.
- Keep show and movie people behavior unchanged: no guest-star fetch for shows or movies, and their Actors rows use main cast only.
- Group People drawer cast results with section headers:
  - Shows and movies use `Cast`.
  - Episodes with main cast use `Main Cast` and `Supporting Cast`.
  - Episodes with only supporting cast use `Cast` (eg: Black Mirror)
  - Empty groups are hidden.
- Keep search across main cast, supporting cast, and crew while preserving visible group headers.
- Hide episode-count tags for episode credits; show counts remain visible for show credits only.

Note: API improvements on sorting cast and guests still in progress, it will feel even better when done.

## Look and Feel

### Show

<img width="1275" height="1013" alt="Screenshot 2026-06-10 at 10 14 41" src="https://github.com/user-attachments/assets/78143b4a-4302-47a5-8b86-8421b3ac0493" />
<img width="1275" height="1013" alt="Screenshot 2026-06-10 at 10 15 02" src="https://github.com/user-attachments/assets/88adf1bf-04ae-4009-9fa1-c839a611179f" />

### Movie

<img width="1275" height="1013" alt="Screenshot 2026-06-10 at 10 14 32" src="https://github.com/user-attachments/assets/3f4cba06-883c-42ae-8f2e-059b7874ca45" />

### Black Mirror == show with only "guest" stars

<img width="1275" height="1013" alt="Screenshot 2026-06-10 at 10 15 24" src="https://github.com/user-attachments/assets/69dc4489-4c77-4514-b001-d5ce5a82b78a" />
<img width="1275" height="1013" alt="Screenshot 2026-06-10 at 10 15 36" src="https://github.com/user-attachments/assets/853795ad-3eef-439d-8f88-3047a9b96665" />



