### PR TITLE
fix(settings): keep paginating while full pages keep arriving

### DIFF
--- a/projects/client/src/lib/sections/settings/export/constants.ts
+++ b/projects/client/src/lib/sections/settings/export/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_LIMIT = 250;

--- a/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
+++ b/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
@@ -2,6 +2,7 @@ import { rawApiFetch } from '$lib/requests/api.ts';
 import { error } from '$lib/utils/console/print.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { isAbortError, retryAsync } from 'ts-retry';
+import { PAGE_LIMIT } from './constants.ts';
 
 type FetchWithRetryParams = {
   url: string;
@@ -41,8 +42,8 @@ export function fetchWithRetry({
   return retryAsync(
     async () => {
       const pageUrl = url.includes('?')
-        ? `${url}&page=${page}&limit=250`
-        : `${url}?page=${page}&limit=250`;
+        ? `${url}&page=${page}&limit=${PAGE_LIMIT}`
+        : `${url}?page=${page}&limit=${PAGE_LIMIT}`;
 
       const response = await rawApiFetch({
         path: `/${pageUrl}`,

--- a/projects/client/src/lib/sections/settings/export/processEndpoint.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/processEndpoint.spec.ts
@@ -1,10 +1,14 @@
 import { server } from '$mocks/server.ts';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
+import { PAGE_LIMIT } from './constants.ts';
 import { processEndpoint } from './processEndpoint.ts';
 
 const PATH = 'users/mega-collector/collection/movies';
 const ENDPOINT = `http://localhost/${PATH}`;
+
+const pageOf = (size: number) =>
+  Array.from({ length: size }, (_, index) => ({ index }));
 
 describe('processEndpoint', () => {
   it('should walk every page and report the requested page', async () => {
@@ -61,6 +65,63 @@ describe('processEndpoint', () => {
     });
 
     expect(pages).to.deep.equal([1]);
+  });
+
+  it('should keep walking while full pages arrive past the reported count', async () => {
+    const sizes: Record<string, number> = {
+      '1': PAGE_LIMIT,
+      '2': PAGE_LIMIT,
+      '3': 10,
+    };
+
+    server.use(
+      http.get(ENDPOINT, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page') ?? '1';
+        return HttpResponse.json(
+          pageOf(sizes[page] ?? 0),
+          { headers: { 'X-Pagination-Page-Count': '1' } },
+        );
+      }),
+    );
+
+    const pages: Array<number> = [];
+    await processEndpoint(PATH, (_, { page }) => {
+      pages.push(page);
+    });
+
+    expect(pages).to.deep.equal([1, 2, 3]);
+  });
+
+  it('should not report a probed page that comes back empty', async () => {
+    server.use(
+      http.get(ENDPOINT, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page') ?? '1';
+        return HttpResponse.json(
+          page === '1' ? pageOf(PAGE_LIMIT) : [],
+          { headers: { 'X-Pagination-Page-Count': '1' } },
+        );
+      }),
+    );
+
+    const pages: Array<number> = [];
+    await processEndpoint(PATH, (_, { page }) => {
+      pages.push(page);
+    });
+
+    expect(pages).to.deep.equal([1]);
+  });
+
+  it('should give up once it runs far past the reported page count', async () => {
+    server.use(
+      http.get(ENDPOINT, () =>
+        HttpResponse.json(pageOf(PAGE_LIMIT), {
+          headers: { 'X-Pagination-Page-Count': '1' },
+        })),
+    );
+
+    await expect(processEndpoint(PATH, () => {})).rejects.toThrow(
+      /past its reported page count/,
+    );
   });
 
   it('should stop after a single page when there is nothing to paginate', async () => {

--- a/projects/client/src/lib/sections/settings/export/processEndpoint.ts
+++ b/projects/client/src/lib/sections/settings/export/processEndpoint.ts
@@ -1,10 +1,13 @@
 import { fetchWithRetry } from './fetchWithRetry.ts';
+import { PAGE_LIMIT } from './constants.ts';
 
 const MAX_PAGES = 10_000;
+const MAX_UNREPORTED_PAGES = 100;
 
 export type Pagination = {
   page: number;
   pageCount: number;
+  hasMore: boolean;
 };
 
 export async function processEndpoint(
@@ -14,12 +17,30 @@ export async function processEndpoint(
   for (let page = 1; page <= MAX_PAGES; page++) {
     const result = await fetchWithRetry({ url: path, page });
 
+    const entries = Array.isArray(result.json) ? result.json : null;
+    const hasMorePages = page < result.paginationPageCount;
+    const isPageFull = entries?.length === PAGE_LIMIT;
+    const unreportedPages = Math.max(0, page - result.paginationPageCount);
+
+    if (unreportedPages > 0 && entries?.length === 0) {
+      return;
+    }
+
+    if (unreportedPages >= MAX_UNREPORTED_PAGES) {
+      throw new Error(
+        `Pagination for ${path} ran ${MAX_UNREPORTED_PAGES} pages past its reported page count`,
+      );
+    }
+
+    const hasMore = hasMorePages || isPageFull;
+
     await onPage(result.json, {
       page,
-      pageCount: result.paginationPageCount,
+      pageCount: Math.max(page, result.paginationPageCount),
+      hasMore,
     });
 
-    if (page >= result.paginationPageCount) {
+    if (!hasMore) {
       return;
     }
   }

--- a/projects/client/src/lib/sections/settings/export/runRawExport.ts
+++ b/projects/client/src/lib/sections/settings/export/runRawExport.ts
@@ -207,7 +207,7 @@ export async function runRawExport({
         progress.totalPages = pagination.pageCount;
         onPage(data, pagination);
 
-        if (pagination.page < pagination.pageCount) {
+        if (pagination.hasMore) {
           assertWithinBudget();
         }
       });


### PR DESCRIPTION
## 🎶 Notes 🎶

- Raw exports were silently truncating. One account only ever got its newest 21,000 plays back, so everything older than 2018-07-22 was missing from the zip, with nothing in the console or on the page to show for it.
- Cause is API side: `X-Pagination-Page-Count` comes from a cached item count that can lag behind the rows, so it advertised 84 pages for an account that had 88. `processEndpoint` took the header at its word and stopped there.
- Root fix is https://github.com/trakt/trakt-rails/pull/2410. This is the client side guard so a bad page count can't quietly cut an export short again.
- The reported page count is now a floor rather than the last word. A page that comes back with a full `limit` of entries means there is more to fetch whatever the header claims, and stopping needs both signals to agree.
  - Can't just ignore the header and stop on the first short page instead. The API drops rows it fails to resolve, so pages come back short mid-scan. That same account had a page with 107 of 250 on it, 30 pages before the end.
  - Non-array payloads (`users/settings`, `stats`, `profile`) can never be full, so single object endpoints still stop at the reported count.
- Probe pages past the reported count that come back empty aren't handed to `onPage`, so no stray empty file lands in the zip.
- Bails after 100 pages past the reported count. An endpoint that ignored pagination entirely would otherwise loop and fill memory with duplicate pages, so it fails into `_errors.json` instead.
- `processEndpoint` now passes `hasMore` to `onPage`, since it's the only thing that knows whether another page is coming. The fetch budget guard in `runRawExport` was inferring it from `page < pageCount` and would have gone quiet for the rest of an endpoint once we ran past the header.
