### PR TITLE
feat(button): adopt outline flat style as the default look

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -95,6 +95,11 @@
     $bg: var(--color-background-#{$color});
     $fg: var(--color-foreground-#{$color});
 
+    // Stable per-colour accent, immune to the hover fg/bg var-swap.
+    :global(#{$base}[data-color=#{$color}]) {
+      --accent-action-button: #{$bg};
+    }
+
     @include variant-styles($base, $color, primary, $bg, $fg);
     @include variant-styles($base, $color, secondary, $fg, $bg);
 
@@ -145,7 +150,7 @@
     align-items: center;
     flex-shrink: 0;
 
-    border-radius: var(--border-radius-m);
+    border-radius: var(--border-radius-l);
     background-color: var(--color-background-action-button);
     color: var(--color-foreground-action-button);
 
@@ -177,18 +182,42 @@
     display: none;
   }
 
+  // Flat is an outline matching the labelled buttons: accent ring + accent
+  // icon, primary heavier than secondary, colour-shift hover, no glow.
+  :global(#{$b}[data-style=flat][data-variant=primary]#{$on}) {
+    background-color: color-mix(in srgb, var(--accent-action-button) 14%, transparent);
+    color: var(--accent-action-button);
+    border: var(--border-thickness-xs) solid
+      color-mix(in srgb, var(--accent-action-button) 65%, transparent);
+  }
+
+  :global(#{$b}[data-style=flat][data-variant=secondary]#{$on}) {
+    background-color: transparent;
+    color: var(--accent-action-button);
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--accent-action-button) 30%, transparent);
+  }
+
   @include for-mouse {
-    :global(#{$b}:hover#{$on}) {
-      box-shadow: 0 var(--ni-2) var(--ni-8) var(--ni-neg-2)
-        color-mix(
-          in srgb,
-          var(--color-background-action-button) 50%,
-          transparent
-        );
+    :global(#{$b}[data-style=flat][data-variant=primary]:hover#{$on}) {
+      background-color: color-mix(in srgb, var(--accent-action-button) 26%, transparent);
+      border-color: color-mix(in srgb, var(--accent-action-button) 95%, transparent);
+    }
+
+    :global(#{$b}[data-style=flat][data-variant=secondary]:hover#{$on}) {
+      background-color: color-mix(in srgb, var(--accent-action-button) 16%, transparent);
+      border-color: color-mix(in srgb, var(--accent-action-button) 60%, transparent);
     }
   }
 
-  :global(#{$b}:active#{$on}) {
+  :global(#{$b}[data-style=flat]:active#{$on}) {
+    transform: scale(0.92);
+    background-color: color-mix(in srgb, var(--accent-action-button) 36%, transparent);
+    border-color: var(--accent-action-button);
+    box-shadow: none;
+  }
+
+  :global(#{$b}[data-style=ghost]:active#{$on}) {
     transform: scale(0.92);
     box-shadow: none;
   }
@@ -206,28 +235,6 @@
   :global(#{$b}[data-size=large]) {
     scale: 1.2;
     margin: var(--ni-4);
-  }
-
-  :global(#{$b}[data-variant=secondary]:not([data-style=ghost])#{$on}) {
-    background-color: color-mix(
-      in srgb,
-      var(--color-foreground-action-button) 5%,
-      transparent
-    );
-    border: var(--border-thickness-xxs) solid
-      color-mix(
-        in srgb,
-        var(--color-foreground-action-button) 50%,
-        transparent
-      );
-    color: var(--color-text-primary);
-  }
-
-  @include for-mouse {
-    :global(#{$b}[data-variant=secondary]:not([data-style=ghost])#{$on}:hover) {
-      background-color: var(--color-background-action-button);
-      color: var(--color-foreground-action-button);
-    }
   }
 
   :global(#{$b}[data-style=ghost]) {

--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -106,6 +106,11 @@
     $bg: var(--color-background-#{$color});
     $fg: var(--color-foreground-#{$color});
 
+    :global(#{$base}[data-color=#{$color}]) {
+      --accent-action-button: var(--color-accent-#{$color}, #{$bg});
+      --surface-action-button: #{$bg};
+    }
+
     @include variant-styles($base, $color, primary, $bg, $fg);
     @include variant-styles($base, $color, secondary, $fg, $bg);
 
@@ -188,18 +193,14 @@
     display: none;
   }
 
-  @include for-mouse {
-    :global(#{$b}:hover#{$on}) {
-      box-shadow: 0 var(--ni-2) var(--ni-8) var(--ni-neg-2)
-        color-mix(
-          in srgb,
-          var(--color-background-action-button) 50%,
-          transparent
-        );
-    }
-  }
+  @include flat-outline-button(
+    $b,
+    var(--accent-action-button),
+    var(--surface-action-button),
+    scale(0.92)
+  );
 
-  :global(#{$b}:active#{$on}) {
+  :global(#{$b}[data-style=ghost]:active#{$on}) {
     transform: scale(0.92);
     box-shadow: none;
   }
@@ -217,28 +218,6 @@
   :global(#{$b}[data-size=large]) {
     scale: 1.2;
     margin: var(--ni-4);
-  }
-
-  :global(#{$b}[data-variant=secondary]:not([data-style=ghost])#{$on}) {
-    background-color: color-mix(
-      in srgb,
-      var(--color-foreground-action-button) 5%,
-      transparent
-    );
-    border: var(--border-thickness-xxs) solid
-      color-mix(
-        in srgb,
-        var(--color-foreground-action-button) 50%,
-        transparent
-      );
-    color: var(--color-text-primary);
-  }
-
-  @include for-mouse {
-    :global(#{$b}[data-variant=secondary]:not([data-style=ghost])#{$on}:hover) {
-      background-color: var(--color-background-action-button);
-      color: var(--color-foreground-action-button);
-    }
   }
 
   :global(#{$b}[data-style=ghost]) {

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -129,6 +129,12 @@
     $bg: var(--color-background-#{$color});
     $fg: var(--color-foreground-#{$color});
 
+    // Stable per-colour accent, immune to the hover fg/bg var-swap below.
+    // The outline flat style leans on this so its ring/text stay the accent.
+    :global(#{$base}[data-color=#{$color}]) {
+      --accent-button: #{$bg};
+    }
+
     @include variant-styles($base, $color, primary, $bg, $fg);
     @include variant-styles($base, $color, secondary, $fg, $bg);
 
@@ -251,7 +257,7 @@
   :global(#{$b}:active[disabled]) {
     height: var(--button-height);
     box-sizing: border-box;
-    border-radius: var(--border-radius-m);
+    border-radius: var(--border-radius-l);
   }
 
   :global(#{$b}::before) {
@@ -344,16 +350,39 @@
     outline: var(--border-thickness-xxs) solid var(--color-foreground);
   }
 
+  // Flat is an outline: no heavy fill, accent ring + accent text. Primary
+  // leans heavier (thicker ring + a tint of fill); secondary is a quiet
+  // hairline ring. Hover/press are pure colour shifts - no lift, no glow.
+  :global(#{$b}[data-style=flat][data-variant=primary]#{$on}) {
+    background: color-mix(in srgb, var(--accent-button) 14%, transparent);
+    color: var(--accent-button);
+    border: var(--border-thickness-xs) solid
+      color-mix(in srgb, var(--accent-button) 65%, transparent);
+  }
+
+  :global(#{$b}[data-style=flat][data-variant=secondary]#{$on}) {
+    background: transparent;
+    color: var(--accent-button);
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--accent-button) 30%, transparent);
+  }
+
   @include for-mouse {
-    :global(#{$b}[data-style=flat]:hover#{$on}) {
-      box-shadow: 0 var(--ni-4) var(--ni-12) var(--ni-neg-2)
-        color-mix(in srgb, var(--color-background-button) 45%, transparent);
-      transform: translateY(calc(var(--ni-1) * -1));
+    :global(#{$b}[data-style=flat][data-variant=primary]:hover#{$on}) {
+      background: color-mix(in srgb, var(--accent-button) 26%, transparent);
+      border-color: color-mix(in srgb, var(--accent-button) 95%, transparent);
+    }
+
+    :global(#{$b}[data-style=flat][data-variant=secondary]:hover#{$on}) {
+      background: color-mix(in srgb, var(--accent-button) 16%, transparent);
+      border-color: color-mix(in srgb, var(--accent-button) 60%, transparent);
     }
   }
 
   :global(#{$b}[data-style=flat]:active#{$on}) {
     transform: scale(calc(var(--scale-factor-button) * 0.97));
+    background: color-mix(in srgb, var(--accent-button) 36%, transparent);
+    border-color: var(--accent-button);
     box-shadow: none;
   }
 

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -132,6 +132,13 @@
     $bg: var(--color-background-#{$color});
     $fg: var(--color-foreground-#{$color});
 
+    @if $color != "custom" {
+      :global(#{$base}[data-color=#{$color}]) {
+        --accent-button: var(--color-accent-#{$color}, #{$bg});
+        --surface-button: #{$bg};
+      }
+    }
+
     @include variant-styles($base, $color, primary, $bg, $fg);
     @include variant-styles($base, $color, secondary, $fg, $bg);
 
@@ -347,17 +354,16 @@
     outline: var(--border-thickness-xxs) solid var(--color-foreground);
   }
 
-  @include for-mouse {
-    :global(#{$b}[data-style=flat]:hover#{$on}) {
-      box-shadow: 0 var(--ni-4) var(--ni-12) var(--ni-neg-2)
-        color-mix(in srgb, var(--color-background-button) 45%, transparent);
-      transform: translateY(calc(var(--ni-1) * -1));
-    }
-  }
+  @include flat-outline-button(
+    $b,
+    var(--accent-button),
+    var(--surface-button),
+    scale(calc(var(--scale-factor-button) * 0.97)),
+    ":not([data-color='custom'])"
+  );
 
-  :global(#{$b}[data-style=flat]:active#{$on}) {
+  :global(#{$b}[data-style=flat][data-color=custom]:active#{$on}) {
     transform: scale(calc(var(--scale-factor-button) * 0.97));
-    box-shadow: none;
   }
 
   :global(#{$b}[data-style=underlined]) {
@@ -434,8 +440,6 @@
     }
   }
 
-  // Press feedback to match `flat`/`ghost`; keep the stroke (unlike `flat`,
-  // whose box-shadow is a hover lift, outline's box-shadow is the border).
   :global(#{$b}[data-style=outline]:active#{$on}) {
     transform: scale(calc(var(--scale-factor-button) * 0.97));
   }

--- a/projects/client/src/lib/sections/landing/components/JoinForFreeButton.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFreeButton.svelte
@@ -9,11 +9,13 @@
 
 <trakt-join-for-free-button>
   <Button
-    color="purple"
+    color="custom"
     label={m.button_label_join_trakt()}
     style="flat"
     navigationType={DpadNavigationType.Item}
     onclick={login}
+    --color-background-custom="var(--purple-500)"
+    --color-foreground-custom="var(--purple-50)"
   >
     {m.button_text_join_trakt_for_free()}
   </Button>

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -245,6 +245,58 @@
   }
 }
 
+@mixin flat-outline-button(
+  $selector,
+  $accent,
+  $surface,
+  $active-transform,
+  $exclude: ""
+) {
+  $on: ":not([disabled]):not([aria-disabled='true'])#{$exclude}";
+
+  :global(#{$selector}[data-style='flat'][data-variant='primary']#{$on}) {
+    --flat-ring-width: var(--border-thickness-xs);
+
+    background-color: color-mix(in srgb, #{$surface} 14%, transparent);
+    color: #{$accent};
+    box-shadow: inset 0 0 0 var(--flat-ring-width)
+      color-mix(in srgb, #{$accent} 65%, transparent);
+  }
+
+  :global(#{$selector}[data-style='flat'][data-variant='secondary']#{$on}) {
+    --flat-ring-width: var(--border-thickness-xxs);
+
+    background-color: transparent;
+    color: #{$accent};
+    box-shadow: inset 0 0 0 var(--flat-ring-width)
+      color-mix(in srgb, #{$accent} 30%, transparent);
+  }
+
+  @include for-mouse {
+    :global(#{$selector}[data-style='flat'][data-variant='primary']:hover#{$on}) {
+      background-color: color-mix(in srgb, #{$surface} 26%, transparent);
+      box-shadow: inset 0 0 0 var(--flat-ring-width)
+        color-mix(in srgb, #{$accent} 95%, transparent);
+    }
+
+    :global(#{$selector}[data-style='flat'][data-variant='secondary']:hover#{$on}) {
+      background-color: color-mix(in srgb, #{$surface} 16%, transparent);
+      box-shadow: inset 0 0 0 var(--flat-ring-width)
+        color-mix(in srgb, #{$accent} 60%, transparent);
+    }
+  }
+
+  // Emitted per variant so the press state ties with the hover rules above on
+  // specificity and wins on source order. A mouse press always also matches
+  // `:hover`, so a bare `[data-style]:active` would lose its fill and ring.
+  :global(#{$selector}[data-style='flat'][data-variant='primary']:active#{$on}),
+  :global(#{$selector}[data-style='flat'][data-variant='secondary']:active#{$on}) {
+    transform: $active-transform;
+    background-color: color-mix(in srgb, #{$surface} 36%, transparent);
+    box-shadow: inset 0 0 0 var(--flat-ring-width) #{$accent};
+  }
+}
+
 // Premium "rare/tier" chip decoration: a diagonal tint gradient, a hairline
 // ring, and a soft drop glow, all keyed off a single colour. Extracted from
 // the match-drawer chips so rank medals and other accents share one look.

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -23,6 +23,12 @@
   --color-medal-bronze: var(--orange-400);
   --color-text-emphasis: var(--purple-700);
 
+  --color-accent-purple: var(--purple-700);
+  --color-accent-red: var(--red-700);
+  --color-accent-blue: var(--blue-700);
+  --color-accent-orange: var(--orange-700);
+  --color-accent-default: var(--color-foreground);
+
   --color-input-background: var(--shade-10);
 
   --color-drawer-border: var(--shade-400);
@@ -514,6 +520,12 @@
   --color-medal-silver: var(--shade-400);
   --color-medal-bronze: var(--orange-400);
   --color-text-emphasis: var(--purple-300);
+
+  --color-accent-purple: var(--purple-300);
+  --color-accent-red: var(--red-300);
+  --color-accent-blue: var(--blue-300);
+  --color-accent-orange: var(--orange-300);
+  --color-accent-default: var(--color-foreground);
 
   --color-input-background: color-mix(
     in srgb,


### PR DESCRIPTION
## What

Makes the redesigned button look the app-wide default (builds on the bits-ui port from #2733).

- **Flat (the default style) becomes an outline** instead of a solid fill: accent ring + accent text/icon, with a primary/secondary hierarchy - primary is heavier (2px ring + a tint of fill), secondary is a quiet hairline ring.
- **Rounder radius** (`--border-radius-l`) for a more tactile feel.
- **Hover/press are pure colour shifts** - stronger fill tint + brighter ring on hover, deeper fill + full ring on press. No lift, no glow (both read as dated/cheap), no size jump.
- A swap-immune `--accent-button` / `--accent-action-button` is derived per colour so the outline's ring/text survive the existing hover fg/bg var-swap.
- Action (icon) buttons share the same outline language so they stay consistent with labelled buttons.
- Ghost, underlined and disabled states keep their baseline behaviour.

The 5 explored variants (aurora/glass/elevated/outline/tactile) and the design-system toggle were scaffolding; this PR ships only the chosen merge ("outline + tactile radius"). The DS buttons page is unchanged from main.

## Notes

- This flips every filled primary CTA to an outline app-wide. On busy/cover backgrounds a solid fill sometimes carried the contrast - worth a look during review. If a few high-emphasis spots need the old solid fill we can add a dedicated `solid` style rather than reverting the default.

## Test

- `deno task check`: 0 errors / 0 warnings
- `deno task test:unit` (buttons): 24 passed
- Verified live across home / summary / design-system routes.