### PR TITLE
feat(cover-image): preview the artwork before it becomes your cover

### DIFF
--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -156,6 +156,25 @@ Use `{#snippet}` and `Snippet` type for flexible content injection.
 
 ---
 
+## Extending a Primitive: Slots, Not Domain Props
+
+`lib/components` primitives stay domain free when **modified**, not just when
+placed. If a feature needs one to render something new, add a `Snippet` slot and
+let the feature fill it, along with any styling specific to that content.
+
+```svelte
+<!-- Bad - the primitive now knows about one feature's data -->
+const { previewUrl }: { previewUrl?: HttpsUrl | Nil } = $props();
+
+<!-- Good - it renders whatever it is handed -->
+const { content }: { content?: Snippet } = $props();
+```
+
+Still props: generic options (`size`, `variant`, `aria-label`) and anything that
+gates behaviour rather than renders.
+
+---
+
 ## Provider Pattern
 
 Feature providers are thin shells calling a context factory from `_internal/`.
@@ -767,6 +786,7 @@ property (`inset-inline-start`, not `left`), or the animation silently dies.
 - [ ] Using Svelte 5 runes (`$props`, `$derived`, `$effect`) - no `export let`
       or `$:`
 - [ ] Snippets used for slot-like composition, not legacy `<slot>`
+- [ ] Primitives extended with a `Snippet` slot, not a domain-shaped prop
 - [ ] Props type file created for components with 3+ props
 - [ ] Provider delegates to `_internal/createXxxContext` via `iffy()`
 - [ ] `use*` hooks live in `features/{domain}/stores/` and return `$derived`

--- a/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
+++ b/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
   import FormInput from "$lib/components/form/FormInput.svelte";
+  import type { Confirmation } from "$lib/features/confirmation/models/Confirmation";
   import type { ConfirmationAction } from "$lib/features/confirmation/models/ConfirmationAction";
-  import type { ConfirmationChallenge } from "$lib/features/confirmation/models/ConfirmationChallenge";
-  import type { ConfirmationOperation } from "$lib/features/confirmation/models/ConfirmationOperation";
   import * as m from "$lib/features/i18n/messages.ts";
-  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import type { Snippet } from "svelte";
   import Modal from "./Modal.svelte";
 
   const {
@@ -17,17 +16,11 @@
     onAction,
     operation,
     challenge,
-    previewUrl,
-  }: {
-    title: string;
+    content,
+  }: Omit<Confirmation, "message"> & {
     message: string;
-    detail?: string;
-    buttonText: string;
-    cancelText?: string;
-    operation: ConfirmationOperation;
+    content?: Snippet;
     onAction: (action: ConfirmationAction) => void;
-    challenge?: ConfirmationChallenge;
-    previewUrl?: string | Nil;
   } = $props();
 
   const isDestructive = $derived(operation === "destructive");
@@ -49,14 +42,9 @@
       <p class="trakt-confirmation-message secondary">{detail}</p>
     {/if}
 
-    {#if previewUrl}
-      <div class="trakt-confirmation-preview">
-        <CrossOriginImage
-          classList="confirmation-preview-image"
-          src={previewUrl}
-          alt=""
-          loading="eager"
-        />
+    {#if content}
+      <div class="trakt-confirmation-slot">
+        {@render content()}
       </div>
     {/if}
 
@@ -108,21 +96,8 @@
     gap: var(--ni-8);
   }
 
-  .trakt-confirmation-preview {
+  .trakt-confirmation-slot {
     margin-top: var(--ni-8);
-
-    aspect-ratio: 16 / 9;
-    overflow: hidden;
-    border-radius: var(--border-radius-m);
-    background-color: color-mix(in srgb, var(--color-border) 80%, transparent);
-
-    :global(img.confirmation-preview-image) {
-      display: block;
-
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
   }
 
   .trakt-confirmation-challenge {

--- a/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
+++ b/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
@@ -5,6 +5,7 @@
   import type { ConfirmationChallenge } from "$lib/features/confirmation/models/ConfirmationChallenge";
   import type { ConfirmationOperation } from "$lib/features/confirmation/models/ConfirmationOperation";
   import * as m from "$lib/features/i18n/messages.ts";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import Modal from "./Modal.svelte";
 
   const {
@@ -16,6 +17,7 @@
     onAction,
     operation,
     challenge,
+    previewUrl,
   }: {
     title: string;
     message: string;
@@ -25,6 +27,7 @@
     operation: ConfirmationOperation;
     onAction: (action: ConfirmationAction) => void;
     challenge?: ConfirmationChallenge;
+    previewUrl?: string | Nil;
   } = $props();
 
   const isDestructive = $derived(operation === "destructive");
@@ -44,6 +47,17 @@
     <p class="trakt-confirmation-message secondary">{message}</p>
     {#if detail}
       <p class="trakt-confirmation-message secondary">{detail}</p>
+    {/if}
+
+    {#if previewUrl}
+      <div class="trakt-confirmation-preview">
+        <CrossOriginImage
+          classList="confirmation-preview-image"
+          src={previewUrl}
+          alt=""
+          loading="eager"
+        />
+      </div>
     {/if}
 
     {#if challenge}
@@ -92,6 +106,23 @@
     display: flex;
     flex-direction: column;
     gap: var(--ni-8);
+  }
+
+  .trakt-confirmation-preview {
+    margin-top: var(--ni-8);
+
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-radius: var(--border-radius-m);
+    background-color: color-mix(in srgb, var(--color-border) 80%, transparent);
+
+    :global(img.confirmation-preview-image) {
+      display: block;
+
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   }
 
   .trakt-confirmation-challenge {

--- a/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
+++ b/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
@@ -18,6 +18,7 @@
     cancelText={$activeConfirmation.cancelText}
     operation={$activeConfirmation.operation}
     challenge={$activeConfirmation.challenge}
+    previewUrl={$activeConfirmation.previewUrl}
     onAction={(action) => {
       if (action === "confirm") {
         $activeConfirmation.onConfirm();

--- a/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
+++ b/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
   import ConfirmationDialog from "$lib/components/dialogs/ConfirmationDialog.svelte";
+  import { confirmationContent } from "./_internal/confirmationContent.ts";
   import { createConfirmationContext } from "./_internal/createConfirmationContext";
 
   const { children }: ChildrenProps = $props();
 
   const { activeConfirmation, hideConfirmation } = createConfirmationContext();
+
+  const ContentComponent = $derived(
+    $activeConfirmation
+      ? confirmationContent[$activeConfirmation.params.type]
+      : undefined,
+  );
 </script>
 
 {@render children()}
+
+{#snippet contentSlot()}
+  {#if ContentComponent && $activeConfirmation}
+    <ContentComponent params={$activeConfirmation.params} />
+  {/if}
+{/snippet}
 
 {#if $activeConfirmation?.message}
   <ConfirmationDialog
@@ -18,7 +31,7 @@
     cancelText={$activeConfirmation.cancelText}
     operation={$activeConfirmation.operation}
     challenge={$activeConfirmation.challenge}
-    previewUrl={$activeConfirmation.previewUrl}
+    content={ContentComponent ? contentSlot : undefined}
     onAction={(action) => {
       if (action === "confirm") {
         $activeConfirmation.onConfirm();

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContentProps.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContentProps.ts
@@ -1,0 +1,6 @@
+import type { ConfirmationParams } from '../models/ConfirmationParams.ts';
+import type { ConfirmationType } from '../models/ConfirmationType.ts';
+
+export type ConfirmationContentProps = {
+  params: ConfirmationParams<ConfirmationType>;
+};

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
@@ -1,18 +1,12 @@
 import { BehaviorSubject } from 'rxjs';
-import type { ConfirmationChallenge } from '../models/ConfirmationChallenge.ts';
-import type { ConfirmationOperation } from '../models/ConfirmationOperation.ts';
+import type { Confirmation } from '../models/Confirmation.ts';
+import type { ConfirmationParams } from '../models/ConfirmationParams.ts';
+import type { ConfirmationType } from '../models/ConfirmationType.ts';
 
-export type ConfirmationRequest = {
+export type ConfirmationRequest = Confirmation & {
   onConfirm: () => void;
   onCancel?: () => void;
-  title: string;
-  message: string | Nil;
-  detail?: string;
-  buttonText: string;
-  cancelText?: string;
-  operation: ConfirmationOperation;
-  challenge?: ConfirmationChallenge;
-  previewUrl?: string | Nil;
+  params: ConfirmationParams<ConfirmationType>;
 };
 
 export type ConfirmationContext = {

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
@@ -12,6 +12,7 @@ export type ConfirmationRequest = {
   cancelText?: string;
   operation: ConfirmationOperation;
   challenge?: ConfirmationChallenge;
+  previewUrl?: string | Nil;
 };
 
 export type ConfirmationContext = {

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationPreviewImage.svelte
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationPreviewImage.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+
+  const { url }: { url: HttpsUrl } = $props();
+</script>
+
+<div class="trakt-confirmation-preview-image">
+  <CrossOriginImage classList="preview-image" src={url} alt="" loading="eager" />
+</div>
+
+<style lang="scss">
+  .trakt-confirmation-preview-image {
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-radius: var(--border-radius-m);
+    background-color: color-mix(in srgb, var(--color-border) 80%, transparent);
+
+    :global(img.preview-image) {
+      display: block;
+
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+</style>

--- a/projects/client/src/lib/features/confirmation/_internal/SetCoverImagePreview.svelte
+++ b/projects/client/src/lib/features/confirmation/_internal/SetCoverImagePreview.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { ConfirmationContentProps } from "./ConfirmationContentProps.ts";
+  import { ConfirmationType } from "../models/ConfirmationType.ts";
+  import ConfirmationPreviewImage from "./ConfirmationPreviewImage.svelte";
+
+  const { params }: ConfirmationContentProps = $props();
+
+  const url = $derived(
+    params.type === ConfirmationType.SetCoverImage ? params.previewUrl : null,
+  );
+</script>
+
+{#if url}
+  <ConfirmationPreviewImage {url} />
+{/if}

--- a/projects/client/src/lib/features/confirmation/_internal/confirmationContent.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/confirmationContent.ts
@@ -1,0 +1,10 @@
+import type { Component } from 'svelte';
+import { ConfirmationType } from '../models/ConfirmationType.ts';
+import type { ConfirmationContentProps } from './ConfirmationContentProps.ts';
+import SetCoverImagePreview from './SetCoverImagePreview.svelte';
+
+export const confirmationContent: Partial<
+  Record<ConfirmationType, Component<ConfirmationContentProps>>
+> = {
+  [ConfirmationType.SetCoverImage]: SetCoverImagePreview,
+};

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
@@ -35,7 +35,7 @@ describe('mapToConfirmation', () => {
   });
 
   describe('for SetCoverImage', () => {
-    it('should ask affirmatively and carry the artwork through as the preview', () => {
+    it('should ask affirmatively and name the media', () => {
       const result = mapToConfirmation({
         type: ConfirmationType.SetCoverImage,
         title: 'Heretic',
@@ -44,7 +44,6 @@ describe('mapToConfirmation', () => {
 
       expect(result.operation).toBe('affirmative');
       expect(result.message).toContain('Heretic');
-      expect(result.previewUrl).toBe('https://example.com/heretic.jpg');
     });
 
     it('should still confirm when the media has no artwork to preview', () => {
@@ -54,7 +53,6 @@ describe('mapToConfirmation', () => {
       });
 
       expect(result.message).toBeTruthy();
-      expect(result.previewUrl).toBeUndefined();
     });
   });
 

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
@@ -34,6 +34,30 @@ describe('mapToConfirmation', () => {
     expect(result.message).toBeTruthy();
   });
 
+  describe('for SetCoverImage', () => {
+    it('should ask affirmatively and carry the artwork through as the preview', () => {
+      const result = mapToConfirmation({
+        type: ConfirmationType.SetCoverImage,
+        title: 'Heretic',
+        previewUrl: 'https://example.com/heretic.jpg',
+      });
+
+      expect(result.operation).toBe('affirmative');
+      expect(result.message).toContain('Heretic');
+      expect(result.previewUrl).toBe('https://example.com/heretic.jpg');
+    });
+
+    it('should still confirm when the media has no artwork to preview', () => {
+      const result = mapToConfirmation({
+        type: ConfirmationType.SetCoverImage,
+        title: 'Heretic',
+      });
+
+      expect(result.message).toBeTruthy();
+      expect(result.previewUrl).toBeUndefined();
+    });
+  });
+
   describe('for CleanUpHistory', () => {
     const cleanUpHistory = (keeps: 'oldest' | 'newest') =>
       mapToConfirmation({

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -1,20 +1,8 @@
 import * as m from '$lib/features/i18n/messages.ts';
-import type { ConfirmationChallenge } from '../models/ConfirmationChallenge.ts';
-import type { ConfirmationOperation } from '../models/ConfirmationOperation.ts';
+import type { Confirmation } from '../models/Confirmation.ts';
 import type { ConfirmationParams } from '../models/ConfirmationParams.ts';
 import { ConfirmationType } from '../models/ConfirmationType.ts';
 import { getWarningMessage } from './getWarningMessage.ts';
-
-type Confirmation = {
-  title: string;
-  message: string | Nil;
-  detail?: string;
-  buttonText: string;
-  cancelText?: string;
-  operation: ConfirmationOperation;
-  challenge?: ConfirmationChallenge;
-  previewUrl?: string | Nil;
-};
 
 type ConfirmationBuilder<T extends ConfirmationType> = (
   props: ConfirmationParams<T>,
@@ -232,7 +220,6 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     buttonText: m.button_text_yes(),
     message: m.warning_prompt_set_cover_image({ title: props.title }),
     operation: 'affirmative',
-    previewUrl: props.previewUrl,
   }),
   [ConfirmationType.RevokeApp]: (props) => ({
     title: m.confirmation_title_revoke_app(),

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -13,6 +13,7 @@ type Confirmation = {
   cancelText?: string;
   operation: ConfirmationOperation;
   challenge?: ConfirmationChallenge;
+  previewUrl?: string | Nil;
 };
 
 type ConfirmationBuilder<T extends ConfirmationType> = (
@@ -225,6 +226,13 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     buttonText: m.button_text_reset_cover_image(),
     message: m.confirmation_message_reset_cover_image(),
     operation: 'destructive',
+  }),
+  [ConfirmationType.SetCoverImage]: (props) => ({
+    title: m.button_text_set_cover_image(),
+    buttonText: m.button_text_yes(),
+    message: m.warning_prompt_set_cover_image({ title: props.title }),
+    operation: 'affirmative',
+    previewUrl: props.previewUrl,
   }),
   [ConfirmationType.RevokeApp]: (props) => ({
     title: m.confirmation_title_revoke_app(),

--- a/projects/client/src/lib/features/confirmation/models/Confirmation.ts
+++ b/projects/client/src/lib/features/confirmation/models/Confirmation.ts
@@ -1,0 +1,12 @@
+import type { ConfirmationChallenge } from './ConfirmationChallenge.ts';
+import type { ConfirmationOperation } from './ConfirmationOperation.ts';
+
+export type Confirmation = {
+  title: string;
+  message: string | Nil;
+  detail?: string;
+  buttonText: string;
+  cancelText?: string;
+  operation: ConfirmationOperation;
+  challenge?: ConfirmationChallenge;
+};

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -126,6 +126,11 @@ interface ConfirmationParamsMap {
   [ConfirmationType.ResetCoverImage]: {
     type: ConfirmationType.ResetCoverImage;
   };
+  [ConfirmationType.SetCoverImage]: {
+    type: ConfirmationType.SetCoverImage;
+    title: string;
+    previewUrl?: string | Nil;
+  };
 }
 
 export type ConfirmationParams<T extends ConfirmationType> =

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -129,7 +129,7 @@ interface ConfirmationParamsMap {
   [ConfirmationType.SetCoverImage]: {
     type: ConfirmationType.SetCoverImage;
     title: string;
-    previewUrl?: string | Nil;
+    previewUrl?: HttpsUrl | Nil;
   };
 }
 

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
@@ -32,4 +32,5 @@ export enum ConfirmationType {
   DeleteApiApp = 'delete-api-app',
   DeleteAccount = 'delete-account',
   ResetCoverImage = 'reset-cover-image',
+  SetCoverImage = 'set-cover-image',
 }

--- a/projects/client/src/lib/features/confirmation/useConfirm.ts
+++ b/projects/client/src/lib/features/confirmation/useConfirm.ts
@@ -25,6 +25,7 @@ export function useConfirm() {
         ...confirmation,
         onConfirm: props.onConfirm,
         onCancel: props.onCancel,
+        params: props,
       });
 
       // Mimic native confirm behavior

--- a/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.spec.ts
@@ -1,0 +1,83 @@
+import { server } from '$mocks/server.ts';
+import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { setAuthorization } from '$test/beds/store/renderStore.ts';
+import { screen, waitFor, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it } from 'vitest';
+import SetCoverImageAction from './SetCoverImageAction.svelte';
+
+const COVER_URL =
+  'https://walter.trakt.tv/images/movies/000/001/000/artwork.jpg';
+
+function trackCoverRequests() {
+  const requests: unknown[] = [];
+
+  server.use(
+    http.put('http://localhost/users/set_cover', async ({ request }) => {
+      requests.push(await request.json());
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  return requests;
+}
+
+async function openConfirmation() {
+  const user = userEvent.setup();
+
+  renderComponent(SetCoverImageAction, {
+    props: {
+      style: 'dropdown-item',
+      type: 'movie',
+      id: 1000,
+      title: 'Heretic',
+      coverUrl: COVER_URL,
+    },
+  });
+
+  const item = await screen.findByRole('button', {
+    name: /set as cover image/i,
+  });
+  await user.click(item);
+
+  return { user, dialog: await screen.findByRole('dialog') };
+}
+
+describe('SetCoverImageAction', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+
+    document.body.style.pointerEvents = '';
+  });
+
+  it('should preview the artwork before setting it as the cover', async () => {
+    const requests = trackCoverRequests();
+
+    const { dialog } = await openConfirmation();
+
+    await waitFor(() => {
+      expect(dialog.querySelector('img')).toHaveAttribute('src', COVER_URL);
+    });
+
+    expect(within(dialog).getByText('Heretic', { exact: false }))
+      .toBeInTheDocument();
+    expect(requests).to.deep.equal([]);
+  });
+
+  it('should set the cover image once the preview is confirmed', async () => {
+    const requests = trackCoverRequests();
+
+    const { user, dialog } = await openConfirmation();
+
+    await user.click(
+      within(dialog).getByRole('button', { name: /^yes$/i }),
+    );
+
+    await waitFor(() => {
+      expect(requests).to.deep.equal([
+        { cover_type: 'movie', cover_id: 1000 },
+      ]);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.svelte
@@ -13,6 +13,7 @@
     id: number;
     type: ExtendedMediaType;
     title: string;
+    coverUrl?: string | Nil;
     variant?: "primary" | "secondary";
   };
 
@@ -21,11 +22,12 @@
     id,
     type,
     title,
+    coverUrl,
     variant = "secondary",
   }: SetCoverImageActionProps = $props();
 
   const { isSettingCoverImage, setCoverImage } = $derived(
-    useCoverImage({ type, id }),
+    useCoverImage({ type, id, title, coverUrl }),
   );
   const { isCover } = $derived(useIsCover({ type, id }));
 

--- a/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.svelte
@@ -13,7 +13,7 @@
     id: number;
     type: ExtendedMediaType;
     title: string;
-    coverUrl?: string | Nil;
+    coverUrl?: HttpsUrl | Nil;
     variant?: "primary" | "secondary";
   };
 

--- a/projects/client/src/lib/sections/media-actions/cover-image/useCoverImage.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/useCoverImage.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { setCoverImageRequest } from '$lib/requests/queries/users/setCoverImageRequest.ts';
@@ -9,23 +11,33 @@ import { BehaviorSubject } from 'rxjs';
 type UseCoverImageProps = {
   type: ExtendedMediaType;
   id: number;
+  title: string;
+  coverUrl?: string | Nil;
 };
 
-export function useCoverImage({ type, id }: UseCoverImageProps) {
+export function useCoverImage(
+  { type, id, title, coverUrl }: UseCoverImageProps,
+) {
   const isSettingCoverImage = new BehaviorSubject(false);
 
   const { invalidate } = useInvalidator();
+  const { confirm } = useConfirm();
   const { track } = useTrack(AnalyticsEvent.CoverImage);
 
-  const setCoverImage = async () => {
-    isSettingCoverImage.next(true);
+  const setCoverImage = confirm({
+    type: ConfirmationType.SetCoverImage,
+    title,
+    previewUrl: coverUrl,
+    onConfirm: async () => {
+      isSettingCoverImage.next(true);
 
-    track({ type });
-    await setCoverImageRequest({ type, id });
-    await invalidate(InvalidateAction.User.CoverImage);
+      track({ type });
+      await setCoverImageRequest({ type, id });
+      await invalidate(InvalidateAction.User.CoverImage);
 
-    isSettingCoverImage.next(false);
-  };
+      isSettingCoverImage.next(false);
+    },
+  });
 
   return {
     setCoverImage,

--- a/projects/client/src/lib/sections/media-actions/cover-image/useCoverImage.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/useCoverImage.ts
@@ -12,7 +12,7 @@ type UseCoverImageProps = {
   type: ExtendedMediaType;
   id: number;
   title: string;
-  coverUrl?: string | Nil;
+  coverUrl?: HttpsUrl | Nil;
 };
 
 export function useCoverImage(

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
@@ -54,6 +54,7 @@
   style="dropdown-item"
   type="episode"
   id={episode.id}
+  coverUrl={episode.cover.url}
   {title}
   variant="primary"
 />

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -91,6 +91,7 @@
   style="dropdown-item"
   type={media.type}
   id={media.id}
+  coverUrl={media.cover.url.medium}
   variant="primary"
   {title}
 />


### PR DESCRIPTION
Closes #2954.
## Imagery
<img width="575" height="474" alt="Screenshot 2026-08-14 at 18 06 50" src="https://github.com/user-attachments/assets/065b2414-62e8-484a-9677-c57f46469319" />
<img width="555" height="479" alt="Screenshot 2026-08-14 at 18 17 14" src="https://github.com/user-attachments/assets/d0348ed2-233e-4b9e-b293-dbb1adcc9164" />


## What

Choosing **Set as cover image** on a movie, show or episode now opens a confirmation that shows the fanart it is about to use, so you decide against the picture instead of the title.

Before: the dropdown item fired the `PUT /users/set_cover` immediately, and the only way to see what you got was to go look at your profile.

## How

`ConfirmationDialog` learned one optional `previewUrl`, threaded through the confirmation layer (`mapToConfirmation` → `ConfirmationRequest` → provider → dialog) and rendered as a 16:9 plate between the message and the buttons, via `CrossOriginImage` so it fades in and keeps the environment-URI fallback. Any future confirmation that wants to show its subject can pass one; every existing dialog renders exactly as before.

`useCoverImage` now wraps the request in `useConfirm` — the same shape `useResetCoverImage` uses on the settings side.

The two call sites pass their own artwork: `media.cover.url.medium` for movies/shows, `episode.cover.url` for episodes. A media entry with no artwork still gets the confirmation, just text-only.

## Copy

`warning_prompt_set_cover_image` (\"Use \"{title}\" as your profile background image?\") already existed, was written for exactly this dialog, and was already translated into all 27 locales — it was simply never wired up. Only `confirmation_title_set_cover_image` is new, so this adds one string to translate.

## Verification

- \`deno fmt\` clean on touched paths, \`deno task check\` 0 errors / 0 warnings (7315 files), full \`vitest\` run 2804 passed.
- New \`SetCoverImageAction.spec.ts\`: opening the menu item shows the preview with the right \`src\` and fires no request; confirming sends \`{ cover_type: 'movie', cover_id: 1000 }\`.
- \`mapToConfirmation.spec.ts\`: affirmative operation, title interpolated, preview carried through, and the no-artwork case still confirms.
- Eyeballed in both themes.

## Notes

- **Stacked on \`feat/reset-cover-image\` (#3133)** — both PRs touch the same three confirmation files, so this sits on top rather than conflicting. Merge #3133 first and this retargets cleanly to \`main\`.
- Affirmative confirmations render their primary button in the same muted ghost treatment as the cancel button (pre-existing — \`RestoreShow\` and \`StartRewatching\` look the same). Left alone here since the button system is due its own pass, but it is the one thing I would change next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
