### PR TITLE
test(share): guards share card rendering against package bumps

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -126,6 +126,19 @@ jobs:
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
 
+      - name: Summon a Typeface aka Ensure Fontconfig
+        timeout-minutes: 3
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          if fc-match sans-serif --format='%{file}' 2>/dev/null | grep -qiE '\.(ttf|otf)$'; then
+            echo "fontconfig already provides $(fc-match sans-serif --format='%{file}')"
+            exit 0
+          fi
+          sudo apt-get update -qq -o DPkg::Lock::Timeout=120
+          sudo apt-get install -y --no-install-recommends \
+            -o DPkg::Lock::Timeout=120 fontconfig fonts-dejavu-core
+
       - name: Forging the Artifacts aka Prebuild
         working-directory: projects/client
         run: 'deno task prebuild'

--- a/projects/client/src/lib/features/share/ShareCard.satori.spec.ts
+++ b/projects/client/src/lib/features/share/ShareCard.satori.spec.ts
@@ -1,0 +1,106 @@
+import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
+import { ShowSiloPeopleMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts';
+import { ShowSiloRatingsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts';
+import { loadSystemFont } from '$test/beds/font/loadSystemFont.ts';
+import { ImageResponse } from '@ethercorps/sveltekit-og';
+import { render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SHARE_TYPE_DIMENSIONS, type ShareType } from './models/ShareType.ts';
+import ShareCard from './ShareCard.svelte';
+
+vi.mock('$lib/features/share/models/ShareType.ts', () => ({
+  SHARE_TYPE_DIMENSIONS: {
+    'open-graph': { width: 600, height: 315, padding: 25 },
+    'feed': { width: 540, height: 540, padding: 20 },
+    'story': { width: 540, height: 960, padding: 30 },
+  },
+}));
+
+const pixelPng =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==';
+
+const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
+
+const show = {
+  media: ShowSiloMappedMock,
+  crew: ShowSiloPeopleMappedMock,
+  ratings: ShowSiloRatingsMappedMock,
+};
+
+function toRootMessage(error: unknown): string {
+  type Wrapped = Error & { originalError?: Wrapped };
+
+  let current = error as Wrapped;
+  while (current?.originalError) {
+    current = current.originalError;
+  }
+
+  return current?.message ?? String(error);
+}
+
+function complaints(
+  calls: ReadonlyArray<ReadonlyArray<unknown>>,
+): ReadonlyArray<string> {
+  return calls
+    .map((args) => args.map(String).join(' '))
+    .filter((message) => !message.startsWith('[MSW]'));
+}
+
+function toImageResponse(variant: ShareType) {
+  const { container } = render(ShareCard, {
+    props: { ...show, posterUrl: pixelPng, variant },
+  });
+
+  const styles = Array.from(document.head.querySelectorAll('style'))
+    .map((style) => style.textContent)
+    .join('');
+
+  const { width, height } = SHARE_TYPE_DIMENSIONS[variant];
+
+  return new ImageResponse(
+    `${container.innerHTML}<style>${styles}</style>`,
+    {
+      width,
+      height,
+      fonts: [{
+        name: 'Inter',
+        data: loadSystemFont(),
+        weight: 400,
+        style: 'normal',
+      }],
+    },
+  );
+}
+
+function renderPng(variant: ShareType): Promise<ArrayBuffer> {
+  return toImageResponse(variant).arrayBuffer().catch((e: unknown) => {
+    throw new Error(toRootMessage(e));
+  });
+}
+
+function isPng(buffer: ArrayBuffer): boolean {
+  const signature = new Uint8Array(buffer.slice(0, pngSignature.length));
+
+  return pngSignature.every((byte, index) => signature[index] === byte);
+}
+
+describe.skipIf(!process.env.CI)('component: ShareCard through satori', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const variants: ReadonlyArray<ShareType> = ['open-graph', 'feed', 'story'];
+
+  for (const variant of variants) {
+    it(`should render ${variant} without complaints`, async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const png = await renderPng(variant);
+
+      expect(isPng(png)).toBe(true);
+      expect(complaints(warn.mock.calls)).toEqual([]);
+      expect(complaints(error.mock.calls)).toEqual([]);
+    });
+  }
+});

--- a/projects/client/test/beds/font/loadSystemFont.ts
+++ b/projects/client/test/beds/font/loadSystemFont.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const supportedFormat = /\.(ttf|otf)$/i;
+
+let cached: Buffer | undefined;
+
+function queryFontconfig(): string {
+  try {
+    return execFileSync(
+      'fc-match',
+      ['sans-serif', '--format=%{file}'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+  } catch {
+    throw new Error('fc-match not found. Install fontconfig.');
+  }
+}
+
+export function loadSystemFont(): Buffer {
+  if (cached) {
+    return cached;
+  }
+
+  const path = queryFontconfig();
+
+  if (!supportedFormat.test(path) || !existsSync(path)) {
+    throw new Error(`fc-match returned an unusable font: ${path}`);
+  }
+
+  cached = readFileSync(path);
+
+  return cached;
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Renders the real ShareCard through satori, so a package bump cannot silently break share images again
  - the satori 0.10 to 0.25 jump dropped every poster for six weeks and nothing caught it
  - drives the actual card through the same ImageResponse the endpoint uses, once per variant, with the existing Silo mapped mocks
  - renders to png rather than svg so resvg runs too, matching what the endpoint produces
- Changing the card does not mean updating the test
  - that was the flaw in asserting on markup shape: it only encodes what we know satori accepts today
- The assertion is that satori has nothing to complain about
  - satori reports rejected values on `console.warn` rather than throwing, so the spies require silence
  - failures are unwrapped to satori's own message, otherwise `ImageResponse` reports an unhelpful "Failed to generate SVG"
  - verified by reverting the poster size fix: it fails with `Invalid value "265" for "height"`
- Runs on CI only, and the test job installs fontconfig
  - satori has no default font and refuses to lay out text without one, even with every string blanked
  - the alternatives were vendoring a font, maintaining a list of font paths, or making everyone install fontconfig locally
  - ⚠️ the gate is `process.env.CI`, not font availability, so a runner without fontconfig fails loudly instead of quietly skipping the one test meant to catch this
- Dimensions are mocked at half scale, which takes rasterisation from 6.6s to 2.6s
  - shrinking only the canvas does not work, the card derives its own boxes from `SHARE_TYPE_DIMENSIONS` so the content overflows and resvg dies
  - a third scale only saves another 0.6s, fixed overhead dominates below half

## 🤔 Worth knowing 🤔

- The test does not run locally, so a break shows up on push rather than before it
- Renders client side and reassembles markup plus head styles, because `resolve.conditions: ['browser']` stops `ImageResponse` taking the component directly. Closing that gap needs a separate vitest project with node conditions

