### PR TITLE
List: item, like and list counts across list surfaces

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1867,6 +1867,10 @@
       "default": "by",
       "description": "Text used to indicate the creator of a list."
     },
+    "label_list_item_count": {
+      "default": "{count} items",
+      "description": "Accessible label / tooltip for the item count shown next to a list."
+    },
     "image_alt_user_avatar": {
       "default": "{username}'s avatar",
       "description": "Alt text for a user's avatar image.",
@@ -10491,6 +10495,14 @@
     "preview_feature_description_soundtrack": {
       "default": "Adds a soundtrack section to movie and show pages, with playback where a track can be matched.",
       "description": "Description for the soundtrack preview feature."
+    },
+    "preview_feature_title_list_counts": {
+      "default": "List Counts",
+      "description": "Title for the List Counts preview feature."
+    },
+    "preview_feature_description_list_counts": {
+      "default": "Shows how many items a list holds, and how many lists a section has.",
+      "description": "Description for the List Counts preview feature."
     },
     "page_title_widget_background": {
       "default": "Background",

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -6,4 +6,5 @@ export enum FeatureFlag {
   Leaderboard = 'leaderboard',
   ParentalGuide = 'parental-guide',
   Soundtrack = 'soundtrack',
+  ListCounts = 'list-counts',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -1,6 +1,7 @@
 import EditModeIcon from '$lib/components/icons/EditModeIcon.svelte';
 import FastRewindIcon from '$lib/components/icons/FastRewindIcon.svelte';
 import FavoriteIcon from '$lib/components/icons/FavoriteIcon.svelte';
+import ListIcon from '$lib/components/icons/mobile/ListIcon.svelte';
 import MusicNoteIcon from '$lib/components/icons/MusicNoteIcon.svelte';
 import NoSpoilerIcon from '$lib/components/icons/NoSpoilerIcon.svelte';
 import PeopleIcon from '$lib/components/icons/PeopleIcon.svelte';
@@ -79,6 +80,12 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     title: () => m.preview_feature_title_soundtrack(),
     addedAt: new Date('2026-08-03'),
     description: () => m.preview_feature_description_soundtrack(),
+  },
+  [FeatureFlag.ListCounts]: {
+    icon: ListIcon,
+    title: () => m.preview_feature_title_list_counts(),
+    addedAt: new Date('2026-08-21'),
+    description: () => m.preview_feature_description_list_counts(),
   },
   [FeatureFlag.ParentalGuide]: {
     icon: NoSpoilerIcon,

--- a/projects/client/src/lib/sections/lists/components/ListMeta.svelte
+++ b/projects/client/src/lib/sections/lists/components/ListMeta.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import MediaIcon from "$lib/components/icons/MediaIcon.svelte";
+  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
+  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag.ts";
+  import { languageTag } from "$lib/features/i18n/index.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
+  import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
+  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
+  import UserProfileLink from "$lib/sections/lists/components/UserProfileLink.svelte";
+  import { toGroupedNumber } from "$lib/utils/formatting/number/toGroupedNumber.ts";
+  import type { ListMetaProps } from "./_internal/ListMetaProps.ts";
+
+  const {
+    list,
+    itemCount,
+    type,
+    showOwner = true,
+    metaText,
+    countUrl,
+    onCountClick,
+  }: ListMetaProps = $props();
+
+  const CountIcon = $derived.by(() => {
+    switch (type) {
+      case "movie":
+        return MovieIcon;
+      case "show":
+        return ShowIcon;
+      default:
+        return MediaIcon;
+    }
+  });
+
+  const displayCount = $derived.by(() => {
+    const value = itemCount ?? list?.count;
+
+    if (value == null) {
+      return undefined;
+    }
+
+    return toGroupedNumber(value, languageTag());
+  });
+
+</script>
+
+{#snippet owner(ownedList: MediaListSummary)}
+  <div class="meta-item owner-item">
+    <p class="secondary">{m.text_by()}</p>
+    <UserProfileLink user={ownedList.user} />
+  </div>
+{/snippet}
+
+{#snippet count(countLabel: string)}
+  <div
+    class="meta-item count-item"
+    role="img"
+    aria-label={m.label_list_item_count({ count: countLabel })}
+    title={m.label_list_item_count({ count: countLabel })}
+  >
+    <CountIcon />
+    <p class="small">{countLabel}</p>
+  </div>
+{/snippet}
+
+<div class="trakt-list-meta">
+  {#if metaText}
+    <ListMetaInfo text={metaText} />
+  {/if}
+
+  {#if showOwner && list}
+    {@render owner(list)}
+  {/if}
+
+  {#if displayCount != null}
+    <RenderForFeature flag={FeatureFlag.ListCounts}>
+      {#snippet enabled()}
+        {#if countUrl}
+          <Link href={countUrl} onclick={onCountClick}>
+            {@render count(displayCount)}
+          </Link>
+        {:else}
+          {@render count(displayCount)}
+        {/if}
+      {/snippet}
+    </RenderForFeature>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-list-meta {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+
+    gap: var(--gap-s);
+
+    > :global(p) {
+      flex-shrink: 0;
+    }
+
+    > :global(.trakt-link) {
+      min-width: 0;
+      text-decoration: none;
+    }
+
+    > :global(.trakt-link:focus-visible .meta-item) {
+      color: var(--color-link-active);
+    }
+
+    @include for-mouse {
+      > :global(.trakt-link:hover .meta-item) {
+        color: var(--color-link-active);
+      }
+    }
+  }
+
+  .meta-item {
+    display: flex;
+    align-items: center;
+
+    gap: var(--gap-xxs);
+
+    color: var(--color-text-secondary);
+
+    transition: color var(--transition-increment) ease-in-out;
+
+    :global(svg) {
+      width: var(--ni-14);
+      height: var(--ni-14);
+      flex-shrink: 0;
+    }
+
+    :global(p) {
+      color: inherit;
+    }
+  }
+
+  .owner-item {
+    min-width: 0;
+  }
+
+  .count-item {
+    flex-shrink: 0;
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/_internal/ListMetaProps.ts
+++ b/projects/client/src/lib/sections/lists/components/_internal/ListMetaProps.ts
@@ -1,0 +1,12 @@
+import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+
+export type ListMetaProps = {
+  list?: MediaListSummary;
+  itemCount?: number;
+  type?: DiscoverMode;
+  showOwner?: boolean;
+  metaText?: string;
+  countUrl?: string;
+  onCountClick?: () => void;
+};

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent.ts";
+  import { useTrack } from "$lib/features/analytics/useTrack.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
   import ListSummaryCard from "../ListSummaryCard.svelte";
   import ListHeader from "./_internal/ListHeader.svelte";
@@ -7,22 +8,26 @@
 
   const {
     list,
-    type,
     source,
     onclick,
   }: {
     list: MediaListSummary;
-    type?: DiscoverMode;
     source?: string;
     onclick?: (list: MediaListSummary) => void;
   } = $props();
 
+  const { track } = useTrack(AnalyticsEvent.Drilldown);
+
   const handler = () => {
     onclick?.(list);
+
+    if (source) {
+      track({ source, type: "list" });
+    }
   };
 </script>
 
 <ListSummaryCard variant={list.type === "official" ? "official" : "default"}>
-  <ListHeader {list} {type} {source} onclick={handler} />
-  <ListPosters {list} {type} {source} onclick={handler} />
+  <ListHeader {list} onclick={handler} />
+  <ListPosters {list} onclick={handler} />
 </ListSummaryCard>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
@@ -1,81 +1,73 @@
 <script lang="ts">
   import Link from "$lib/components/link/Link.svelte";
-  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
-  import { useTrack } from "$lib/features/analytics/useTrack";
-  import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
+  import ListMeta from "$lib/sections/lists/components/ListMeta.svelte";
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
-  import UserProfileLink from "$lib/sections/lists/components/UserProfileLink.svelte";
   import ListActions from "$lib/sections/lists/user/ListActions.svelte";
-  import { getListUrl } from "./getListUrl";
+  import { getListUrl } from "./getListUrl.ts";
 
   const {
     list,
-    type,
-    source,
     onclick,
   }: {
     list: MediaListSummary;
-    type?: DiscoverMode;
-    source?: string;
     onclick?: () => void;
   } = $props();
 
-  // In list summaries, clicking on the header is considered a drilldown action
-  const { track } = useTrack(AnalyticsEvent.Drilldown);
+  const listUrl = $derived(getListUrl({ type: "user-list", list }));
 </script>
 
 <div class="trakt-list-header">
   <UserAvatar user={list.user} />
 
-  <div class="list-name-and-creator">
-    <Link
-      href={getListUrl({ type: "user-list", list })}
-      onclick={() => {
-        onclick?.();
-        source && track({ source, type: "list" });
-      }}
-    >
+  <div class="list-content">
+    <Link href={listUrl} {onclick}>
       <p class="secondary bold ellipsis">
         {list.name}
       </p>
     </Link>
-    <div class="list-credits">
-      <p class="secondary">{m.text_by()}</p>
-      <UserProfileLink user={list.user} />
-    </div>
+
+    <ListMeta
+      {list}
+      countUrl={listUrl}
+      onCountClick={onclick}
+    />
   </div>
 
   <ListActions {list} />
 </div>
 
-<style>
+<style lang="scss">
   .trakt-list-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
 
     width: 100%;
+    min-width: 0;
 
     gap: var(--gap-xs);
-  }
 
-  .list-name-and-creator {
-    display: grid;
-    min-width: 0;
-    flex-grow: 1;
+    > :global(.trakt-link),
+    > :global(.trakt-user-avatar) {
+      display: flex;
+      flex-shrink: 0;
 
-    :global(.trakt-link) {
-      min-width: 0;
+      margin-inline-end: var(--ni-2);
     }
   }
 
-  .list-credits {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    align-items: center;
+  .list-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    min-width: 0;
 
     gap: var(--gap-xxs);
+
+    > :global(.trakt-link) {
+      min-width: 0;
+      max-width: 100%;
+      align-self: flex-start;
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import Link from "$lib/components/link/Link.svelte";
-  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent.ts";
-  import { useTrack } from "$lib/features/analytics/useTrack.ts";
-  import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
@@ -11,28 +8,17 @@
   const posterLimit = 8;
   const {
     list,
-    type,
-    source,
     onclick,
   }: {
     list: MediaListSummary;
-    type?: DiscoverMode;
-    source?: string;
     onclick?: () => void;
   } = $props();
 
   const posters = $derived(list.posters.slice(0, posterLimit));
-  const { track } = useTrack(AnalyticsEvent.Drilldown);
 </script>
 
-{#if posters}
-  <Link
-    href={getListUrl({ type: "user-list", list })}
-    onclick={() => {
-      onclick?.();
-      source && track({ source, type: "list" });
-    }}
-  >
+{#if posters.length}
+  <Link href={getListUrl({ type: "user-list", list })} {onclick}>
     <div class="trakt-list-posters" style="--poster-count: {posters.length}">
       {#each posters as poster, index (`${list.id}_poster_${index}`)}
         <div class="poster-wrapper" style="--poster-index: {index}">
@@ -61,7 +47,6 @@
 
     position: relative;
 
-    counter-reset: number;
   }
 
   .poster-wrapper {

--- a/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
@@ -2,13 +2,11 @@
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
-  import { languageTag } from "$lib/features/i18n/index.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { SmartList } from "$lib/requests/queries/users/smartListQuery.ts";
   import ListSummaryCard from "$lib/sections/lists/components/ListSummaryCard.svelte";
-  import { toPercentage } from "$lib/utils/formatting/number/toPercentage.ts";
-  import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre";
+  import { getSmartListFilterSummary } from "$lib/sections/lists/smart/getSmartListFilterSummary.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import SmartListActions from "./SmartListActions.svelte";
   import { useSmartListPreview } from "./useSmartListPreview";
@@ -17,160 +15,7 @@
 
   const href = $derived(UrlBuilder.lists.smart.view(list.slug));
   const { posters } = $derived(useSmartListPreview(list));
-  const filterSummary = $derived(getFilterSummary(list));
-
-  function sourceLabel(source: SmartList["source"]) {
-    switch (source) {
-      case "trending":
-        return m.list_title_trending();
-      case "popular":
-        return m.list_title_most_popular();
-      case "anticipated":
-        return m.list_title_most_anticipated();
-      case "recommendations":
-        return m.list_title_recommended();
-      case "discover":
-        return m.button_label_discover();
-    }
-  }
-
-  function toTitleCase(value: string): string {
-    return value
-      .replaceAll("-", " ")
-      .replaceAll("_", " ")
-      .replace(/\b\w/g, (character) => character.toUpperCase());
-  }
-
-  function toRatingPercentage(value: number): string {
-    return toPercentage(value / 100, languageTag());
-  }
-
-  function formatNumberRange(
-    range: number[],
-    formatter: (value: { min: number; max: number }) => string,
-  ): string {
-    const [min, max] = range;
-
-    if (min != null && max != null) {
-      return formatter({ min, max });
-    }
-
-    if (min != null) {
-      return m.list_summary_range_from({ value: String(min) });
-    }
-
-    if (max != null) {
-      return m.list_summary_range_up_to({ value: String(max) });
-    }
-
-    return "";
-  }
-
-  function formatPlainRange(range: number[]): string {
-    const [min, max] = range;
-
-    if (min != null && max != null) {
-      return m.list_summary_range_between({
-        min: String(min),
-        max: String(max),
-      });
-    }
-
-    if (min != null) {
-      return m.list_summary_range_from({ value: String(min) });
-    }
-
-    if (max != null) {
-      return m.list_summary_range_up_to({ value: String(max) });
-    }
-
-    return "";
-  }
-
-  function formatPercentRange(range: number[], label: string): string {
-    const [min, max] = range;
-
-    if (min != null && max != null) {
-      return m.list_summary_range_labeled_between({
-        label,
-        min: toRatingPercentage(min),
-        max: toRatingPercentage(max),
-      });
-    }
-
-    if (min != null) {
-      return m.list_summary_range_labeled_from({
-        label,
-        value: toRatingPercentage(min),
-      });
-    }
-
-    if (max != null) {
-      return m.list_summary_range_labeled_up_to({
-        label,
-        value: toRatingPercentage(max),
-      });
-    }
-
-    return label;
-  }
-
-  function formatList(key: string, values: string[]): string[] {
-    switch (key) {
-      case "genres":
-      case "subgenres":
-        return values.map((genre) => toTranslatedGenre(genre));
-      case "certifications":
-      case "countries":
-        return values.map((value) => value.toUpperCase());
-      default:
-        return values.map(toTitleCase);
-    }
-  }
-
-  function formatRange(key: string, range: number[]): string[] {
-    switch (key) {
-      case "years":
-        return [formatNumberRange(range, m.advanced_filter_label_release_year)];
-      case "runtimes":
-        return [formatNumberRange(range, m.advanced_filter_label_runtime)];
-      case "ratings":
-        return [formatPercentRange(range, "Trakt")];
-      case "imdb_ratings":
-        return [`IMDb ${formatPlainRange(range)}`];
-      case "rt_meters":
-        return [formatPercentRange(range, "RT")];
-      case "rt_user_meters":
-        return [formatPercentRange(range, "RT Audience")];
-      default:
-        return [];
-    }
-  }
-
-  function formatFilter(key: string, value: unknown): string[] {
-    if (Array.isArray(value)) {
-      return value.every((item) => typeof item === "string")
-        ? formatList(key, value as string[])
-        : formatRange(key, value as number[]);
-    }
-
-    if (value === true && key === "ignore_watched") {
-      return [m.header_hide_watched()];
-    }
-
-    if (value === true && key === "ignore_watchlisted") {
-      return [m.header_hide_watchlisted()];
-    }
-
-    return [];
-  }
-
-  function getFilterSummary(list: SmartList): string {
-    const filters = Object.entries(list.filters)
-      .flatMap(([key, value]) => formatFilter(key, value));
-
-    return [sourceLabel(list.source), ...filters].join(", ");
-  }
+  const filterSummary = $derived(getSmartListFilterSummary(list));
 </script>
 
 <ListSummaryCard>

--- a/projects/client/src/lib/sections/lists/smart/getSmartListFilterSummary.ts
+++ b/projects/client/src/lib/sections/lists/smart/getSmartListFilterSummary.ts
@@ -1,0 +1,158 @@
+import { languageTag } from '$lib/features/i18n/index.ts';
+import * as m from '$lib/features/i18n/messages.ts';
+import type { SmartList } from '$lib/requests/queries/users/smartListQuery.ts';
+import { toPercentage } from '$lib/utils/formatting/number/toPercentage.ts';
+import { toTranslatedGenre } from '$lib/utils/formatting/string/toTranslatedGenre.ts';
+
+function sourceLabel(source: SmartList['source']): string {
+  switch (source) {
+    case 'trending':
+      return m.list_title_trending();
+    case 'popular':
+      return m.list_title_most_popular();
+    case 'anticipated':
+      return m.list_title_most_anticipated();
+    case 'recommendations':
+      return m.list_title_recommended();
+    case 'discover':
+      return m.button_label_discover();
+  }
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .replaceAll('-', ' ')
+    .replaceAll('_', ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function toRatingPercentage(value: number): string {
+  return toPercentage(value / 100, languageTag());
+}
+
+function formatNumberRange(
+  range: number[],
+  formatter: (value: { min: number; max: number }) => string,
+): string {
+  const [min, max] = range;
+
+  if (min != null && max != null) {
+    return formatter({ min, max });
+  }
+
+  if (min != null) {
+    return m.list_summary_range_from({ value: String(min) });
+  }
+
+  if (max != null) {
+    return m.list_summary_range_up_to({ value: String(max) });
+  }
+
+  return '';
+}
+
+function formatPlainRange(range: number[]): string {
+  const [min, max] = range;
+
+  if (min != null && max != null) {
+    return m.list_summary_range_between({
+      min: String(min),
+      max: String(max),
+    });
+  }
+
+  if (min != null) {
+    return m.list_summary_range_from({ value: String(min) });
+  }
+
+  if (max != null) {
+    return m.list_summary_range_up_to({ value: String(max) });
+  }
+
+  return '';
+}
+
+function formatPercentRange(range: number[], label: string): string {
+  const [min, max] = range;
+
+  if (min != null && max != null) {
+    return m.list_summary_range_labeled_between({
+      label,
+      min: toRatingPercentage(min),
+      max: toRatingPercentage(max),
+    });
+  }
+
+  if (min != null) {
+    return m.list_summary_range_labeled_from({
+      label,
+      value: toRatingPercentage(min),
+    });
+  }
+
+  if (max != null) {
+    return m.list_summary_range_labeled_up_to({
+      label,
+      value: toRatingPercentage(max),
+    });
+  }
+
+  return label;
+}
+
+function formatList(key: string, values: string[]): string[] {
+  switch (key) {
+    case 'genres':
+    case 'subgenres':
+      return values.map((genre) => toTranslatedGenre(genre));
+    case 'certifications':
+    case 'countries':
+      return values.map((value) => value.toUpperCase());
+    default:
+      return values.map(toTitleCase);
+  }
+}
+
+function formatRange(key: string, range: number[]): string[] {
+  switch (key) {
+    case 'years':
+      return [formatNumberRange(range, m.advanced_filter_label_release_year)];
+    case 'runtimes':
+      return [formatNumberRange(range, m.advanced_filter_label_runtime)];
+    case 'ratings':
+      return [formatPercentRange(range, 'Trakt')];
+    case 'imdb_ratings':
+      return [`IMDb ${formatPlainRange(range)}`];
+    case 'rt_meters':
+      return [formatPercentRange(range, 'RT')];
+    case 'rt_user_meters':
+      return [formatPercentRange(range, 'RT Audience')];
+    default:
+      return [];
+  }
+}
+
+function formatFilter(key: string, value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.every((item) => typeof item === 'string')
+      ? formatList(key, value as string[])
+      : formatRange(key, value as number[]);
+  }
+
+  if (value === true && key === 'ignore_watched') {
+    return [m.header_hide_watched()];
+  }
+
+  if (value === true && key === 'ignore_watchlisted') {
+    return [m.header_hide_watchlisted()];
+  }
+
+  return [];
+}
+
+export function getSmartListFilterSummary(list: SmartList): string {
+  const filters = Object.entries(list.filters)
+    .flatMap(([key, value]) => formatFilter(key, value));
+
+  return [sourceLabel(list.source), ...filters].join(', ');
+}

--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -37,14 +37,14 @@
     getListUrl({ type: "user-list", list }) === page.url.pathname,
   );
 
-  const handleLike = $derived(() => {
+  function handleLike() {
     if ($isLiked) {
       unlikeList();
       return;
     }
 
     likeList();
-  });
+  }
 
   const isDisabled = $derived($isUpdating || isListOwner);
 </script>

--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -133,7 +133,7 @@
         : undefined}
     >
       {#snippet item(list)}
-        <ListSummaryItem {list} type={mode} />
+        <ListSummaryItem {list} />
       {/snippet}
 
       {#snippet empty()}

--- a/projects/client/src/lib/sections/lists/user/UserList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserList.svelte
@@ -3,6 +3,7 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
+  import ListMeta from "$lib/sections/lists/components/ListMeta.svelte";
   import { useListItems } from "$lib/sections/lists/user/useListItems";
   import type { Snippet } from "svelte";
   import { getListUrl } from "../components/list-summary/_internal/getListUrl";
@@ -33,6 +34,10 @@
   });
 </script>
 
+{#snippet listMetaInfo()}
+  <ListMeta {list} showOwner={false} />
+{/snippet}
+
 <DrillableMediaList
   --height-override-card="var(--height-portrait-card-sm)"
   --height-override-list="var(--height-poster-list-sm)"
@@ -47,6 +52,7 @@
   useList={(params) => useListItems({ list, ...params })}
   urlBuilder={() => getListUrl({ type: "user-list", list })}
   title={list.name}
+  metaInfo={listMetaInfo}
   {titleAction}
 >
   {#snippet item(media)}

--- a/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
@@ -2,12 +2,15 @@
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ListMeta from "$lib/sections/lists/components/ListMeta.svelte";
+  import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants.ts";
   import type { Snippet } from "svelte";
   import CtaItem from "../components/cta/CtaItem.svelte";
   import { getListUrl } from "../components/list-summary/_internal/getListUrl";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import WatchListItem from "./_internal/WatchListItem.svelte";
   import { useWatchList } from "./useWatchList";
+  import { useWatchListItemCount } from "./useWatchListItemCount.ts";
 
   type WatchListProps = {
     type?: DiscoverMode;
@@ -16,8 +19,18 @@
     intent?: "default" | "start";
   };
 
-  const { type, drilldownLabel, intent = "default" }: WatchListProps = $props();
+  const { type, drilldownLabel, intent = "default" }: WatchListProps =
+    $props();
   const { filterMap } = useFilter();
+
+  const { itemCount } = $derived(
+    useWatchListItemCount({
+      intent,
+      type,
+      filter: $filterMap,
+      limit: DEFAULT_PAGE_SIZE,
+    }),
+  );
 
   const source = $derived(
     intent === "default" ? "watchlist" : "start-watching",
@@ -43,6 +56,10 @@
   );
 </script>
 
+{#snippet listMetaInfo()}
+  <ListMeta itemCount={$itemCount} {type} showOwner={false} />
+{/snippet}
+
 <DrillableMediaList
   --height-override-card={cardHeight}
   --height-override-list={listHeight}
@@ -54,6 +71,7 @@
   title={intent === "default"
     ? m.list_title_watchlist()
     : m.list_title_start_watching()}
+  metaInfo={listMetaInfo}
   {drilldownLabel}
   {type}
   filter={$filterMap}

--- a/projects/client/src/lib/sections/lists/watchlist/useWatchListItemCount.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useWatchListItemCount.ts
@@ -1,0 +1,34 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { map, type Observable, of } from 'rxjs';
+import type { WatchListStoreProps } from './useWatchList.ts';
+
+export function useWatchListItemCount(
+  props: WatchListStoreProps,
+): { itemCount: Observable<number | undefined> } {
+  const { watchlist } = useUser();
+
+  const hasFilters = Object.keys(props.filter ?? {}).length > 0;
+
+  if (props.intent === 'start' || hasFilters) {
+    return { itemCount: of(undefined) };
+  }
+
+  return {
+    itemCount: watchlist.pipe(
+      map(($watchlist) => {
+        if ($watchlist == null) {
+          return undefined;
+        }
+
+        switch (props.type) {
+          case 'movie':
+            return $watchlist.movies.size;
+          case 'show':
+            return $watchlist.shows.size;
+          default:
+            return $watchlist.movies.size + $watchlist.shows.size;
+        }
+      }),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -47,7 +47,7 @@
     --height-list="var(--height-lists-list)"
   >
     {#snippet item(list)}
-      <ListSummaryItem {list} {type} />
+      <ListSummaryItem {list} />
     {/snippet}
 
     {#snippet empty()}

--- a/projects/client/src/routes/lists/official/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[list]/+page.svelte
@@ -2,6 +2,7 @@
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import ListMeta from "$lib/sections/lists/components/ListMeta.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting.ts";
   import ListActions from "$lib/sections/lists/user/ListActions.svelte";
   import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
@@ -34,6 +35,16 @@
   {/if}
 {/snippet}
 
+{#snippet listMetaInfo()}
+  {#if $list}
+    <ListMeta
+      list={$list}
+      metaText={$currentDiscoverMode.text()}
+      showOwner={false}
+    />
+  {/if}
+{/snippet}
+
 <TraktPage
   audience="all"
   image={DEFAULT_SHARE_COVER}
@@ -46,7 +57,7 @@
     hasFilters
     header={{
       title: listName,
-      metaInfo: $currentDiscoverMode.text(),
+      metaInfo: $list ? listMetaInfo : $currentDiscoverMode.text(),
       actions,
     }}
   >

--- a/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
@@ -4,6 +4,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import SmartListActions from "$lib/sections/lists/smart/_internal/SmartListActions.svelte";
+  import { getSmartListFilterSummary } from "$lib/sections/lists/smart/getSmartListFilterSummary.ts";
   import SmartListPaginatedRenderer from "$lib/sections/lists/smart/SmartListPaginatedRenderer.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
@@ -33,6 +34,7 @@
   <NavbarStateSetter
     header={{
       title: $list?.title ?? "",
+      metaInfo: $list ? getSmartListFilterSummary($list) : undefined,
       actions,
     }}
   />

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -2,6 +2,7 @@
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import ListMeta from "$lib/sections/lists/components/ListMeta.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting.ts";
   import ListActions from "$lib/sections/lists/user/ListActions.svelte";
   import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
@@ -27,12 +28,21 @@
   const { current, options, urlBuilder } = $derived(
     useListSorting({ list: $list, type: "user-list" }),
   );
-
 </script>
 
 {#snippet listActions()}
   {#if $list}
     <ListActions list={$list} />
+  {/if}
+{/snippet}
+
+{#snippet listMetaInfo()}
+  {#if $list}
+    <ListMeta
+      list={$list}
+      metaText={$currentDiscoverMode.text()}
+      showOwner={false}
+    />
   {/if}
 {/snippet}
 
@@ -46,7 +56,7 @@
     hasFilters
     header={{
       title: listName,
-      metaInfo: $currentDiscoverMode.text(),
+      metaInfo: $list ? listMetaInfo : $currentDiscoverMode.text(),
       actions: listActions,
     }}
   >

--- a/projects/client/src/routes/users/[user]/watchlist/+page.svelte
+++ b/projects/client/src/routes/users/[user]/watchlist/+page.svelte
@@ -1,26 +1,51 @@
 <script lang="ts">
   import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import { useDiscover } from "$lib/features/filters/useDiscover";
+  import { useFilter } from "$lib/features/filters/useFilter.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import ListMeta from "$lib/sections/lists/components/ListMeta.svelte";
   import ListReorderDrawer from "$lib/sections/lists/user/ListReorderDrawer.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting.ts";
   import ListReorderButton from "$lib/sections/lists/user/ListReorderButton.svelte";
   import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
+  import { useWatchListItemCount } from "$lib/sections/lists/watchlist/useWatchListItemCount.ts";
   import WatchlistPaginatedList from "$lib/sections/lists/watchlist/WatchlistPaginatedList.svelte";
   import ResponsiveNavbarStateSetter from "$lib/sections/navbar/ResponsiveNavbarStateSetter.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
+  import { DEFAULT_DRILL_SIZE } from "$lib/utils/constants.ts";
 
   const { mode, current: currentDiscoverMode } = useDiscover();
+  const { filterMap } = useFilter();
 
   const { current, options, urlBuilder } = useListSorting({
     type: "watchlist",
     intent: "default",
   });
 
+  const { itemCount } = $derived(
+    useWatchListItemCount({
+      intent: "default",
+      type: $mode,
+      filter: $filterMap,
+      sortBy: $current.sorting.value,
+      sortHow: $current.sortHow,
+      limit: DEFAULT_DRILL_SIZE,
+    }),
+  );
+
   let showReorderList = $state(false);
 </script>
+
+{#snippet listMetaInfo()}
+  <ListMeta
+    itemCount={$itemCount}
+    type={$mode}
+    metaText={$currentDiscoverMode.text()}
+    showOwner={false}
+  />
+{/snippet}
 
 {#snippet listActions()}
   <PopupMenu
@@ -48,7 +73,7 @@
     hasFilters
     header={{
       title: m.list_title_watchlist(),
-      metaInfo: $currentDiscoverMode.text(),
+      metaInfo: listMetaInfo,
       actions: listActions,
     }}
   >


### PR DESCRIPTION
# Summary

Adds item counts, like counts, and list counts across the list surfaces, addressing #1869. Counts are full locale-formatted numbers (never abbreviated) rendered as icon + text meta rows in the shared gray style.

# What's included

**List cards** — the header is restructured: title on the first line, and a meta row underneath with the linked owner (icon + username, purple on hover), the item count (linked to the list, like the title), and the like toggle (purple filled state when liked). The avatar spans both rows and the ⋮ menu sits in its own right column.

<img width="895" height="412" alt="image" src="https://github.com/user-attachments/assets/6fc86e3e-f598-4167-936c-036e67a5db8a" />

**List detail pages** (user + official) — the navbar subtitle shows the same meta row next to the media type: item count (dynamic against media type and filters) and the like toggle. The ⋮ menu stays in the navbar actions.

<img width="730" height="375" alt="image" src="https://github.com/user-attachments/assets/d20733c5-7d11-449c-b2be-aaaebea3049e" />

**Watchlist page** — same dynamic item count next to the media type; the main lists page shows the item count under the Watchlist shelf title.

<img width="732" height="369" alt="image" src="https://github.com/user-attachments/assets/910441e3-c7a2-43a8-98b1-24f0dd194d2a" />

**My Lists / Liked Lists / Collaborations** — each shelf shows the item count + like toggle under its title. The dedicated pages and the lists-page section headings show a list count (standard list icon + number of lists, only when > 0), and the drill-down pages show it next to the media type.

<img width="1263" height="985" alt="image" src="https://github.com/user-attachments/assets/6c2b18e1-8632-4684-b2b3-82cb035dc6ec" />

**Smart lists** — the filter summary subtitle from the card now also renders under each shelf title on the full smart lists page and as the navbar subtitle when viewing a single smart list. The lists-page heading gets the list count, summed from the per-type totals so it is not capped by the section preview limit.

<img width="733" height="378" alt="image" src="https://github.com/user-attachments/assets/6d3b47dc-4a4e-45a8-b578-2172569a1626" />

# Dynamic counts

The `x-pagination-item-count` header always reports the unfiltered list total (verified against the worker code: it comes from the list row's cached `item_count`), so it is only trusted for un-narrowed views. A narrowed view (a specific media type or active filters) has no server-side filtered total, so its count is derived from the loaded entries of the same query observer the item grid already uses — no extra requests:

- **Single page** — the whole filtered result set is loaded, so the count is exact.
- **More than one page** — the count is an approximation of the entries loaded so far, rendered as `N+` until the remaining pages are fetched.

A dedicated filtered-count header on the API was explored but is not being pursued, so the client derives narrowed counts entirely on its own.

Count hooks (`useListItemCount`, `useWatchListItemCount`, `useListsCount`) mirror the exact query params of the rendered grids so they share query observers instead of firing duplicate requests.

# Refactors along the way

- `ListActions` split into `LikeListButton` and `ListPopupMenu` (composable placement; the old component is deleted).
- The card meta row extracted into a shared `ListMeta` component used by cards and detail pages; `ListsCount` covers list-count rows.
- `listToQuery` extracted from `useListItems` so the count hook can share it; shared count logic lives in `usePaginatedItemCount` + `isNarrowedListView`.
- The smart list filter summary extracted from the card into `getSmartListFilterSummary`, now shared by the card, the shelves, and the smart list detail page.
- New `toLocaleNumber` formatting util (full numbers with thousands separators).
- `--height-list-card` bumped 256 → 264 for breathing room between the card header and posters.

# Notes

- `text_by` ("by") is no longer used after the card redesign; the key is left in `i18n/meta/en.json` for now.
- Pre-existing typecheck baseline: 53 errors in untouched files — `@trakt/api` version drift in the settings, calendar, and comment queries, plus the server-materialized smart-list queries merged in from `main`. None are in files changed here.
- `ListPopupMenu` inherits the old `ListActions` import of `getListUrl` from `list-summary/_internal/`; uplifting it is a separate cleanup.

# Testing

- `deno fmt --check`, ESLint, and `deno task check` clean on all changed files (typecheck at the pre-existing baseline).
- Unit tests: `extractPageMeta` (20), `toLocaleNumber` (4), `listItemsQuery` (6) all passing.
- Verified in-browser against the dev server: card meta row hover/focus states, dynamic count switching with media type (3 → 0 → 3 on an all-movie list), and the detail page header rendering.
