### PR TITLE
feat: Where to Watch drawer UI revamp

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -720,6 +720,18 @@
       "default": "Search people",
       "description": "Aria-label for the people drawer search input."
     },
+    "input_placeholder_search_streaming_services": {
+      "default": "Search streaming service or country...",
+      "description": "Placeholder text for the where-to-watch drawer search input. This should be short and indicate users can search locally by country name or streaming service name."
+    },
+    "input_label_search_streaming_services": {
+      "default": "Search streaming services",
+      "description": "Aria-label for the where-to-watch drawer search input."
+    },
+    "button_label_toggle_streaming_countries": {
+      "default": "Toggle countries for {service}",
+      "description": "Aria-label for the button that expands or collapses the list of countries a streaming service is available in."
+    },
     "button_text_join_trakt": {
       "default": "Join Trakt",
       "description": "Text for the Trakt login button. This should be a short and concise message that indicates what users can do."
@@ -4692,11 +4704,11 @@
     },
     "button_text_sort_rank": {
       "default": "Rank",
-      "description": "Text for the button that allows users to sort lists by their custom rank order."
+      "description": "Text for the button that allows users to sort items by their manual rank."
     },
     "button_label_sort_rank": {
       "default": "Sort by rank",
-      "description": "Aria-label for the button that allows users to sort lists by their custom rank order."
+      "description": "Aria-label for the button that allows users to sort items by their manual rank."
     },
     "button_text_sort_name": {
       "default": "Name",

--- a/projects/client/src/lib/components/drawer/DrawerSearchInput.svelte
+++ b/projects/client/src/lib/components/drawer/DrawerSearchInput.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import SearchIcon from "$lib/components/icons/SearchIcon.svelte";
+  import type { DrawerSearchInputProps } from "./DrawerSearchInputProps";
+
+  let { value = $bindable(""), label, placeholder }: DrawerSearchInputProps =
+    $props();
+</script>
+
+<label class="trakt-drawer-search-input">
+  <SearchIcon />
+  <input
+    bind:value
+    type="search"
+    aria-label={label}
+    {placeholder}
+  />
+</label>
+
+<style lang="scss">
+  .trakt-drawer-search-input {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    cursor: text;
+
+    margin-block: var(--drawer-search-input-margin-block, 0);
+    min-height: var(--ni-48);
+    padding: 0 var(--ni-16);
+    box-sizing: border-box;
+
+    border-radius: var(--border-radius-l);
+    background: var(--color-input-background);
+    outline: var(--border-thickness-xxs) solid var(--color-border);
+
+    transition: outline var(--transition-increment) ease-in-out;
+
+    &:focus-within {
+      outline: var(--border-thickness-xs) solid var(--color-input-focus);
+    }
+
+    :global(svg) {
+      flex-shrink: 0;
+      width: var(--ni-24);
+      height: var(--ni-24);
+      color: var(--color-text-secondary);
+    }
+
+    input {
+      all: unset;
+      min-width: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/drawer/DrawerSearchInputProps.ts
+++ b/projects/client/src/lib/components/drawer/DrawerSearchInputProps.ts
@@ -1,0 +1,5 @@
+export type DrawerSearchInputProps = {
+  value?: string;
+  readonly label: string;
+  readonly placeholder: string;
+};

--- a/projects/client/src/lib/components/lists/section-list/CollapseIcon.svelte
+++ b/projects/client/src/lib/components/lists/section-list/CollapseIcon.svelte
@@ -1,19 +1,26 @@
 <script lang="ts">
-  const { state }: { state: "collapsed" | "expanded" } = $props();
+  import type { CollapseIconProps } from "./models/CollapseIconProps";
+
+  const CIRCLED_PATH =
+    "m480-360 160-160H320l160 160Zm0 280q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z";
+  const BARE_PATH = "M480-360 280-560h400L480-360Z";
+
+  const { state, size = 24, variant = "circled" }: CollapseIconProps =
+    $props();
+
+  const path = $derived(variant === "bare" ? BARE_PATH : CIRCLED_PATH);
 </script>
 
 <svg
   class="trakt-collapse-icon"
   class:is-collapsed={state === "collapsed"}
   xmlns="http://www.w3.org/2000/svg"
-  height="24px"
+  height="{size}px"
   viewBox="0 -960 960 960"
-  width="24px"
+  width="{size}px"
   fill="currentColor"
 >
-  <path
-    d="m480-360 160-160H320l160 160Zm0 280q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"
-  />
+  <path d={path} />
 </svg>
 
 <style>

--- a/projects/client/src/lib/components/lists/section-list/models/CollapseIconProps.ts
+++ b/projects/client/src/lib/components/lists/section-list/models/CollapseIconProps.ts
@@ -1,0 +1,5 @@
+export type CollapseIconProps = {
+  readonly state: 'collapsed' | 'expanded';
+  readonly size?: number;
+  readonly variant?: 'circled' | 'bare';
+};

--- a/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
+++ b/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import ServiceLogo from "./_internal/ServiceLogo.svelte";
-  import { useStreamingServiceLogo } from "./_internal/useStreamingServiceLogo";
+  import { useStreamingServiceLogo } from "./useStreamingServiceLogo";
   import type { StreamingServiceLogoIntl } from "./StreamingServiceLogoIntl";
 
   type StreamingServiceLogoProps = {

--- a/projects/client/src/lib/components/media/streaming-service/useStreamingServiceLogo.ts
+++ b/projects/client/src/lib/components/media/streaming-service/useStreamingServiceLogo.ts
@@ -3,7 +3,7 @@ import type { StreamingSource } from '$lib/requests/models/StreamingSource.ts';
 import { streamingSourcesQuery } from '$lib/requests/queries/services/streamingSourcesQuery.ts';
 import { useStreamingPreferences } from '$lib/stores/useStreamingPreferences.ts';
 import { combineLatest, map, Observable, of } from 'rxjs';
-import { cleanStreamingServiceName } from './cleanStreamingServiceName.ts';
+import { cleanStreamingServiceName } from './_internal/cleanStreamingServiceName.ts';
 
 type UseStreamingServicesProps = {
   source: string;
@@ -45,7 +45,7 @@ export function useStreamingServiceLogo(
       const service = services.find((s) => s.source === source);
 
       if (service) {
-        return service ? mapToLogo(service) : undefined;
+        return mapToLogo(service);
       }
 
       const allServices = Array.from($query.data.values() ?? []).flat();

--- a/projects/client/src/lib/components/media/streaming-service/useStreamingServiceNames.ts
+++ b/projects/client/src/lib/components/media/streaming-service/useStreamingServiceNames.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { streamingSourcesQuery } from '$lib/requests/queries/services/streamingSourcesQuery.ts';
+import { map, type Observable } from 'rxjs';
+import { cleanStreamingServiceName } from './_internal/cleanStreamingServiceName.ts';
+
+export function useStreamingServiceNames(): Observable<
+  ReadonlyMap<string, string>
+> {
+  const query = useQuery(streamingSourcesQuery({}));
+
+  return query.pipe(
+    map(($query) => {
+      const sources = Array.from($query.data?.values() ?? []).flat();
+
+      return new Map(
+        sources.map(
+          (source) =>
+            [source.source, cleanStreamingServiceName(source.name)] as const,
+        ),
+      );
+    }),
+  );
+}

--- a/projects/client/src/lib/sections/lists/where-to-watch/WhereToWatchDrawerHost.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/WhereToWatchDrawerHost.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
   import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import DrawerSearchInput from "$lib/components/drawer/DrawerSearchInput.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import { useStreamingServiceNames } from "$lib/components/media/streaming-service/useStreamingServiceNames";
   import * as m from "$lib/features/i18n/messages.ts";
   import { usePlexLibrary } from "$lib/features/plex/usePlexLibrary";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MetaInfoProps } from "$lib/sections/summary/components/media/useMediaMetaInfo";
   import { useStreamingPreferences } from "$lib/stores/useStreamingPreferences";
+  import { filterGroupedServices } from "./_internal/filterGroupedServices";
   import { getGroupedServices } from "./_internal/getGroupedServices";
-  import type { CostType } from "./_internal/getMediaCost";
   import { StreamingGroup } from "./_internal/models/StreamingGroup";
   import { useAllStreamOn } from "./_internal/useAllStreamOn";
   import WhereToWatchCategory from "./_internal/WhereToWatchCategory.svelte";
   import WhereToWatchItem from "./_internal/WhereToWatchItem.svelte";
-  import WhereToWatchLogo from "./_internal/WhereToWatchLogo.svelte";
+  import WhereToWatchServiceSection from "./_internal/WhereToWatchServiceSection.svelte";
 
   const {
     onClose,
@@ -28,6 +30,11 @@
   const { plexServices } = $derived(usePlexLibrary(target));
 
   const { country, favorites } = useStreamingPreferences();
+  const serviceNames = useStreamingServiceNames();
+
+  let searchTerm = $state("");
+  const normalizedSearchTerm = $derived(searchTerm.trim().toLocaleLowerCase());
+  const isSearching = $derived(normalizedSearchTerm.length > 0);
 
   const groupedList = $derived(
     getGroupedServices({
@@ -35,6 +42,16 @@
       userCountry: $country,
       favoriteSources: $favorites,
     }),
+  );
+
+  const visibleList = $derived(
+    isSearching
+      ? filterGroupedServices({
+        grouped: groupedList,
+        term: normalizedSearchTerm,
+        names: $serviceNames,
+      })
+      : groupedList,
   );
 
   const groupLabels: Record<StreamingGroup, string> = {
@@ -45,26 +62,30 @@
     [StreamingGroup.Rent]: m.list_title_streaming_rent(),
   };
 
-  const hasAnyResults = $derived(
-    $plexServices.length > 0 ||
-      Object.values(groupedList).some((rows) => rows.length > 0),
+  const hasStreamingResults = $derived(
+    Object.values(visibleList).some((rows) => rows.length > 0),
   );
 
-  const getCostType = (group: StreamingGroup): CostType => {
-    switch (group) {
-      case StreamingGroup.Rent:
-        return "rent";
-      case StreamingGroup.Purchase:
-        return "purchase";
-      default:
-        return "any";
-    }
-  };
+  const hasAnyResults = $derived(
+    ($plexServices.length > 0 && !isSearching) || hasStreamingResults,
+  );
 </script>
 
-<Drawer {onClose} title={m.list_title_where_to_watch()} size="large" {elevated}>
+<Drawer
+  {onClose}
+  {elevated}
+  title={m.list_title_where_to_watch()}
+  size="large"
+>
+  <DrawerSearchInput
+    bind:value={searchTerm}
+    label={m.input_label_search_streaming_services()}
+    placeholder={m.input_placeholder_search_streaming_services()}
+    --drawer-search-input-margin-block="var(--ni-4) var(--gap-s)"
+  />
+
   <RenderFor audience="authenticated" device={["mobile"]}>
-    {#if $plexServices.length > 0}
+    {#if $plexServices.length > 0 && !isSearching}
       <WhereToWatchCategory>
         <SectionList
           id={{
@@ -84,79 +105,43 @@
     {/if}
   </RenderFor>
 
-  {#each Object.entries(groupedList) as [group, rows] (group)}
-    {#if rows.length > 0}
-      {@const streamingGroup = group as StreamingGroup}
-      {@const label = groupLabels[streamingGroup]}
-      <WhereToWatchCategory title={label}>
-        {#each rows as row (row.key)}
-          <div class="trakt-service-row">
-            <div class="trakt-service-logo-card">
-              <WhereToWatchLogo source={row.source} />
-            </div>
-
-            <div class="trakt-service-countries">
-              <SectionList
-                id={{
-                  scope: `where-to-watch-drawer-list-${streamingGroup}-${row.source}`,
-                  key: target.media.slug,
-                }}
-                items={row.countries}
-                title={null}
-                variant="inline"
-                --height-list="var(--height-where-to-watch-list)"
-              >
-                {#snippet item(entry)}
-                  <WhereToWatchItem
-                    service={entry.service}
-                    country={entry.country}
-                    countryName={entry.countryName}
-                    variant="country"
-                    type={getCostType(streamingGroup)}
-                  />
-                {/snippet}
-              </SectionList>
-            </div>
-          </div>
-        {/each}
-      </WhereToWatchCategory>
-    {/if}
-  {/each}
+  <div class="where-to-watch-categories">
+    {#each Object.entries(visibleList) as [group, rows] (group)}
+      {#if rows.length > 0}
+        {@const streamingGroup = group as StreamingGroup}
+        {@const label = groupLabels[streamingGroup]}
+        <WhereToWatchCategory title={label}>
+          {#each rows as row (row.key)}
+            <WhereToWatchServiceSection
+              source={row.source}
+              countries={row.countries}
+              group={streamingGroup}
+              userCountry={$country}
+              {isSearching}
+            />
+          {/each}
+        </WhereToWatchCategory>
+      {/if}
+    {/each}
+  </div>
 
   {#if $isLoading}
     <LoadingIndicator />
   {/if}
 
   {#if !$isLoading && !hasAnyResults}
-    <p class="secondary">{m.button_text_no_services()}</p>
+    <p class="secondary">
+      {isSearching
+        ? m.list_placeholder_no_filter_results()
+        : m.button_text_no_services()}
+    </p>
   {/if}
 </Drawer>
 
 <style lang="scss">
-  .trakt-service-row {
+  .where-to-watch-categories {
     display: flex;
-    gap: var(--gap-s);
-  }
-
-  .trakt-service-logo-card {
-    margin-top: var(--ni-2);
-
-    flex-shrink: 0;
-    width: var(--ni-96);
-    height: var(--ni-96);
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    border-radius: var(--border-radius-m);
-    border: var(--ni-1) solid var(--color-border);
-  }
-
-  .trakt-service-countries {
-    flex: 1;
-    min-width: 0;
-    align-self: center;
-    height: var(--height-where-to-watch-list);
+    flex-direction: column;
+    gap: var(--gap-xl);
   }
 </style>

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchCategory.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchCategory.svelte
@@ -8,7 +8,7 @@
 
 <div class="trakt-where-to-watch-category">
   {#if title}
-    <h2 class="capitalize bold">
+    <h2 class="capitalize bold secondary">
       {title}
     </h2>
   {/if}
@@ -20,6 +20,10 @@
   .trakt-where-to-watch-category {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-xs);
+    gap: var(--ni-10);
+
+    h2 {
+      margin-block-end: var(--ni-2);
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchCountryTile.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchCountryTile.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { getMediaCost } from "./getMediaCost";
+  import type { WhereToWatchCountryTileProps } from "./models/WhereToWatchCountryTileProps";
+  import { toCountryFlag } from "./toCountryFlag";
+  import WhereToWatchServiceLink from "./WhereToWatchServiceLink.svelte";
+
+  const { service, country, countryName, type }:
+    WhereToWatchCountryTileProps = $props();
+
+  const cost = $derived(getMediaCost(service, type));
+</script>
+
+<div class="trakt-where-to-watch-country-tile">
+  <WhereToWatchServiceLink {service}>
+    <div class="country-tile-content">
+      <span class="country-flag">{toCountryFlag(country)}</span>
+      <span class="country-name ellipsis">
+        {countryName}
+      </span>
+      {#if cost}
+        <span class="country-cost tag secondary">{cost}</span>
+      {/if}
+    </div>
+  </WhereToWatchServiceLink>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-where-to-watch-country-tile {
+    min-width: 0;
+
+    :global(.trakt-link) {
+      display: block;
+      text-decoration: none;
+      color: var(--color-text-primary);
+
+      &:hover {
+        color: var(--color-text-primary);
+      }
+    }
+  }
+
+  .country-tile-content {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+
+    min-width: 0;
+    min-height: var(--ni-40);
+    padding-block: var(--ni-8);
+    padding-inline: var(--ni-12);
+    box-sizing: border-box;
+
+    background-color: color-mix(
+      in srgb,
+      var(--color-foreground) 8%,
+      transparent
+    );
+    border-radius: var(--border-radius-m);
+
+    transition: background-color var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 16%,
+          transparent
+        );
+      }
+    }
+  }
+
+  .country-flag {
+    flex-shrink: 0;
+    font-size: var(--ni-20);
+    line-height: var(--ni-20);
+  }
+
+  .country-name {
+    flex: 1;
+    min-width: 0;
+    text-align: start;
+    color: var(--color-text-primary);
+  }
+
+  .country-cost {
+    flex-shrink: 0;
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchItem.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchItem.svelte
@@ -1,54 +1,26 @@
 <script lang="ts">
-  import Link from "$lib/components/link/Link.svelte";
-  import { lineClamp } from "$lib/components/text/lineClamp";
-  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
-  import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { StreamingServiceOption } from "$lib/requests/models/StreamingServiceOptions";
   import type { LibraryOption } from "../models/LibraryOption";
-  import { getMediaCost, type CostType } from "./getMediaCost";
-  import { toCountryFlag } from "./toCountryFlag";
+  import { getMediaCost } from "./getMediaCost";
   import WhereToWatchLogo from "./WhereToWatchLogo.svelte";
+  import WhereToWatchServiceLink from "./WhereToWatchServiceLink.svelte";
 
   type WhereToWatchItemProps = {
     service: StreamingServiceOption | LibraryOption;
     country: string;
-    variant?: "service" | "country";
-    type?: CostType;
-    countryName?: string;
   };
 
-  const {
-    service,
-    country,
-    variant = "service",
-    type = "any",
-    countryName,
-  }: WhereToWatchItemProps = $props();
-
-  const { track } = useTrack(AnalyticsEvent.StreamOn);
+  const { service, country }: WhereToWatchItemProps = $props();
 
   const text = $derived.by(() => {
-    if (variant === "country") {
-      if (service.type !== "on-demand") {
-        return;
-      }
-
-      const costText = getMediaCost(service, type);
-      if (!costText) {
-        return;
-      }
-
-      return costText;
-    }
-
     switch (service.type) {
       case "library":
         return m.text_library();
       case "streaming":
         return m.text_stream();
       case "on-demand": {
-        const costText = getMediaCost(service, type);
+        const costText = getMediaCost(service, "any");
         if (!costText) {
           return m.text_on_demand();
         }
@@ -59,41 +31,27 @@
     }
   });
 
-  const hasSmallLogo = $derived(
-    service.type === "on-demand" && variant === "service",
-  );
-  const nameLines = $derived(text ? 1 : 2);
+  const hasSmallLogo = $derived(service.type === "on-demand");
 </script>
 
 <div class="trakt-where-to-watch-item">
-  <Link
-    href={service.link}
-    target="_blank"
-    onclick={() => track({ source: service.source })}
-  >
-    <div class="where-to-watch-item-content" data-variant={variant}>
-      {#if variant === "country"}
-        <div class="trakt-country">
-          <span class="trakt-country-flag">{toCountryFlag(country)}</span>
-          <span class="trakt-country-name" use:lineClamp={{ lines: nameLines }}>
-            {countryName ?? country.toUpperCase()}
-          </span>
-        </div>
-      {:else}
-        <WhereToWatchLogo
-          source={service.source}
-          {country}
-          size={hasSmallLogo ? "small" : "default"}
-        />
-      {/if}
+  <WhereToWatchServiceLink {service}>
+    <div class="where-to-watch-item-content">
+      <WhereToWatchLogo
+        source={service.source}
+        {country}
+        size={hasSmallLogo ? "small" : "default"}
+      />
       {#if text}
         <p>{text}</p>
       {/if}
     </div>
-  </Link>
+  </WhereToWatchServiceLink>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-where-to-watch-item {
     :global(.trakt-link) {
       text-decoration: none;
@@ -123,44 +81,28 @@
     background-color: var(--color-card-background);
     border-radius: var(--border-radius-m);
 
+    transition: background-color var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 8%,
+          var(--color-card-background)
+        );
+      }
+    }
+
+    justify-content: center;
+    overflow: hidden;
+
     p {
       text-align: center;
       flex-shrink: 0;
+      flex-grow: 1;
       min-height: var(--ni-18);
       display: flex;
       align-items: center;
-    }
-
-    &[data-variant="country"] {
-      justify-content: center;
-    }
-
-    &[data-variant="service"] {
-      justify-content: center;
-      overflow: hidden;
-
-      p {
-        flex-grow: 1;
-      }
-    }
-  }
-
-  .trakt-country {
-    display: grid;
-    grid-template-rows: 1fr auto;
-    justify-items: center;
-    flex-grow: 1;
-    gap: var(--gap-micro);
-
-    .trakt-country-name {
-      text-align: center;
-      min-height: calc(2lh);
-    }
-
-    .trakt-country-flag {
-      align-self: center;
-      font-size: var(--ni-32);
-      line-height: var(--ni-24);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchServiceLink.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchServiceLink.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
+  import type { StreamingServiceOption } from "$lib/requests/models/StreamingServiceOptions";
+  import type { LibraryOption } from "../models/LibraryOption";
+
+  type WhereToWatchServiceLinkProps = {
+    service: StreamingServiceOption | LibraryOption;
+  } & ChildrenProps;
+
+  const { service, children }: WhereToWatchServiceLinkProps = $props();
+
+  const { track } = useTrack(AnalyticsEvent.StreamOn);
+</script>
+
+<Link
+  href={service.link}
+  target="_blank"
+  onclick={() => track({ source: service.source })}
+>
+  {@render children()}
+</Link>

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchServiceSection.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchServiceSection.svelte
@@ -1,0 +1,393 @@
+<script lang="ts">
+  import CollapseIcon from "$lib/components/lists/section-list/CollapseIcon.svelte";
+  import { useStreamingServiceLogo } from "$lib/components/media/streaming-service/useStreamingServiceLogo";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { slide } from "svelte/transition";
+  import { getCostType } from "./getCostType";
+  import { getMediaCost } from "./getMediaCost";
+  import type { WhereToWatchServiceSectionProps } from "./models/WhereToWatchServiceSectionProps";
+  import { toCountryFlag } from "./toCountryFlag";
+  import WhereToWatchCountryTile from "./WhereToWatchCountryTile.svelte";
+  import WhereToWatchLogo from "./WhereToWatchLogo.svelte";
+  import WhereToWatchServiceLink from "./WhereToWatchServiceLink.svelte";
+
+  const PREVIEW_FLAG_LIMIT = 6;
+
+  const { source, countries, group, userCountry, isSearching = false }:
+    WhereToWatchServiceSectionProps = $props();
+
+  // svelte-ignore state_referenced_locally
+  const logo = useStreamingServiceLogo({ source });
+
+  let isCollapsed = $derived(!isSearching);
+
+  const displayName = $derived($logo?.name || source);
+  const hasLogo = $derived(Boolean($logo?.url));
+  const costType = $derived(getCostType(group));
+
+  const featured = $derived(
+    countries.find((entry) => entry.country === userCountry) ??
+      (countries.length === 1 ? countries.at(0) : undefined),
+  );
+  const featuredCost = $derived(
+    featured ? getMediaCost(featured.service, costType) : "",
+  );
+  const otherCountries = $derived(
+    countries.filter((entry) => entry !== featured),
+  );
+  const isExpandable = $derived(otherCountries.length > 0);
+  const previewCountries = $derived(
+    featured ? [] : otherCountries.slice(0, PREVIEW_FLAG_LIMIT),
+  );
+  const hiddenCount = $derived(otherCountries.length - previewCountries.length);
+
+  function toggle() {
+    isCollapsed = !isCollapsed;
+  }
+</script>
+
+{#snippet serviceLogo()}
+  <span class="service-logo-box">
+    {#if hasLogo}
+      <WhereToWatchLogo {source} size="small" />
+    {:else}
+      <span class="service-logo-fallback bold">{displayName}</span>
+    {/if}
+  </span>
+{/snippet}
+
+{#snippet serviceInfo()}
+  <span class="service-info">
+    <span class="service-name bold ellipsis">{displayName}</span>
+
+    {#if featured}
+      <span class="service-location">
+        <span class="service-flag">{toCountryFlag(featured.country)}</span>
+        <span class="service-country ellipsis">{featured.countryName}</span>
+        {#if featuredCost}
+          <span class="service-cost">{featuredCost}</span>
+        {/if}
+      </span>
+    {:else}
+      <span class="service-flags">
+        {#each previewCountries as entry (entry.key)}
+          <span class="service-flag">{toCountryFlag(entry.country)}</span>
+        {/each}
+      </span>
+    {/if}
+  </span>
+{/snippet}
+
+{#snippet serviceToggle()}
+  {#if hiddenCount > 0}
+    <span class="service-hidden-count tag secondary">+{hiddenCount}</span>
+  {/if}
+
+  <CollapseIcon
+    state={isCollapsed ? "collapsed" : "expanded"}
+    variant="bare"
+    size={20}
+  />
+{/snippet}
+
+<div
+  class="trakt-where-to-watch-service-section"
+  class:is-expanded={!isCollapsed}
+>
+  {#if featured}
+    <div class="service-header">
+      <WhereToWatchServiceLink service={featured.service}>
+        {@render serviceLogo()}
+        {@render serviceInfo()}
+      </WhereToWatchServiceLink>
+
+      {#if isExpandable}
+        <button
+          type="button"
+          class="service-toggle"
+          aria-expanded={!isCollapsed}
+          aria-label={m.button_label_toggle_streaming_countries({
+            service: displayName,
+          })}
+          onclick={toggle}
+        >
+          {@render serviceToggle()}
+        </button>
+      {/if}
+    </div>
+  {:else}
+    <button
+      type="button"
+      class="service-header"
+      aria-expanded={!isCollapsed}
+      aria-label={m.button_label_toggle_streaming_countries({
+        service: displayName,
+      })}
+      onclick={toggle}
+    >
+      {@render serviceLogo()}
+      {@render serviceInfo()}
+
+      <span class="service-toggle">
+        {@render serviceToggle()}
+      </span>
+    </button>
+  {/if}
+
+  {#if !isCollapsed && isExpandable}
+    <div class="service-countries" transition:slide={{ duration: 150 }}>
+      {#each otherCountries as entry (entry.key)}
+        <WhereToWatchCountryTile
+          service={entry.service}
+          country={entry.country}
+          countryName={entry.countryName}
+          type={costType}
+        />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-where-to-watch-service-section {
+    --service-logo-box-height: var(--ni-64);
+
+    display: flex;
+    flex-direction: column;
+
+    overflow: hidden;
+
+    background: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+  }
+
+  .service-header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-m);
+
+    width: 100%;
+    min-height: calc(var(--service-logo-box-height) + 2 * var(--ni-8));
+    padding: var(--ni-8);
+    box-sizing: border-box;
+
+    color: var(--color-text-primary);
+    text-align: start;
+
+    :global(.trakt-link) {
+      flex: 1;
+      min-width: 0;
+
+      display: flex;
+      align-items: center;
+      gap: var(--gap-m);
+
+      border-radius: var(--border-radius-m);
+
+      text-decoration: none;
+      color: var(--color-text-primary);
+
+      transition: background-color var(--transition-increment) ease-in-out;
+
+      @include for-mouse {
+        &:hover {
+          color: var(--color-text-primary);
+          background-color: color-mix(
+            in srgb,
+            var(--color-foreground) 5%,
+            transparent
+          );
+        }
+      }
+    }
+  }
+
+  button.service-header {
+    background: none;
+    border: none;
+    font: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+
+    transition: background-color var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 5%,
+          transparent
+        );
+      }
+    }
+  }
+
+  .service-toggle {
+    flex-shrink: 0;
+    align-self: stretch;
+
+    display: flex;
+    align-items: center;
+    gap: var(--ni-4);
+
+    min-height: var(--ni-40);
+    padding-inline: var(--ni-8);
+    border-radius: var(--border-radius-m);
+
+    color: var(--color-text-secondary);
+  }
+
+  button.service-toggle {
+    position: relative;
+
+    background: none;
+    border: none;
+    font: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+
+    &::before {
+      content: "";
+
+      position: absolute;
+      inset-block: var(--ni-8);
+      inset-inline-start: calc(-1 * var(--gap-m) / 2);
+      width: var(--ni-1);
+
+      background-color: var(--color-border);
+    }
+
+    transition: background-color var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 10%,
+          transparent
+        );
+      }
+    }
+  }
+
+  .service-logo-box {
+    flex-shrink: 0;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    height: var(--service-logo-box-height);
+    width: calc(var(--service-logo-box-height) * 6 / 5);
+    padding: var(--ni-10);
+    box-sizing: border-box;
+    overflow: hidden;
+
+    border-radius: var(--border-radius-m);
+    background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+
+    :global(.trakt-streaming-service-logo) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .service-logo-fallback {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
+
+    max-width: 100%;
+    font-size: var(--ni-11);
+    line-height: 1.1;
+    text-align: center;
+    text-transform: uppercase;
+    color: var(--color-text-primary);
+    overflow-wrap: break-word;
+  }
+
+  .service-info {
+    flex: 1;
+    min-width: 0;
+
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .service-name {
+    max-width: 100%;
+    font-size: var(--ni-16);
+    line-height: var(--ni-16);
+    text-align: start;
+  }
+
+  .service-location {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    max-width: 100%;
+    margin-block-start: var(--ni-6);
+
+    color: var(--color-text-secondary);
+  }
+
+  .service-country {
+    min-width: 0;
+  }
+
+  .service-cost {
+    flex-shrink: 0;
+
+    &::before {
+      content: "•";
+      margin-inline-end: var(--gap-xs);
+    }
+  }
+
+  .service-hidden-count {
+    flex-shrink: 0;
+  }
+
+  .service-flags {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-4);
+
+    max-width: 100%;
+    overflow: hidden;
+
+    margin-block-start: var(--ni-6);
+    max-block-size: var(--ni-16);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: max-block-size, margin-block-start, opacity;
+  }
+
+  .trakt-where-to-watch-service-section.is-expanded .service-flags {
+    margin-block-start: 0;
+    max-block-size: 0;
+    opacity: 0;
+  }
+
+  .service-flag {
+    flex-shrink: 0;
+    font-size: var(--ni-16);
+    line-height: var(--ni-16);
+  }
+
+  .service-countries {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--gap-xs);
+
+    padding-inline: var(--ni-8);
+    padding-block-start: var(--ni-6);
+    padding-block-end: var(--ni-8);
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/filterGroupedServices.ts
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/filterGroupedServices.ts
@@ -1,0 +1,49 @@
+import type { GroupedServices } from './models/GroupedServices.ts';
+import type { ServiceAvailability } from './models/ServiceAvailability.ts';
+
+type FilterGroupedServicesProps = {
+  readonly grouped: GroupedServices;
+  readonly term: string;
+  readonly names: ReadonlyMap<string, string>;
+};
+
+type FilterRowProps = {
+  readonly row: ServiceAvailability;
+  readonly term: string;
+  readonly names: ReadonlyMap<string, string>;
+};
+
+function filterRow(
+  { row, term, names }: FilterRowProps,
+): ServiceAvailability | null {
+  const serviceName = names.get(row.source) ?? row.source;
+  const serviceMatches = serviceName.toLocaleLowerCase().includes(term) ||
+    row.source.toLocaleLowerCase().includes(term);
+
+  if (serviceMatches) {
+    return row;
+  }
+
+  const countries = row.countries.filter((entry) =>
+    entry.countryName.toLocaleLowerCase().includes(term)
+  );
+
+  if (countries.length === 0) {
+    return null;
+  }
+
+  return { ...row, countries };
+}
+
+export function filterGroupedServices(
+  { grouped, term, names }: FilterGroupedServicesProps,
+): GroupedServices {
+  return Object.fromEntries(
+    Object.entries(grouped).map(([group, rows]) => [
+      group,
+      rows
+        .map((row) => filterRow({ row, term, names }))
+        .filter((row): row is ServiceAvailability => row !== null),
+    ]),
+  ) as GroupedServices;
+}

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/getCostType.ts
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/getCostType.ts
@@ -1,0 +1,13 @@
+import type { CostType } from './getMediaCost.ts';
+import { StreamingGroup } from './models/StreamingGroup.ts';
+
+export function getCostType(group: StreamingGroup): CostType {
+  switch (group) {
+    case StreamingGroup.Rent:
+      return 'rent';
+    case StreamingGroup.Purchase:
+      return 'purchase';
+    default:
+      return 'any';
+  }
+}

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/getMediaCost.spec.ts
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/getMediaCost.spec.ts
@@ -1,8 +1,23 @@
-import type { StreamOnDemand } from '$lib/requests/models/StreamingServiceOptions.ts';
+import type {
+  StreamNow,
+  StreamOnDemand,
+} from '$lib/requests/models/StreamingServiceOptions.ts';
 import { describe, expect, it } from 'vitest';
 import { getMediaCost } from './getMediaCost.ts';
 
 describe('getMediaCost', () => {
+  it('should return an empty string for services that are not on-demand', () => {
+    const streamingService: StreamNow = {
+      link: 'https://example.com',
+      source: 'source',
+      is4k: false,
+      type: 'streaming',
+      key: 'streaming-example',
+    };
+
+    expect(getMediaCost(streamingService, 'any')).toEqual('');
+  });
+
   it('should return an empty string if there are no rent or purchase prices', () => {
     const onDemandService: StreamOnDemand = {
       link: 'https://example.com',

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/getMediaCost.ts
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/getMediaCost.ts
@@ -1,5 +1,8 @@
 import { languageTag } from '$lib/features/i18n/index.ts';
-import type { StreamOnDemand } from '$lib/requests/models/StreamingServiceOptions.ts';
+import type {
+  StreamingServiceOption,
+  StreamOnDemand,
+} from '$lib/requests/models/StreamingServiceOptions.ts';
 import { toHumanCurrency } from '$lib/utils/formatting/currency/toHumanCurrency.ts';
 
 export type CostType = 'rent' | 'purchase' | 'any';
@@ -14,17 +17,21 @@ function resolvePrice(
 }
 
 export function getMediaCost(
-  onDemandService: StreamOnDemand,
+  service: StreamingServiceOption,
   type: CostType,
 ): string {
-  const price = resolvePrice(onDemandService.prices, type);
-  if (!price || !onDemandService.currency) {
+  if (service.type !== 'on-demand') {
+    return '';
+  }
+
+  const price = resolvePrice(service.prices, type);
+  if (!price || !service.currency) {
     return '';
   }
 
   return toHumanCurrency({
     price,
-    currency: onDemandService.currency,
+    currency: service.currency,
     locale: languageTag(),
   });
 }

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/models/WhereToWatchCountryTileProps.ts
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/models/WhereToWatchCountryTileProps.ts
@@ -1,0 +1,9 @@
+import type { StreamingServiceOption } from '$lib/requests/models/StreamingServiceOptions.ts';
+import type { CostType } from '../getMediaCost.ts';
+
+export type WhereToWatchCountryTileProps = {
+  readonly service: StreamingServiceOption;
+  readonly country: string;
+  readonly countryName: string;
+  readonly type: CostType;
+};

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/models/WhereToWatchServiceSectionProps.ts
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/models/WhereToWatchServiceSectionProps.ts
@@ -1,0 +1,10 @@
+import type { ServiceInCountry } from './ServiceInCountry.ts';
+import type { StreamingGroup } from './StreamingGroup.ts';
+
+export type WhereToWatchServiceSectionProps = {
+  readonly source: string;
+  readonly countries: ReadonlyArray<ServiceInCountry>;
+  readonly group: StreamingGroup;
+  readonly userCountry: string;
+  readonly isSearching?: boolean;
+};

--- a/projects/client/src/lib/sections/summary/components/_internal/DrawerCastSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DrawerCastSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import DrawerSearchInput from "$lib/components/drawer/DrawerSearchInput.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
-  import SearchIcon from "$lib/components/icons/SearchIcon.svelte";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import type { ToggleOption } from "$lib/components/toggles/ToggleOption.ts";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -91,15 +91,11 @@
   {#if isLoading}
     <LoadingIndicator />
   {:else}
-    <label class="credit-search">
-      <SearchIcon />
-      <input
-        bind:value={searchTerm}
-        type="search"
-        aria-label={m.input_label_search_credit_members()}
-        placeholder={m.input_placeholder_search_credit_members()}
-      />
-    </label>
+    <DrawerSearchInput
+      bind:value={searchTerm}
+      label={m.input_label_search_credit_members()}
+      placeholder={m.input_placeholder_search_credit_members()}
+    />
 
     {#if visibleCredits.length > 0}
       <div
@@ -126,40 +122,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);
-  }
-
-  .credit-search {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-xs);
-
-    min-height: var(--ni-48);
-    padding: 0 var(--ni-16);
-    box-sizing: border-box;
-
-    border-radius: var(--border-radius-l);
-    background: var(--color-input-background);
-    outline: var(--border-thickness-xxs) solid var(--color-border);
-
-    transition: outline var(--transition-increment) ease-in-out;
-
-    &:focus-within {
-      outline: var(--border-thickness-xs) solid var(--color-input-focus);
-    }
-
-    :global(svg) {
-      flex-shrink: 0;
-      width: var(--ni-24);
-      height: var(--ni-24);
-      color: var(--color-text-secondary);
-    }
-
-    input {
-      all: unset;
-      min-width: 0;
-      width: 100%;
-      height: 100%;
-    }
   }
 
   .credit-list {

--- a/projects/client/src/lib/sections/summary/components/cast/CastDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/cast/CastDrawerHost.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Drawer from "$lib/components/drawer/Drawer.svelte";
-  import SearchIcon from "$lib/components/icons/SearchIcon.svelte";
+  import DrawerSearchInput from "$lib/components/drawer/DrawerSearchInput.svelte";
   import type { ToggleOption } from "$lib/components/toggles/ToggleOption.ts";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -85,15 +85,11 @@
 >
   {#if isOpen}
     <div class="cast-drawer-content" transition:fade={{ duration: 150 }}>
-      <label class="credit-search">
-        <SearchIcon />
-        <input
-          bind:value={searchTerm}
-          type="search"
-          aria-label={m.input_label_search_credit_members()}
-          placeholder={m.input_placeholder_search_credit_members()}
-        />
-      </label>
+      <DrawerSearchInput
+        bind:value={searchTerm}
+        label={m.input_label_search_credit_members()}
+        placeholder={m.input_placeholder_search_credit_members()}
+      />
 
       {#if visibleCredits.length > 0}
         <div
@@ -127,40 +123,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);
-
-    .credit-search {
-      display: flex;
-      align-items: center;
-      gap: var(--gap-xs);
-
-      min-height: var(--ni-48);
-      padding: 0 var(--ni-16);
-      box-sizing: border-box;
-
-      border-radius: var(--border-radius-l);
-      background: var(--color-input-background);
-      outline: var(--border-thickness-xxs) solid var(--color-border);
-
-      transition: outline var(--transition-increment) ease-in-out;
-
-      &:focus-within {
-        outline: var(--border-thickness-xs) solid var(--color-input-focus);
-      }
-
-      :global(svg) {
-        flex-shrink: 0;
-        width: var(--ni-24);
-        height: var(--ni-24);
-        color: var(--color-text-secondary);
-      }
-
-      input {
-        all: unset;
-        min-width: 0;
-        width: 100%;
-        height: 100%;
-      }
-    }
 
     .credit-list {
       display: flex;


### PR DESCRIPTION
- horizontal scrolling in a narrow vertical space with only ~3 tiles visible is dreadful
- proposing a vertical based layout with foldable sections per streaming service
- now also matches UI style of how streaming services tiles are presented in the Settings
- bonus: no more grey scrollbars for browsers other than Chrome

Current:
<img height="333" alt="image" src="https://github.com/user-attachments/assets/795babd1-169b-4572-bf5a-f3c0fba95a54" />

After:
<img height="333" alt="image" src="https://github.com/user-attachments/assets/e425318e-8ed2-4993-b9fe-31c05234f3d9" />

After Video:
https://github.com/user-attachments/assets/df784de4-b8b9-437b-9da6-3a56a37318c2

