### PR TITLE
Media: use new translation language query param

### DIFF
--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -81,7 +81,7 @@
     "@tanstack/query-core": "5.101.4",
     "@tanstack/query-devtools": "5.101.4",
     "@tanstack/query-persist-client-core": "5.101.4",
-    "@trakt/api": "npm:@jsr/trakt__api@0.5.4",
+    "@trakt/api": "npm:@jsr/trakt__api@0.6.0",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/requests/queries/episode/episodeIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeIntlQuery.ts
@@ -40,6 +40,8 @@ const episodeIntlRequest = (
         id: slug,
         season: castNumberAsString(season),
         episode,
+      },
+      query: {
         language,
       },
     });

--- a/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
@@ -20,6 +20,8 @@ const movieIntlRequest = (
     .translations({
       params: {
         id: slug,
+      },
+      query: {
         language,
       },
     });

--- a/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
@@ -20,6 +20,8 @@ const showIntlRequest = (
     .translations({
       params: {
         id: slug,
+      },
+      query: {
         language,
       },
     });

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -42,21 +42,14 @@ export const movies = [
     },
   ),
   http.get(
-    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/translations/en`,
-    () => {
-      return HttpResponse.json(MovieHereticTranslationsResponseMock.get('en'));
-    },
-  ),
-  http.get(
-    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/translations/nl`,
-    () => {
-      return HttpResponse.json(MovieHereticTranslationsResponseMock.get('nl'));
-    },
-  ),
-  http.get(
-    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/translations/pt`,
-    () => {
-      return HttpResponse.json(MovieHereticTranslationsResponseMock.get('pt'));
+    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/translations`,
+    ({ request }) => {
+      const { searchParams } = new URL(request.url);
+      return HttpResponse.json(
+        MovieHereticTranslationsResponseMock.get(
+          searchParams.get('language') ?? '',
+        ),
+      );
     },
   ),
   http.get(

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -55,26 +55,13 @@ export const shows = [
     },
   ),
   http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/translations/en`,
-    () => {
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/translations`,
+    ({ request }) => {
+      const { searchParams } = new URL(request.url);
       return HttpResponse.json(
-        ShowSiloTranslationsResponseMock.get('en'),
-      );
-    },
-  ),
-  http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/translations/nl`,
-    () => {
-      return HttpResponse.json(
-        ShowSiloTranslationsResponseMock.get('nl'),
-      );
-    },
-  ),
-  http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/translations/ja`,
-    () => {
-      return HttpResponse.json(
-        ShowSiloTranslationsResponseMock.get('ja'),
+        ShowSiloTranslationsResponseMock.get(
+          searchParams.get('language') ?? '',
+        ),
       );
     },
   ),
@@ -173,15 +160,14 @@ export const shows = [
     },
   ),
   http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/${EpisodeSiloResponseMock.season}/episodes/${EpisodeSiloResponseMock.number}/translations/en`,
-    () => {
-      return HttpResponse.json(EpisodeSiloTranslationsResponseMock.get('en'));
-    },
-  ),
-  http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/${EpisodeSiloResponseMock.season}/episodes/${EpisodeSiloResponseMock.number}/translations/nl`,
-    () => {
-      return HttpResponse.json(EpisodeSiloTranslationsResponseMock.get('nl'));
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/${EpisodeSiloResponseMock.season}/episodes/${EpisodeSiloResponseMock.number}/translations`,
+    ({ request }) => {
+      const { searchParams } = new URL(request.url);
+      return HttpResponse.json(
+        EpisodeSiloTranslationsResponseMock.get(
+          searchParams.get('language') ?? '',
+        ),
+      );
     },
   ),
   http.get(


### PR DESCRIPTION
# Summary

Bumps `@trakt/api` to 0.6.0 and migrates the translations calls to the new contract shape, where the `language` filter is an optional query param instead of a path segment (trakt/trakt-api#901, refs trakt/trakt-api#869). The client now requests `/translations?language=xx` instead of `/translations/xx`.

# Changes

- `@trakt/api` pin bumped from 0.5.4 to 0.6.0 in `projects/client/package.json`.
- `movieIntlQuery`, `showIntlQuery`, and `episodeIntlQuery` pass `language` via `query` instead of `params`.
- MSW handlers: the per-language `/translations/{lang}` mocks (movie en/nl/pt, show en/nl/ja, episode en/nl) are collapsed into single `/translations` handlers that serve the same mock data keyed off the `language` query param, since the old path-based handlers would no longer match the new request URLs.

# Dependencies

Draft until the upstream pieces land, in order:

1. The Rails API deploys support for `?language=` on the translations endpoints.
2. trakt/trakt-api#901 merges and `@trakt/api` 0.6.0 is published (tag `v0.6.0`).
3. Then this PR: refresh `deno.lock` with an install (the 0.6.0 pin cannot resolve before publish) and mark ready for review.

Merging early would fail install in CI on the unresolvable 0.6.0 pin, and running ahead of the Rails deploy would return unfiltered translations because the query param is ignored.
