### PR TITLE
fix(drawer): drag down to close on mobile

### DIFF
--- a/projects/client/src/lib/components/drawer/_internal/handleDrag.spec.ts
+++ b/projects/client/src/lib/components/drawer/_internal/handleDrag.spec.ts
@@ -45,7 +45,7 @@ describe('handleDrag', () => {
       });
     });
 
-    it('should exit full screen when exceeding threshold', () => {
+    it('should close for downward drag exceeding threshold', () => {
       const state = createDragState({
         isFullScreen: true,
         threshold: 100,
@@ -59,8 +59,9 @@ describe('handleDrag', () => {
 
       expect(result).toEqual({
         ...state,
-        isFullScreen: false,
-        dragOffset: 0,
+        isFullScreen: true,
+        dragOffset: 150,
+        shouldClose: true,
       });
     });
 
@@ -181,6 +182,25 @@ describe('handleDrag', () => {
     });
   });
 
+  describe('when expanding then closing', () => {
+    it('should close without needing a collapse first', () => {
+      const expanded = handleDrag({
+        state: createDragState({ threshold: 100 }),
+        gesture: createGestureState({ movementY: -150, isStoppingDrag: true }),
+      });
+
+      expect(expanded.isFullScreen).toBe(true);
+      expect(expanded.shouldClose).toBe(false);
+
+      const closed = handleDrag({
+        state: expanded,
+        gesture: createGestureState({ movementY: 150, isStoppingDrag: true }),
+      });
+
+      expect(closed.shouldClose).toBe(true);
+    });
+  });
+
   describe('when a close has already been requested', () => {
     it('should not request a second close while dragging', () => {
       const state = createDragState({ shouldClose: true });
@@ -206,20 +226,21 @@ describe('handleDrag', () => {
       expect(result.shouldClose).toBe(false);
     });
 
-    it('should not request a close when settling out of full screen', () => {
+    it('should not request a close when settling back in full screen', () => {
       const state = createDragState({
         isFullScreen: true,
         shouldClose: true,
         threshold: 100,
       });
       const gesture = createGestureState({
-        movementY: 150,
+        movementY: 20,
         isStoppingDrag: true,
       });
 
       const result = handleDrag({ state, gesture });
 
       expect(result.shouldClose).toBe(false);
+      expect(result.isFullScreen).toBe(true);
     });
   });
 });

--- a/projects/client/src/lib/components/drawer/_internal/handleDrag.spec.ts
+++ b/projects/client/src/lib/components/drawer/_internal/handleDrag.spec.ts
@@ -135,7 +135,7 @@ describe('handleDrag', () => {
       expect(result).toEqual({
         ...state,
         isFullScreen: false,
-        dragOffset: 0,
+        dragOffset: 150,
         shouldClose: true,
       });
     });
@@ -178,6 +178,48 @@ describe('handleDrag', () => {
         dragOffset: 0,
         shouldClose: false,
       });
+    });
+  });
+
+  describe('when a close has already been requested', () => {
+    it('should not request a second close while dragging', () => {
+      const state = createDragState({ shouldClose: true });
+      const gesture = createGestureState({
+        movementY: 20,
+        isStoppingDrag: false,
+      });
+
+      const result = handleDrag({ state, gesture });
+
+      expect(result.shouldClose).toBe(false);
+    });
+
+    it('should not request a close when settling back below threshold', () => {
+      const state = createDragState({ shouldClose: true, threshold: 100 });
+      const gesture = createGestureState({
+        movementY: 20,
+        isStoppingDrag: true,
+      });
+
+      const result = handleDrag({ state, gesture });
+
+      expect(result.shouldClose).toBe(false);
+    });
+
+    it('should not request a close when settling out of full screen', () => {
+      const state = createDragState({
+        isFullScreen: true,
+        shouldClose: true,
+        threshold: 100,
+      });
+      const gesture = createGestureState({
+        movementY: 150,
+        isStoppingDrag: true,
+      });
+
+      const result = handleDrag({ state, gesture });
+
+      expect(result.shouldClose).toBe(false);
     });
   });
 });

--- a/projects/client/src/lib/components/drawer/_internal/handleDrag.ts
+++ b/projects/client/src/lib/components/drawer/_internal/handleDrag.ts
@@ -23,22 +23,12 @@ export function handleDrag({ state, gesture }: HandleDragProps): DragState {
   }
 
   const exceedsThreshold = Math.abs(movementY) > state.threshold;
-
-  if (state.isFullScreen) {
-    return {
-      ...state,
-      isFullScreen: !exceedsThreshold,
-      dragOffset: 0,
-      shouldClose: false,
-    };
-  }
-
   const shouldClose = !isUpwardDrag && exceedsThreshold;
 
   return {
     ...state,
     dragOffset: shouldClose ? movementY : 0,
-    isFullScreen: isUpwardDrag && exceedsThreshold,
+    isFullScreen: isUpwardDrag ? exceedsThreshold : state.isFullScreen,
     shouldClose,
   };
 }

--- a/projects/client/src/lib/components/drawer/_internal/handleDrag.ts
+++ b/projects/client/src/lib/components/drawer/_internal/handleDrag.ts
@@ -18,6 +18,7 @@ export function handleDrag({ state, gesture }: HandleDragProps): DragState {
     return {
       ...state,
       dragOffset: movementY,
+      shouldClose: false,
     };
   }
 
@@ -28,13 +29,16 @@ export function handleDrag({ state, gesture }: HandleDragProps): DragState {
       ...state,
       isFullScreen: !exceedsThreshold,
       dragOffset: 0,
+      shouldClose: false,
     };
   }
 
+  const shouldClose = !isUpwardDrag && exceedsThreshold;
+
   return {
     ...state,
-    dragOffset: 0,
+    dragOffset: shouldClose ? movementY : 0,
     isFullScreen: isUpwardDrag && exceedsThreshold,
-    shouldClose: !isUpwardDrag && exceedsThreshold,
+    shouldClose,
   };
 }

--- a/projects/client/src/lib/components/drawer/_internal/verticalDrag.ts
+++ b/projects/client/src/lib/components/drawer/_internal/verticalDrag.ts
@@ -24,11 +24,25 @@ export function verticalDrag(
     'Drag handle must have a parent element',
   );
 
+  const currentThreshold = () =>
+    globalThis.window.innerHeight * STATE_CHANGE_THRESHOLD;
+
   let dragState: DragState = {
     isFullScreen: false,
     dragOffset: 0,
-    threshold: globalThis.window.innerHeight * STATE_CHANGE_THRESHOLD,
+    threshold: currentThreshold(),
     shouldClose: false,
+  };
+
+  const startGesture = () => {
+    dragState = { ...dragState, threshold: currentThreshold() };
+    parent.style.setProperty(offsetVariable, '0px');
+
+    if (dragState.isFullScreen) {
+      return;
+    }
+
+    parent.style.setProperty('--initial-height', `${parent.clientHeight}px`);
   };
 
   const gesture = new DragGesture(
@@ -41,11 +55,8 @@ export function verticalDrag(
         movement: [_, movementY],
       } = state;
 
-      if (first && !dragState.isFullScreen) {
-        parent.style.setProperty(
-          '--initial-height',
-          `${parent.clientHeight}px`,
-        );
+      if (first) {
+        startGesture();
       }
 
       const gestureState: GestureState = { isStoppingDrag: last, movementY };
@@ -53,10 +64,12 @@ export function verticalDrag(
       dragState = handleDrag({ state: dragState, gesture: gestureState });
 
       parent.classList.toggle(fullscreenClass, dragState.isFullScreen);
-      parent.classList.toggle(dragClass, active);
+      parent.classList.toggle(dragClass, active || dragState.shouldClose);
       parent.style.setProperty(offsetVariable, `${dragState.dragOffset}px`);
 
-      dragState.shouldClose && onClose();
+      if (dragState.shouldClose) {
+        onClose();
+      }
     },
     {
       axis: 'y',


### PR DESCRIPTION
## 🎶 Notes 🎶

- Dragging a drawer down to close no longer snaps it back to full height before the slide out. It now keeps the dragged height through the outro.
- Dragging down now closes from any state.
  - `.is-fullscreen` and `[data-size="large"]` resolve to the same height, so expanding a large drawer changed nothing on screen but still flipped the flag. Dragging down then spent a gesture clearing it instead of closing, which read as the drag doing nothing. `size="auto"` hit the same once its content reached the cap.
  - Repro on `main`: open a large drawer on mobile, drag the handle up ~80px and release, then drag down. First drag down does nothing, second closes.
  - Trade-off: collapsing full screen back to base height is gone. Drag down always closes.
- Threshold is recomputed per gesture. `innerHeight` shifts when the Android URL bar collapses.
- Resets `shouldClose` in the non-closing branches, so drawers with an async `onClose` can't refire it on every move frame.
- ⚠️ The full screen fix is verified. The outro fix is reasoned from the code but not checked on a device yet.

## 👀 Example 👀
**Before**
Issue is most easily reproducible by dragging the drawer up a bit first. After that, the first time you try to drag it down to close it, it doesn't, and you'd have to drag it down again:

https://github.com/user-attachments/assets/b1a23185-48c2-4ef7-970e-5aab01a690af


**After**

https://github.com/user-attachments/assets/e6b9b5d2-1061-47c9-8efd-3ee520f623aa

