### PR TITLE
fix(select): restore scroll button interaction

### DIFF
--- a/projects/client/src/lib/components/select/_internal/SelectBase.svelte
+++ b/projects/client/src/lib/components/select/_internal/SelectBase.svelte
@@ -76,24 +76,16 @@
                 {@render header()}
               {/if}
 
-              <Select.ScrollUpButton>
-                {#snippet child({ props: scrollProps })}
-                  <div {...scrollProps} class="trakt-select-scroll-button">
-                    <ScrollUpIcon />
-                  </div>
-                {/snippet}
+              <Select.ScrollUpButton class="trakt-select-scroll-button">
+                <ScrollUpIcon />
               </Select.ScrollUpButton>
 
               <Select.Viewport>
                 {@render children()}
               </Select.Viewport>
 
-              <Select.ScrollDownButton>
-                {#snippet child({ props: scrollProps })}
-                  <div {...scrollProps} class="trakt-select-scroll-button">
-                    <ScrollDownIcon />
-                  </div>
-                {/snippet}
+              <Select.ScrollDownButton class="trakt-select-scroll-button">
+                <ScrollDownIcon />
               </Select.ScrollDownButton>
             </div>
           </div>
@@ -232,7 +224,7 @@
     }
   }
 
-  .trakt-select-scroll-button {
+  :global(.trakt-select-scroll-button) {
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Scroll buttons in the select dropdowns stopped responding to hover and tap.
- Cause: bits-ui passes `restProps` instead of `mergedProps` into the `child` snippet of `Select.ScrollUpButton` / `Select.ScrollDownButton`, so `onpointerdown`, `onpointermove` and `onpointerleave` are all dropped. `Select.Viewport` passes `mergedProps` correctly, which is why only the buttons broke.
- Introduced when `SelectBase` was extracted out of `MultiSelect`, which rewrote them to use `child`. This goes back to the plain markup we had before.
- Class moved to `:global` since bits-ui renders the element itself now, same as we do for `Slider` and `TabView`.
- Two touch quirks are left over. Both are upstream, both reproduce on bits-ui's own docs demo, so leaving them for now and reporting separately:
  - the button unmounts the moment the viewport hits an edge, so if that happens mid-gesture the release lands on the item underneath and selects it.
  - the down button re-scrolls the highlighted item into view every time it re-mounts, which fights scrolling away from an already selected option.
  
## 👀 Examples 👀
On desktop, hovering over the buttons scrolls the dropdown again:

https://github.com/user-attachments/assets/8826ea14-8da0-4553-b58d-731d12a3a80f



On touch, tapping (keeping it pressed) scrolls the dropdown again:

https://github.com/user-attachments/assets/19ec67d2-e7d2-42ac-b498-3638d588bf0d

