### PR TITLE
ci(share): prunes stale share images on a schedule

### DIFF
--- a/.github/workflows/prune_share_images.yml
+++ b/.github/workflows/prune_share_images.yml
@@ -1,0 +1,49 @@
+name: The Purge of Stale Visions aka Prune Share Images
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prune:
+    name: Expunging the Stale Relics
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Sealing the Outbound Gates aka Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            codeload.github.com:443
+            deno.com:443
+            dl.deno.land:443
+            github.com:443
+            jsr.io:443
+            npm.jsr.io:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            *.r2.cloudflarestorage.com:443
+
+      - name: Secure the Evidence aka Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Setup Deno Environment
+        uses: ./.github/actions/setup-deno
+
+      - name: Purge the Stale Visions aka Prune Share Images
+        working-directory: projects/client
+        run: 'deno task prune:share-images'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: walter

--- a/projects/client/.scripts/_internal/r2.ts
+++ b/projects/client/.scripts/_internal/r2.ts
@@ -21,6 +21,7 @@ const REGION = 'auto';
 const SERVICE = 's3';
 const EMPTY_BODY_SHA256 =
   'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+const META_HEADER_PREFIX = 'x-amz-meta-';
 
 function hex(buf: ArrayBuffer | Uint8Array): string {
   const view = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
@@ -148,6 +149,30 @@ export class R2Client {
     throw new Error(`HEAD ${key} → ${res.status} ${await res.text()}`);
   }
 
+  /** R2 lowercases the metadata names it stores. */
+  async headMetadata(key: string): Promise<Record<string, string> | undefined> {
+    const headers = await this.sign('HEAD', this.keyPath(key), '', null);
+    const res = await fetch(this.url(key), { method: 'HEAD', headers });
+    if (!res.ok) return undefined;
+
+    return Object.fromEntries(
+      [...res.headers.entries()]
+        .filter(([name]) => name.startsWith(META_HEADER_PREFIX))
+        .map(([name, value]) => [
+          name.slice(META_HEADER_PREFIX.length),
+          value,
+        ]),
+    );
+  }
+
+  async delete(key: string): Promise<void> {
+    const headers = await this.sign('DELETE', this.keyPath(key), '', null);
+    const res = await fetch(this.url(key), { method: 'DELETE', headers });
+    if (!res.ok && res.status !== 204) {
+      throw new Error(`DELETE ${key} → ${res.status} ${await res.text()}`);
+    }
+  }
+
   async put(
     key: string,
     body: Uint8Array<ArrayBuffer>,
@@ -171,43 +196,56 @@ export class R2Client {
     return res.text();
   }
 
+  async listPage(
+    { prefix, cursor }: { prefix?: string; cursor?: string },
+  ): Promise<{ keys: string[]; cursor?: string }> {
+    const params = new URLSearchParams({ 'list-type': '2' });
+    if (prefix) params.set('prefix', prefix);
+    if (cursor) params.set('continuation-token', cursor);
+
+    // SigV4 canonicalises the query sorted by name and %-encoded.
+    const query = [...params.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+
+    const pathSuffix = `/${this.config.bucket}`;
+    const headers = await this.sign('GET', pathSuffix, query, null);
+    const res = await fetch(
+      `${this.endpoint}${pathSuffix}?${query}`,
+      { method: 'GET', headers },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `LIST ${prefix ?? 'root'} → ${res.status} ${await res.text()}`,
+      );
+    }
+
+    const xml = await res.text();
+    const keys = [...xml.matchAll(/<Key>([^<]+)<\/Key>/g)].map((m) =>
+      xmlUnescape(m[1] ?? '')
+    );
+    const isTruncated = /<IsTruncated>true<\/IsTruncated>/.test(xml);
+    const token = xml.match(
+      /<NextContinuationToken>([^<]+)<\/NextContinuationToken>/,
+    )?.[1];
+
+    return {
+      keys,
+      cursor: isTruncated && token ? xmlUnescape(token) : undefined,
+    };
+  }
+
   /**
    * Iterates every key under a prefix (paginated by the S3 list API).
    */
   async *list(prefix: string): AsyncGenerator<string, void, unknown> {
-    let continuationToken: string | undefined;
+    let cursor: string | undefined;
     do {
-      const params = new URLSearchParams({
-        'list-type': '2',
-        prefix,
-      });
-      if (continuationToken) {
-        params.set('continuation-token', continuationToken);
-      }
-      const query = params.toString();
-      const pathSuffix = `/${this.config.bucket}`;
-      const headers = await this.sign('GET', pathSuffix, query, null);
-      const res = await fetch(
-        `${this.endpoint}${pathSuffix}?${query}`,
-        { method: 'GET', headers },
-      );
-      if (!res.ok) {
-        throw new Error(
-          `LIST ${prefix} → ${res.status} ${await res.text()}`,
-        );
-      }
-      const xml = await res.text();
-      const keys = [...xml.matchAll(/<Key>([^<]+)<\/Key>/g)].map((m) =>
-        xmlUnescape(m[1] ?? '')
-      );
-      for (const k of keys) yield k;
-
-      const isTruncated = /<IsTruncated>true<\/IsTruncated>/.test(xml);
-      const token = xml.match(
-        /<NextContinuationToken>([^<]+)<\/NextContinuationToken>/,
-      )?.[1];
-      continuationToken = isTruncated && token ? xmlUnescape(token) : undefined;
-    } while (continuationToken);
+      const page = await this.listPage({ prefix, cursor });
+      for (const key of page.keys) yield key;
+      cursor = page.cursor;
+    } while (cursor);
   }
 
   /**

--- a/projects/client/.scripts/pruneShareImages.run.ts
+++ b/projects/client/.scripts/pruneShareImages.run.ts
@@ -1,0 +1,67 @@
+import { buildTargetPrefixes } from '../src/routes/api/shareable-image/_internal/buildTargetPrefixes.ts';
+import { R2Client } from './_internal/r2.ts';
+import { pruneShareImages } from './pruneShareImages.ts';
+
+// A full 1000-key page of HEAD requests exhausts sockets and trips rate limits.
+const HEAD_CHUNK_SIZE = 50;
+
+function requireEnv(name: string): string {
+  const value = Deno.env.get(name);
+
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    Deno.exit(1);
+  }
+
+  return value;
+}
+
+const r2 = new R2Client({
+  accountId: requireEnv('CLOUDFLARE_ACCOUNT_ID'),
+  accessKey: requireEnv('R2_ACCESS_KEY_ID'),
+  secretKey: requireEnv('R2_SECRET_ACCESS_KEY'),
+  bucket: requireEnv('R2_BUCKET_NAME'),
+});
+
+// The S3 list API omits custom metadata, so every key needs its own HEAD.
+async function hydrateMetadata(keys: ReadonlyArray<string>) {
+  const objects = [];
+
+  for (let i = 0; i < keys.length; i += HEAD_CHUNK_SIZE) {
+    const hydrated = await Promise.all(
+      keys.slice(i, i + HEAD_CHUNK_SIZE).map(async (key) => ({
+        key,
+        customMetadata: await r2.headMetadata(key),
+      })),
+    );
+    objects.push(...hydrated);
+  }
+
+  return objects;
+}
+
+const bucket = {
+  list: async (opts?: { cursor?: string; prefix?: string }) => {
+    const page = await r2.listPage({
+      prefix: opts?.prefix,
+      cursor: opts?.cursor,
+    });
+
+    return {
+      objects: await hydrateMetadata(page.keys),
+      truncated: page.cursor !== undefined,
+      cursor: page.cursor,
+    };
+  },
+  delete: (key: string) => r2.delete(key),
+};
+
+const result = await pruneShareImages(bucket, buildTargetPrefixes());
+
+console.log(
+  `Prune complete. deleted: ${result.deleted}, skipped: ${result.skipped}, errors: ${result.errors}`,
+);
+
+if (result.errors > 0) {
+  Deno.exit(1);
+}

--- a/projects/client/.scripts/pruneShareImages.spec.ts
+++ b/projects/client/.scripts/pruneShareImages.spec.ts
@@ -1,0 +1,402 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pruneShareImages } from './pruneShareImages.ts';
+
+const NOW = new Date('2026-06-04T12:00:00Z').getTime();
+
+type BucketObject = {
+  key: string;
+  customMetadata?: Record<string, string>;
+};
+
+function makeBucket(objects: BucketObject[]) {
+  const deleted: string[] = [];
+
+  const bucket = {
+    list: vi.fn((opts?: { prefix?: string; cursor?: string }) => {
+      const prefix = opts?.prefix;
+      const filtered = prefix
+        ? objects.filter((o) => o.key.startsWith(prefix))
+        : objects;
+      return Promise.resolve({
+        objects: filtered,
+        truncated: false,
+        cursor: undefined,
+      });
+    }),
+    delete: vi.fn((key: string) => {
+      deleted.push(key);
+      return Promise.resolve();
+    }),
+    deleted,
+  };
+
+  return bucket;
+}
+
+function cachedAt(msBefore: number): string {
+  return new Date(NOW - msBefore).toISOString();
+}
+
+function releasedAt(daysAgo: number): string {
+  return new Date(NOW - daysAgo * time.days(1)).toISOString();
+}
+
+const prefixes = ['images/share/og/movie/', 'images/share/og/show/'];
+
+describe('pruneShareImages', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  describe('staleness tiers', () => {
+    it('prunes a fresh release cached over 12 hours ago (tier 1: ≤14 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/the-dark-knight/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.hours(13)),
+            releasedAt: releasedAt(7),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('skips a fresh release cached under 12 hours ago (tier 1: ≤14 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/the-dark-knight/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.hours(11)),
+            releasedAt: releasedAt(7),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('prunes a mid-age release cached over 3 days ago (tier 2: 15-40 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/oppenheimer/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(4)),
+            releasedAt: releasedAt(20),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+    });
+
+    it('skips a mid-age release cached under 3 days ago (tier 2: 15-40 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/oppenheimer/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(2)),
+            releasedAt: releasedAt(20),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.skipped).toBe(1);
+    });
+
+    it('prunes older release cached over 7 days ago (tier 3: 41-120 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/show/breaking-bad/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(8)),
+            releasedAt: releasedAt(60),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+    });
+
+    it('prunes catalog content cached over 30 days ago (fallback: >120 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/show/the-wire/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(31)),
+            releasedAt: releasedAt(365 * 10),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+    });
+
+    it('skips catalog content cached under 30 days ago (fallback: >120 days)', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/show/the-wire/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(20)),
+            releasedAt: releasedAt(365 * 10),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('threshold boundaries', () => {
+    it('prunes when the cached age exactly equals the recheck interval', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/the-dark-knight/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.hours(12)),
+            releasedAt: releasedAt(7),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('keeps a release aged exactly 14 days in tier 1', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/the-dark-knight/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.hours(13)),
+            releasedAt: releasedAt(14),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('moves a release aged just over 14 days into tier 2', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/the-dark-knight/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.hours(13)),
+            releasedAt: releasedAt(14 + 1 / 24),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('legacy entries (missing releasedAt)', () => {
+    it('always prunes entries missing releasedAt metadata', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/legacy-film/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.hours(1)),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(1);
+      expect(result.skipped).toBe(0);
+    });
+  });
+
+  describe('legacy epoch metadata', () => {
+    it('still reads objects written before the ISO switch', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/epoch-film/image.png',
+          customMetadata: {
+            cachedAt: String(NOW - time.hours(11)),
+            releasedAt: String(NOW - time.days(7)),
+          },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('missing cachedAt', () => {
+    it('skips entries with no cachedAt metadata', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'images/share/og/movie/unknown/image.png',
+          customMetadata: { releasedAt: releasedAt(10) },
+        },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('skips entries with no metadata at all', async () => {
+      const bucket = makeBucket([
+        { key: 'images/share/og/movie/no-meta/image.png' },
+      ]);
+
+      const result = await pruneShareImages(bucket, prefixes);
+
+      expect(result.deleted).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('prefix scoping', () => {
+    it('only lists objects under the given prefixes', async () => {
+      const bucket = makeBucket([]);
+
+      await pruneShareImages(bucket, [
+        'images/share/og/movie/',
+        'images/share/feed/show/',
+      ]);
+
+      expect(bucket.list).toHaveBeenCalledTimes(2);
+      expect(bucket.list).toHaveBeenCalledWith(
+        expect.objectContaining({ prefix: 'images/share/og/movie/' }),
+      );
+      expect(bucket.list).toHaveBeenCalledWith(
+        expect.objectContaining({ prefix: 'images/share/feed/show/' }),
+      );
+    });
+
+    it('does not delete objects outside the given prefixes', async () => {
+      const bucket = makeBucket([
+        {
+          key: 'immutable/some-asset.js',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(365)),
+            releasedAt: releasedAt(365),
+          },
+        },
+      ]);
+
+      await pruneShareImages(bucket, ['images/share/og/movie/']);
+
+      expect(bucket.deleted).toHaveLength(0);
+    });
+  });
+
+  describe('error handling', () => {
+    it('counts delete errors and continues processing remaining objects', async () => {
+      const objects: BucketObject[] = [
+        {
+          key: 'images/share/og/movie/film-a/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(31)),
+            releasedAt: releasedAt(200),
+          },
+        },
+        {
+          key: 'images/share/og/movie/film-b/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(31)),
+            releasedAt: releasedAt(200),
+          },
+        },
+      ];
+
+      const bucket = makeBucket(objects);
+      bucket.delete.mockRejectedValueOnce(new Error('R2 error'));
+
+      const result = await pruneShareImages(bucket, ['images/share/og/movie/']);
+
+      expect(result.errors).toBe(1);
+      expect(result.deleted).toBe(1);
+    });
+  });
+
+  describe('pagination', () => {
+    it('follows cursor until truncated is false', async () => {
+      const page1: BucketObject[] = [
+        {
+          key: 'images/share/og/movie/film-a/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(31)),
+            releasedAt: releasedAt(200),
+          },
+        },
+      ];
+      const page2: BucketObject[] = [
+        {
+          key: 'images/share/og/movie/film-b/image.png',
+          customMetadata: {
+            cachedAt: cachedAt(time.days(31)),
+            releasedAt: releasedAt(200),
+          },
+        },
+      ];
+
+      const listMock = vi.fn()
+        .mockResolvedValueOnce({
+          objects: page1,
+          truncated: true,
+          cursor: 'token-1',
+        })
+        .mockResolvedValueOnce({
+          objects: page2,
+          truncated: false,
+          cursor: undefined,
+        });
+
+      const bucket = {
+        list: listMock,
+        delete: vi.fn(async () => {}),
+        deleted: [] as string[],
+      };
+
+      const result = await pruneShareImages(bucket, ['images/share/og/movie/']);
+
+      expect(listMock).toHaveBeenCalledTimes(2);
+      expect(listMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ cursor: 'token-1' }),
+      );
+      expect(result.deleted).toBe(2);
+    });
+  });
+});

--- a/projects/client/.scripts/pruneShareImages.ts
+++ b/projects/client/.scripts/pruneShareImages.ts
@@ -1,0 +1,109 @@
+import { time } from '$lib/utils/timing/time.ts';
+
+type RecheckTier = {
+  maxDaysSinceRelease: number;
+  recheckIntervalMs: number;
+};
+
+const RECHECK_TIERS: ReadonlyArray<RecheckTier> = [
+  { maxDaysSinceRelease: 14, recheckIntervalMs: time.hours(12) },
+  { maxDaysSinceRelease: 40, recheckIntervalMs: time.days(3) },
+  { maxDaysSinceRelease: 120, recheckIntervalMs: time.days(7) },
+];
+const FALLBACK_RECHECK_INTERVAL_MS = time.days(30);
+
+function getRecheckIntervalMs(daysSinceRelease: number): number {
+  const tier = RECHECK_TIERS.find(
+    (t) => daysSinceRelease <= t.maxDaysSinceRelease,
+  );
+
+  return tier?.recheckIntervalMs ?? FALLBACK_RECHECK_INTERVAL_MS;
+}
+
+function toTimestamp(value: string | undefined): number {
+  if (!value) {
+    return Number.NaN;
+  }
+
+  const parsed = Date.parse(value);
+
+  return Number.isNaN(parsed) ? Number(value) : parsed;
+}
+
+type IsStaleProps = {
+  cachedAt: number;
+  releasedAt: number;
+  now: number;
+};
+
+function isStale({ cachedAt, releasedAt, now }: IsStaleProps): boolean {
+  const daysSinceRelease = (now - releasedAt) / time.days(1);
+
+  return now - cachedAt >= getRecheckIntervalMs(daysSinceRelease);
+}
+
+type R2Bucket = {
+  list: (
+    opts?: { cursor?: string; prefix?: string },
+  ) => Promise<{
+    objects: Array<{
+      key: string;
+      customMetadata?: Record<string, string>;
+    }>;
+    truncated: boolean;
+    cursor?: string;
+  }>;
+  delete: (key: string) => Promise<void>;
+};
+
+type PruneResult = {
+  deleted: number;
+  skipped: number;
+  errors: number;
+};
+
+export async function pruneShareImages(
+  bucket: R2Bucket,
+  prefixes: ReadonlyArray<string>,
+): Promise<PruneResult> {
+  const now = Date.now();
+  const result: PruneResult = { deleted: 0, skipped: 0, errors: 0 };
+
+  for (const prefix of prefixes) {
+    let cursor: string | undefined;
+
+    do {
+      const listed = await bucket.list({ cursor, prefix });
+
+      for (const object of listed.objects) {
+        const meta = object.customMetadata ?? {};
+        const cachedAt = toTimestamp(meta.cachedAt ?? meta.cachedat);
+        const releasedAt = toTimestamp(meta.releasedAt ?? meta.releasedat);
+
+        if (Number.isNaN(cachedAt)) {
+          result.skipped++;
+          continue;
+        }
+
+        // Entries predating `releasedAt` get rewritten with full metadata.
+        const shouldDelete = Number.isNaN(releasedAt) ||
+          isStale({ cachedAt, releasedAt, now });
+
+        if (!shouldDelete) {
+          result.skipped++;
+          continue;
+        }
+
+        try {
+          await bucket.delete(object.key);
+          result.deleted++;
+        } catch {
+          result.errors++;
+        }
+      }
+
+      cursor = listed.truncated ? listed.cursor : undefined;
+    } while (cursor);
+  }
+  return result;
+}

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -30,6 +30,7 @@
     "i18n:prepare": "deno task i18n:web && deno task i18n:compile",
     "sync:immutable": "deno run --allow-net --allow-read --allow-env .scripts/sync-immutable-to-r2.ts",
     "prune:immutable": "deno run --allow-net --allow-env .scripts/prune-immutable-r2.ts",
+    "prune:share-images": "deno run --allow-net --allow-env .scripts/pruneShareImages.run.ts",
     "i18n:resolve": "deno run --allow-read --allow-write .scripts/resolve-i18n.ts",
     "i18n:check": "deno run --allow-read .scripts/check-i18n-placeholders.ts",
     "i18n:generate": "deno run --allow-read --allow-write i18n/generator/cli.ts -i i18n/meta/ -o i18n/",

--- a/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
@@ -11,8 +11,12 @@ import { mapToSocialMedia } from './mapToSocialMedia.ts';
 import { mapToTrailerUrl } from './mapToTrailerUrl.ts';
 import { mapToTraktRating } from './mapToTraktRating.ts';
 
+type ShowResponseWithLastAired = ShowResponse & {
+  last_aired?: string | null;
+};
+
 export function mapToShowEntry(
-  show: ShowResponse,
+  show: ShowResponseWithLastAired,
 ): ShowEntry {
   const poster = mapToPoster(show.images);
   const cover = mapToCover(show.images);
@@ -63,6 +67,7 @@ export function mapToShowEntry(
     airDate: effectiveReleaseDate,
     releaseDate: effectiveReleaseDate,
     effectiveReleaseDate,
+    ...(show.last_aired ? { lastAired: new Date(show.last_aired) } : {}),
     certification: show.certification,
     votes: show.votes ?? 0,
     plexSlug: show.ids.plex?.slug,

--- a/projects/client/src/lib/requests/models/ShowEntry.ts
+++ b/projects/client/src/lib/requests/models/ShowEntry.ts
@@ -14,5 +14,6 @@ export const ShowEntrySchema = MediaEntrySchema.merge(EpisodeCountSchema)
     network: z.string().nullish(),
     totalRuntime: z.number(),
     airs: ShowAirsSchema.nullish(),
+    lastAired: z.date().nullish(),
   });
 export type ShowEntry = z.infer<typeof ShowEntrySchema>;

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.spec.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.spec.ts
@@ -4,24 +4,48 @@ import { buildImageMetadata } from './buildImageMetadata.ts';
 
 const CACHED_AT = new Date('2026-08-17T18:30:00.000Z');
 const RELEASED_AT = new Date('2022-02-04T00:00:00.000Z');
+const LAST_AIRED = new Date('2026-05-30T00:00:00.000Z');
 
-function buildFor(effectiveReleaseDate: Date) {
+type BuildForProps = {
+  effectiveReleaseDate?: Date;
+  lastAired?: Date | null;
+};
+
+function buildFor({ effectiveReleaseDate, lastAired }: BuildForProps = {}) {
   return buildImageMetadata({
-    media: { effectiveReleaseDate },
+    media: {
+      effectiveReleaseDate: effectiveReleaseDate ?? RELEASED_AT,
+      lastAired,
+    },
     cachedAt: CACHED_AT,
   });
 }
 
 describe('util: buildImageMetadata', () => {
   it('should record when the image was cached', () => {
-    expect(buildFor(RELEASED_AT).cachedAt).toBe('2026-08-17T18:30:00.000Z');
+    expect(buildFor().cachedAt).toBe('2026-08-17T18:30:00.000Z');
   });
 
-  it('should record when the media was released', () => {
-    expect(buildFor(RELEASED_AT).releasedAt).toBe('2022-02-04T00:00:00.000Z');
+  describe('for movies', () => {
+    it('should anchor on the release date', () => {
+      expect(buildFor().releasedAt).toBe('2022-02-04T00:00:00.000Z');
+    });
+
+    it('should anchor on the max date when the release date is unknown', () => {
+      expect(buildFor({ effectiveReleaseDate: MAX_DATE }).releasedAt)
+        .toBe(MAX_DATE.toISOString());
+    });
   });
 
-  it('should record the max date when the release date is unknown', () => {
-    expect(buildFor(MAX_DATE).releasedAt).toBe(MAX_DATE.toISOString());
+  describe('for shows', () => {
+    it('should anchor on the last aired episode', () => {
+      expect(buildFor({ lastAired: LAST_AIRED }).releasedAt)
+        .toBe('2026-05-30T00:00:00.000Z');
+    });
+
+    it('should anchor on the release date when nothing has aired yet', () => {
+      expect(buildFor({ lastAired: null }).releasedAt)
+        .toBe('2022-02-04T00:00:00.000Z');
+    });
   });
 });

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImageMetadata.ts
@@ -1,7 +1,10 @@
 import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 
 type BuildImageMetadataProps = {
-  media: Pick<MediaEntry, 'effectiveReleaseDate'>;
+  media:
+    & Pick<MediaEntry, 'effectiveReleaseDate'>
+    & Partial<Pick<ShowEntry, 'lastAired'>>;
   cachedAt: Date;
 };
 
@@ -15,6 +18,7 @@ export function buildImageMetadata(
 ): ImageMetadata {
   return {
     cachedAt: cachedAt.toISOString(),
-    releasedAt: media.effectiveReleaseDate.toISOString(),
+    releasedAt: (media.lastAired ?? media.effectiveReleaseDate)
+      .toISOString(),
   };
 }

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.ts
@@ -1,7 +1,6 @@
 import type { ShareType } from '$lib/features/share/models/ShareType.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-
-const ROOT_PATH = 'images/share';
+import { shareImagePrefix } from './shareImagePrefix.ts';
 
 type BuildImagePathProps = {
   shareType: ShareType;
@@ -9,29 +8,6 @@ type BuildImagePathProps = {
   type: MediaType;
 };
 
-function toShareTypePath(shareType: ShareType): string {
-  switch (shareType) {
-    case 'open-graph':
-      return 'og';
-    case 'feed':
-      return 'feed';
-    case 'story':
-      return 'story';
-  }
-}
-
-function toMediaPath(type: MediaType, slug: string): string {
-  switch (type) {
-    case 'movie':
-      return `movie/${slug}`;
-    case 'show':
-      return `show/${slug}`;
-  }
-}
-
 export function buildImagePath({ shareType, slug, type }: BuildImagePathProps) {
-  const shareTypePath = toShareTypePath(shareType);
-  const mediaPath = toMediaPath(type, slug);
-
-  return `${ROOT_PATH}/${shareTypePath}/${mediaPath}/image.png`;
+  return `${shareImagePrefix({ shareType, type })}${slug}/image.png`;
 }

--- a/projects/client/src/routes/api/shareable-image/_internal/buildTargetPrefixes.spec.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildTargetPrefixes.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildTargetPrefixes } from './buildTargetPrefixes.ts';
+
+describe('util: buildTargetPrefixes', () => {
+  it('should cover every share type and media type combination', () => {
+    expect(buildTargetPrefixes()).toEqual([
+      'images/share/og/movie/',
+      'images/share/og/show/',
+      'images/share/feed/movie/',
+      'images/share/feed/show/',
+      'images/share/story/movie/',
+      'images/share/story/show/',
+    ]);
+  });
+
+  it('should scope every prefix under the share root', () => {
+    const prefixes = buildTargetPrefixes();
+
+    expect(prefixes.every((prefix) => prefix.startsWith('images/share/')))
+      .toBe(true);
+  });
+
+  it('should end every prefix with a separator so it cannot match sibling keys', () => {
+    const prefixes = buildTargetPrefixes();
+
+    expect(prefixes.every((prefix) => prefix.endsWith('/'))).toBe(true);
+  });
+});

--- a/projects/client/src/routes/api/shareable-image/_internal/buildTargetPrefixes.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildTargetPrefixes.ts
@@ -1,0 +1,14 @@
+import {
+  SHARE_TYPE_DIMENSIONS,
+  type ShareType,
+} from '$lib/features/share/models/ShareType.ts';
+import { MediaTypeSchema } from '$lib/requests/models/MediaType.ts';
+import { shareImagePrefix } from './shareImagePrefix.ts';
+
+export function buildTargetPrefixes(): ReadonlyArray<string> {
+  const shareTypes = Object.keys(SHARE_TYPE_DIMENSIONS) as ShareType[];
+
+  return shareTypes.flatMap((shareType) =>
+    MediaTypeSchema.options.map((type) => shareImagePrefix({ shareType, type }))
+  );
+}

--- a/projects/client/src/routes/api/shareable-image/_internal/shareImagePrefix.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/shareImagePrefix.ts
@@ -1,0 +1,26 @@
+import type { ShareType } from '$lib/features/share/models/ShareType.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+
+const ROOT_PATH = 'images/share';
+
+type ShareImagePrefixProps = {
+  shareType: ShareType;
+  type: MediaType;
+};
+
+function toShareTypePath(shareType: ShareType): string {
+  switch (shareType) {
+    case 'open-graph':
+      return 'og';
+    case 'feed':
+      return 'feed';
+    case 'story':
+      return 'story';
+  }
+}
+
+export function shareImagePrefix(
+  { shareType, type }: ShareImagePrefixProps,
+): string {
+  return `${ROOT_PATH}/${toShareTypePath(shareType)}/${type}/`;
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a daily job that prunes stale share images so cards get regenerated as their media changes
- Tiers mirror `AGGRESSIVE_RECHECK_SCHEDULE` in trakt-workers, so the two stay in step:
  - first 14 days since the anchor: recheck every 12h
  - 15-40 days: 3d
  - 41-120 days: 7d
  - after that: 30d
- Scoped to `images/share/{og,feed,story}/{movie,show}/`, derived from the same helper the endpoint builds paths with, so the prefixes cannot drift from where images actually land
- Reads `cachedAt` and `releasedAt` from object metadata. An image goes when its `cachedAt` age passes the recheck interval for its `releasedAt` age
- `releasedAt` is now the last aired episode for shows, the release date for movies
  - `first_aired` was wrong here. A long running show that premiered years ago sat in the slowest tier while it was actively airing and churning weekly
  - `updated_at` was the other candidate, but it re-stamps on every metadata refresh, and it is frozen into R2 at generate time, so it would pin anything the refresh pipeline touches to the 12h tier forever
  - needs `last_aired` on the show payload, added in https://github.com/trakt/trakt-workers/pull/1476 (merged and deployed)
- `last_aired` is not on `ShowResponse` in @trakt/api yet, so `mapToShowEntry` reads it through a module-private type extension for now. Drops out when the SDK catches up

## 🧪 Dry run 🧪

Ran it on CI against walter with the delete path stubbed out: https://github.com/trakt/trakt-web/actions/runs/32983215775

- All 6 prefixes resolved
- Would delete 389 of 5239 objects. 196 in the 12h tier, 88 in the 3d, 105 in the 7d
- Zero legacy entries, so nothing needed a one time reset
- Deleted exactly one candidate for real (`images/share/og/show/lanterns/image.png`, the oldest `cachedAt`) and HEADed it after to confirm it was gone, so the signed DELETE is proven too
- ⚠️ Those 389 were judged on the old `first_aired` anchors, since walter only gets `lastAired` based ones once this deploys. The temp commit that did all this has been reverted

## 🛠 Fixed along the way 🛠

- The egress allowlist would have failed on the first run. It only permitted `api.cloudflare.com`, but the script talks to `<account>.r2.cloudflarestorage.com` and `setup-deno` needs jsr and npm. Copied the proven set from `supply_chain.yml` and added the R2 host
- Kept the checkout before `setup-deno`. Dropped it at first thinking the composite action's own checkout covered it, but a local action cannot resolve without the repo on disk first, so CI died on `Can't find 'action.yml'` 😅
- Split `buildTargetPrefixes` and `shareImagePrefix` out of `buildImagePath` so each file keeps one export
- Spec fixtures were still on the pre move `images/og/...` prefixes
- Folded the run script onto `R2Client` in `.scripts/_internal/r2.ts` rather than keeping its own SigV4 signer, list and delete. Added `listPage`, `headMetadata` and a single key `delete` to the client, and put the existing `list()` generator on top of `listPage`. The run script drops from 266 lines to 68
  - kept a single key `DELETE` instead of reusing `deleteMany`, since the batch API answers 200 with per key errors in the body and would have inflated the deleted count and hidden failures from the exit code
  - `R2Client.list()` now builds its query sorted by name and %-encoded, which is what SigV4 specifies. Signing and the request use the same string either way, so signatures stay valid, but the immutable sync and prune scripts share that path 👀
- Runs as `deno task prune:share-images` from `projects/client`, matching how `ci_cd.yml` invokes the other two R2 scripts
- Spec durations go through `time.hours/days` instead of raw millisecond arithmetic

## 🤔 Worth knowing 🤔

- One HEAD request per object per run, since the S3 list API does not return custom metadata. Chunked 50 at a time
- Real media images in walter carry no `cachedAt`, so they are skipped even if a prefix were ever wrong. That is the safety net, not the plan
- The anchor migrates gradually. A stored `releasedAt` only becomes `lastAired` based when that image is regenerated, and this job is what triggers the regeneration, so the two phase in together
- The cron arms at merge, not at deploy. GitHub only runs `schedule` from the default branch, and the job talks to R2 directly rather than through the worker

