### PR TITLE
fix(share): restores posters on share cards

### DIFF
--- a/projects/client/deno.json
+++ b/projects/client/deno.json
@@ -8,6 +8,8 @@
     "$mocks/": "./src/mocks/",
     "$style": "./src/style",
     "$style/": "./src/style/",
+    "$static": "./static",
+    "$static/": "./static/",
     "$test": "./test",
     "$test/": "./test/",
     "$env/static/public": "./.svelte-kit/ambient.d.ts",

--- a/projects/client/src/lib/features/share/_internal/Poster.spec.ts
+++ b/projects/client/src/lib/features/share/_internal/Poster.spec.ts
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import type { ShareType } from '../models/ShareType.ts';
+import Poster from './Poster.svelte';
+
+const POSTER_URL = 'data:image/jpeg;base64,abc';
+const POSTER_ASPECT_RATIO = 232 / 350;
+
+const PX_VALUE = /^\d+(\.\d+)?px$/;
+
+function renderPoster(variant: ShareType) {
+  render(Poster, { props: { posterUrl: POSTER_URL, variant } });
+
+  return screen.getByAltText('poster');
+}
+
+describe('component: share Poster', () => {
+  const variants: ReadonlyArray<ShareType> = ['open-graph', 'feed', 'story'];
+
+  for (const variant of variants) {
+    describe(`variant: ${variant}`, () => {
+      it('should size the poster via CSS, which satori parses', () => {
+        const poster = renderPoster(variant);
+
+        expect(poster.style.width).toMatch(PX_VALUE);
+        expect(poster.style.height).toMatch(PX_VALUE);
+      });
+
+      it('should not size the poster via width/height attributes, which satori discards', () => {
+        const poster = renderPoster(variant);
+
+        expect(poster.getAttribute('width')).toBeNull();
+        expect(poster.getAttribute('height')).toBeNull();
+      });
+
+      it('should keep the poster aspect ratio', () => {
+        const poster = renderPoster(variant);
+
+        const width = Number.parseFloat(poster.style.width);
+        const height = Number.parseFloat(poster.style.height);
+
+        expect(width / height).toBeCloseTo(POSTER_ASPECT_RATIO);
+      });
+    });
+  }
+});

--- a/projects/client/src/lib/features/share/_internal/Poster.svelte
+++ b/projects/client/src/lib/features/share/_internal/Poster.svelte
@@ -32,8 +32,7 @@
     src={posterUrl}
     class="trakt-share-poster"
     alt="poster"
-    width={posterWidth}
-    height={posterHeight}
+    style="width: {posterWidth}px; height: {posterHeight}px;"
   />
 </div>
 

--- a/projects/client/src/routes/api/shareable-image/+server.ts
+++ b/projects/client/src/routes/api/shareable-image/+server.ts
@@ -7,6 +7,7 @@ import { error } from '$lib/utils/console/print.ts';
 import { IS_DEV } from '$lib/utils/env/index.ts';
 import { ImageResponse } from '@ethercorps/sveltekit-og';
 import type { RequestHandler } from '@sveltejs/kit';
+import { buildImageMetadata } from './_internal/buildImageMetadata.ts';
 import { buildImagePath } from './_internal/buildImagePath.ts';
 import { fetchMediaData } from './_internal/fetchMediaData.ts';
 import { fetchWithUserAgent } from './_internal/fetchWithUserAgent.ts';
@@ -102,7 +103,7 @@ export const GET: RequestHandler = async (
       try {
         await platform.env.R2_WALTER.put(imagePath, buffer, {
           httpMetadata: { contentType: 'image/png' },
-          customMetadata: { cachedAt: String(Date.now()) },
+          customMetadata: buildImageMetadata({ media, cachedAt: new Date() }),
         });
       } catch (e) {
         error('Failed to cache image in R2:', e);

--- a/projects/client/src/routes/api/shareable-image/+server.ts
+++ b/projects/client/src/routes/api/shareable-image/+server.ts
@@ -9,8 +9,8 @@ import { ImageResponse } from '@ethercorps/sveltekit-og';
 import type { RequestHandler } from '@sveltejs/kit';
 import { buildImagePath } from './_internal/buildImagePath.ts';
 import { fetchMediaData } from './_internal/fetchMediaData.ts';
-import { fetchPosterDataUri } from './_internal/fetchPosterDataUri.ts';
 import { fetchWithUserAgent } from './_internal/fetchWithUserAgent.ts';
+import { resolvePosterDataUri } from './_internal/resolvePosterDataUri.ts';
 
 const cacheControl = 'public, max-age=604800';
 
@@ -78,15 +78,10 @@ export const GET: RequestHandler = async (
 
   const { media, ratings, crew } = mediaData;
 
-  const posterUrl = media.poster.url.medium.replace(/\.webp$/i, '');
-
-  let posterDataUri: string;
-  try {
-    posterDataUri = await fetchPosterDataUri({ posterUrl, fetch: fetchFn });
-  } catch (e) {
-    error('Failed to fetch poster:', e);
-    return new Response('Failed to fetch poster', { status: 500 });
-  }
+  const posterDataUri = await resolvePosterDataUri({
+    posterUrl: media.poster.url.medium,
+    fetch: fetchFn,
+  });
 
   const { width, height } = SHARE_TYPE_DIMENSIONS[shareType];
 

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.spec.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.spec.ts
@@ -1,0 +1,27 @@
+import { MAX_DATE } from '$lib/utils/constants.ts';
+import { describe, expect, it } from 'vitest';
+import { buildImageMetadata } from './buildImageMetadata.ts';
+
+const CACHED_AT = new Date('2026-08-17T18:30:00.000Z');
+const RELEASED_AT = new Date('2022-02-04T00:00:00.000Z');
+
+function buildFor(effectiveReleaseDate: Date) {
+  return buildImageMetadata({
+    media: { effectiveReleaseDate },
+    cachedAt: CACHED_AT,
+  });
+}
+
+describe('util: buildImageMetadata', () => {
+  it('should record when the image was cached', () => {
+    expect(buildFor(RELEASED_AT).cachedAt).toBe('2026-08-17T18:30:00.000Z');
+  });
+
+  it('should record when the media was released', () => {
+    expect(buildFor(RELEASED_AT).releasedAt).toBe('2022-02-04T00:00:00.000Z');
+  });
+
+  it('should record the max date when the release date is unknown', () => {
+    expect(buildFor(MAX_DATE).releasedAt).toBe(MAX_DATE.toISOString());
+  });
+});

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.ts
@@ -1,0 +1,20 @@
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+
+type BuildImageMetadataProps = {
+  media: Pick<MediaEntry, 'effectiveReleaseDate'>;
+  cachedAt: Date;
+};
+
+type ImageMetadata = {
+  cachedAt: string;
+  releasedAt: string;
+};
+
+export function buildImageMetadata(
+  { media, cachedAt }: BuildImageMetadataProps,
+): ImageMetadata {
+  return {
+    cachedAt: cachedAt.toISOString(),
+    releasedAt: media.effectiveReleaseDate.toISOString(),
+  };
+}

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.spec.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.spec.ts
@@ -1,0 +1,43 @@
+import type { ShareType } from '$lib/features/share/models/ShareType.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { describe, expect, it } from 'vitest';
+import { buildImagePath } from './buildImagePath.ts';
+
+describe('util: buildImagePath', () => {
+  it('should namespace share images under their own root', () => {
+    const path = buildImagePath({
+      shareType: 'open-graph',
+      type: 'show',
+      slug: 'reacher',
+    });
+
+    expect(path).toBe('images/share/og/show/reacher/image.png');
+  });
+
+  describe('share types', () => {
+    it.each<[ShareType, string]>([
+      ['open-graph', 'og'],
+      ['feed', 'feed'],
+      ['story', 'story'],
+    ])('should store the %s variant under %s', (shareType, folder) => {
+      const path = buildImagePath({ shareType, type: 'show', slug: 'reacher' });
+
+      expect(path).toBe(`images/share/${folder}/show/reacher/image.png`);
+    });
+  });
+
+  describe('media types', () => {
+    it.each<MediaType>(['movie', 'show'])(
+      'should keep %s paths separate',
+      (type) => {
+        const path = buildImagePath({
+          shareType: 'feed',
+          type,
+          slug: 'reacher',
+        });
+
+        expect(path).toBe(`images/share/feed/${type}/reacher/image.png`);
+      },
+    );
+  });
+});

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.ts
@@ -1,7 +1,7 @@
 import type { ShareType } from '$lib/features/share/models/ShareType.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 
-const rootPath = 'images';
+const ROOT_PATH = 'images/share';
 
 type BuildImagePathProps = {
   shareType: ShareType;
@@ -33,5 +33,5 @@ export function buildImagePath({ shareType, slug, type }: BuildImagePathProps) {
   const shareTypePath = toShareTypePath(shareType);
   const mediaPath = toMediaPath(type, slug);
 
-  return `${rootPath}/${shareTypePath}/${mediaPath}/image.png`;
+  return `${ROOT_PATH}/${shareTypePath}/${mediaPath}/image.png`;
 }

--- a/projects/client/src/routes/api/shareable-image/_internal/resolvePosterDataUri.spec.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/resolvePosterDataUri.spec.ts
@@ -1,0 +1,93 @@
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/assets.ts';
+import { describe, expect, it, vi } from 'vitest';
+import { resolvePosterDataUri } from './resolvePosterDataUri.ts';
+
+type PosterFetch = Parameters<typeof resolvePosterDataUri>[0]['fetch'];
+
+const POSTER_URL =
+  'https://media.trakt.tv/images/shows/000/155/536/posters/medium/c15067608d.jpg.webp';
+
+const PLACEHOLDER_DATA_URI = /^data:image\/png;base64,/;
+
+const jpegResponse = () =>
+  new Response(new Uint8Array([255, 216, 255, 224]), {
+    headers: { 'content-type': 'image/jpeg' },
+  });
+
+describe('util: resolvePosterDataUri', () => {
+  describe('when the media has no poster', () => {
+    it('should inline the bundled placeholder', async () => {
+      const fetch = vi.fn<PosterFetch>();
+
+      const result = await resolvePosterDataUri({
+        posterUrl: MEDIA_POSTER_PLACEHOLDER,
+        fetch,
+      });
+
+      expect(result).toMatch(PLACEHOLDER_DATA_URI);
+    });
+
+    it('should not request the placeholder over the network', async () => {
+      const fetch = vi.fn<PosterFetch>();
+
+      await resolvePosterDataUri({
+        posterUrl: MEDIA_POSTER_PLACEHOLDER,
+        fetch,
+      });
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the media has a poster', () => {
+    it('should request the poster without the webp extension', async () => {
+      const fetch = vi.fn<PosterFetch>().mockResolvedValue(jpegResponse());
+
+      await resolvePosterDataUri({ posterUrl: POSTER_URL, fetch });
+
+      expect(fetch).toHaveBeenCalledWith(
+        POSTER_URL.replace('.webp', ''),
+        expect.anything(),
+      );
+    });
+
+    it('should return the poster as a data uri', async () => {
+      const fetch = vi.fn<PosterFetch>().mockResolvedValue(jpegResponse());
+
+      const result = await resolvePosterDataUri({
+        posterUrl: POSTER_URL,
+        fetch,
+      });
+
+      expect(result).toMatch(/^data:image\/jpeg;base64,/);
+    });
+  });
+
+  describe('when the poster request fails', () => {
+    it('should fall back to the placeholder on a failed response', async () => {
+      const fetch = vi.fn<PosterFetch>().mockResolvedValue(
+        new Response('connection timed out', { status: 522 }),
+      );
+
+      const result = await resolvePosterDataUri({
+        posterUrl: POSTER_URL,
+        fetch,
+      });
+
+      expect(result).toMatch(PLACEHOLDER_DATA_URI);
+    });
+
+    it('should fall back to the placeholder when the request throws', async () => {
+      const fetch = vi.fn<PosterFetch>().mockRejectedValue(
+        new Error('Network connection lost.'),
+      );
+
+      const result = await resolvePosterDataUri({
+        posterUrl: POSTER_URL,
+        fetch,
+      });
+
+      expect(result).toMatch(PLACEHOLDER_DATA_URI);
+    });
+  });
+});

--- a/projects/client/src/routes/api/shareable-image/_internal/resolvePosterDataUri.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/resolvePosterDataUri.ts
@@ -1,0 +1,27 @@
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/assets.ts';
+import { error } from '$lib/utils/console/print.ts';
+import placeholderPosterDataUri from '$static/placeholders/portrait_placeholder.png?inline';
+import { fetchPosterDataUri } from './fetchPosterDataUri.ts';
+
+type ResolvePosterDataUriProps = {
+  posterUrl: string;
+  fetch: typeof globalThis.fetch;
+};
+
+export async function resolvePosterDataUri(
+  { posterUrl, fetch }: ResolvePosterDataUriProps,
+): Promise<string> {
+  if (posterUrl === MEDIA_POSTER_PLACEHOLDER) {
+    return placeholderPosterDataUri;
+  }
+
+  try {
+    return await fetchPosterDataUri({
+      posterUrl: posterUrl.replace(/\.webp$/i, ''),
+      fetch,
+    });
+  } catch (e) {
+    error('Failed to fetch poster, falling back to the placeholder:', e);
+    return placeholderPosterDataUri;
+  }
+}

--- a/projects/client/svelte.config.js
+++ b/projects/client/svelte.config.js
@@ -46,6 +46,7 @@ const config = {
       '$worker': './src/worker',
       '$test': './test',
       '$style': 'src/style',
+      '$static': './static',
       '$e2e': './e2e',
       '$types': './.svelte-kit/types/src/routes',
     },


### PR DESCRIPTION
## 🎶 Notes 🎶

- Share cards have been generating without posters since 2026-07-12
  - `chore(deps): bump minor & patch versions` moved sveltekit-og to 4.3.0, which jumped satori from 0.10.14 to 0.25.0
  - satori 0.25 rejects string values for the img `width`/`height` props, and satori-html always hands attributes over as strings
  - poster ended up laid out at 0x0, so every variant rendered without artwork
  - open-graph looked fine for a while purely because most of those objects predate the bump
- Sizes the poster via inline CSS instead, which satori parses
- Titles with no poster no longer 500
  - the placeholder is a relative path, so fetching it server side resolved against our own zone and came back 522
  - 18 of these in Sentry, all on `GET /api/shareable-image`, going back as far as the window retains
  - it is now a build time data uri via `$static` + `?inline`, so there is no subrequest left to route
  - a poster that fails to fetch falls back to it rather than losing the whole card
- Moves share images to `images/share/*` in R2
  - orphans every posterless object, so `images/og`, `images/feed` and `images/story` can be dropped wholesale once this is out
  - no pruning by date needed
  - this was a planned change anyway to also add the `releasedAt` meta data (i.e. will get a follow-up to auto prune "new"-ish releases to keep posters and ratings up-to-date)
- Stores `releasedAt` next to `cachedAt`, so a future prune can target recent titles whose artwork landed after we cached them
  - both ISO now, matching the `uploadedAt` written by `sync-immutable-to-r2`
  - nothing reads either value yet
- Specs for the poster dimensions, the placeholder fallback and the R2 path

## 🚀 Deploying 🚀

- Needs a CF cache purge once this is out, prefix `app.trakt.tv/api/shareable-image`
  - the public URL is unchanged and still carries `max-age=604800`, so the edge keeps serving posterless images for up to 7 days otherwise
  - `feed` for a known title should go from ~121KB to ~800KB, that is the poster being there
- Already posted links refresh on each platform's own schedule, nothing we can do there

## 🤔 Not in this PR 🤔

- Fonts are fetched from `cdn-sveltekit-og.ethercorps.io` on every cache miss, ~2.7s on a cold generation, no fallback. Worth passing `fonts` explicitly at some point
- Tried a spec that runs the real satori pipeline, so a future bump can't break this silently again. It works, but it was slow enough to want its own command. Left out for now
