### PR TITLE
fix: keys each blocks by stable identifiers

### DIFF
--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -156,6 +156,48 @@ Use `{#snippet}` and `Snippet` type for flexible content injection.
 
 ---
 
+## Keying `{#each}` Blocks
+
+Key on identity the data owns, never on what the row renders.
+
+Display text is not an identifier. Translated strings collide per locale,
+formatted values collide after rounding, and titles collide by coincidence.
+Svelte throws `each_key_duplicate` and blanks the entire page, so the crash only
+reproduces in the locale or dataset where the collision happens - it will pass
+review and pass in English.
+
+```svelte
+<!-- Bad - i18n output, collides in some locales -->
+{#each rows as row (row.title)}
+
+<!-- Bad - formatted value, collides after rounding -->
+{#each buckets as bucket (bucket.formattedTotal)}
+
+<!-- Good - identity the row owns -->
+{#each rows as row (row.mediaKind)}
+{#each entries as entry (entry.id)}
+```
+
+When the data has no natural identifier, give it one at the source rather than
+reaching for the nearest string. A `key` field on the mapper output is cheaper
+than a production crash.
+
+Positional keys (`(index)`) are correct when the rendered array carries no
+identity of its own: skeleton placeholders, fixed-length layouts. Reach for
+them only when there is genuinely nothing to identify a row by. Where a row
+does map to a real datum, key on that datum even if it is positionally
+derived, so Svelte replaces the node instead of morphing one datum into
+another.
+
+Backend ids are only as unique as the endpoint guarantees. When an upstream list
+can repeat an id, dedupe in the mapper; do not key on something else to work
+around it.
+
+ESLint's `svelte/require-each-key` catches a missing key. Nothing catches an
+unstable one, so this is on the author.
+
+---
+
 ## Extending a Primitive: Slots, Not Domain Props
 
 `lib/components` primitives stay domain free when **modified**, not just when
@@ -809,6 +851,8 @@ property (`inset-inline-start`, not `left`), or the animation silently dies.
 - [ ] Using Svelte 5 runes (`$props`, `$derived`, `$effect`) - no `export let`
       or `$:`
 - [ ] Snippets used for slot-like composition, not legacy `<slot>`
+- [ ] `{#each}` keys are stable identifiers - never translated text, formatted
+      values, or any other rendered string
 - [ ] Primitives extended with a `Snippet` slot, not a domain-shaped prop
 - [ ] Shared components styled via their props / CSS variable hooks, not
       `:global()` overrides from the consumer

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -253,6 +253,28 @@ const { isCollapsed, toggle } = $derived(useCollapsedList(id));
 {@render navbarState(true)}
 ```
 
+### Keying Each Blocks
+
+Key `{#each}` blocks on identity the data owns, never on what the row renders.
+Translated strings collide per locale, formatted values collide after rounding,
+and Svelte throws `each_key_duplicate` and blanks the page when they do.
+
+**Bad:**
+
+```svelte
+{#each rows as row (row.title)}
+{#each ticks as tick (tick.text)}
+```
+
+**Good:**
+
+```svelte
+{#each rows as row (row.mediaKind)}
+{#each entries as entry (entry.id)}
+```
+
+Positional keys (`(index)`) are correct only when the row carries no identity of its own, such as skeleton placeholders or fixed-length layouts. Where a row maps to a real datum, key on that datum. When the data has no natural identifier, add a `key` field at the mapper rather than keying on the nearest string.
+
 ### Custom Hooks Pattern
 
 ```typescript

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexMediaKind.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexMediaKind.ts
@@ -1,0 +1,1 @@
+export type PlexMediaKind = 'movie' | 'show' | 'season' | 'episode';

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexScrobblerSettings.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexScrobblerSettings.svelte
@@ -3,33 +3,16 @@
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useQuery } from "$lib/features/query/useQuery.ts";
-  import { InvalidateAction } from "$lib/requests/models/InvalidateAction.ts";
   import { plexSettingsQuery } from "$lib/requests/plex/plexSettingsQuery.ts";
-  import { plexUpdateSettingsRequest } from "$lib/requests/plex/plexUpdateSettingsRequest.ts";
-  import { useInvalidator } from "$lib/stores/useInvalidator.ts";
   import { map } from "rxjs";
   import PlexToggleSettings from "./PlexToggleSettings.svelte";
+  import { usePlexSettingsToggle } from "./usePlexSettingsToggle.ts";
 
-  const { invalidate } = useInvalidator();
+  const toggle = usePlexSettingsToggle("scrobbler");
 
   const settingsQuery = useQuery(plexSettingsQuery());
   const settings = settingsQuery.pipe(map((q) => q.data?.scrobbler.toggles));
   const isLoading = settingsQuery.pipe(map((q) => q.isLoading));
-
-  type MediaKind = "movie" | "show" | "season" | "episode";
-
-  async function toggle(
-    { mediaKind, key, current }: {
-      mediaKind: MediaKind;
-      key: string;
-      current: boolean;
-    },
-  ) {
-    await plexUpdateSettingsRequest({
-      settings: { scrobbler: { toggles: { [mediaKind]: { [key]: !current } } } },
-    });
-    await invalidate(InvalidateAction.Plex.Settings);
-  }
 </script>
 
 {#snippet movieIcon()}<MovieIcon />{/snippet}
@@ -41,6 +24,7 @@
     description={m.description_plex_scrobbler_settings()}
     isLoading={true}
     rows={[]}
+    onToggle={toggle}
   />
 {:else}
   {@const t = $settings}
@@ -48,88 +32,93 @@
     title={m.header_plex_scrobbler_settings()}
     description={m.description_plex_scrobbler_settings()}
     isLoading={false}
+    onToggle={toggle}
     rows={[
       {
+        mediaKind: "movie",
         icon: movieIcon,
         title: m.button_text_browse_movies(),
         chips: [
           {
+            settingKey: "watching",
             label: m.button_plex_toggle_scrobble(),
             ariaLabel: m.button_label_plex_scrobble_movie_watching(),
             isActive: t.movie.watching,
-            onToggle: () => toggle({ mediaKind: "movie", key: "watching", current: t.movie.watching }),
           },
           {
+            settingKey: "watched",
             label: m.button_plex_toggle_watched(),
             ariaLabel: m.button_label_plex_scrobble_movie_watched(),
             isActive: t.movie.watched,
-            onToggle: () => toggle({ mediaKind: "movie", key: "watched", current: t.movie.watched }),
           },
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_scrobble_movie_rated(),
             isActive: t.movie.rated,
-            onToggle: () => toggle({ mediaKind: "movie", key: "rated", current: t.movie.rated }),
           },
           {
+            settingKey: "collected",
             label: m.text_library(),
             ariaLabel: m.button_label_plex_scrobble_movie_library(),
             isActive: t.movie.collected,
-            onToggle: () => toggle({ mediaKind: "movie", key: "collected", current: t.movie.collected }),
           },
         ],
       },
       {
+        mediaKind: "show",
         icon: showIcon,
         title: m.button_text_browse_shows(),
         chips: [
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_scrobble_show_rated(),
             isActive: t.show.rated,
-            onToggle: () => toggle({ mediaKind: "show", key: "rated", current: t.show.rated }),
           },
         ],
       },
       {
+        mediaKind: "season",
         icon: showIcon,
         title: m.list_title_seasons(),
         chips: [
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_scrobble_season_rated(),
             isActive: t.season.rated,
-            onToggle: () => toggle({ mediaKind: "season", key: "rated", current: t.season.rated }),
           },
         ],
       },
       {
+        mediaKind: "episode",
         icon: showIcon,
         title: m.list_title_episodes(),
         chips: [
           {
+            settingKey: "watching",
             label: m.button_plex_toggle_scrobble(),
             ariaLabel: m.button_label_plex_scrobble_episode_watching(),
             isActive: t.episode.watching,
-            onToggle: () => toggle({ mediaKind: "episode", key: "watching", current: t.episode.watching }),
           },
           {
+            settingKey: "watched",
             label: m.button_plex_toggle_watched(),
             ariaLabel: m.button_label_plex_scrobble_episode_watched(),
             isActive: t.episode.watched,
-            onToggle: () => toggle({ mediaKind: "episode", key: "watched", current: t.episode.watched }),
           },
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_scrobble_episode_rated(),
             isActive: t.episode.rated,
-            onToggle: () => toggle({ mediaKind: "episode", key: "rated", current: t.episode.rated }),
           },
           {
+            settingKey: "collected",
             label: m.text_library(),
             ariaLabel: m.button_label_plex_scrobble_episode_library(),
             isActive: t.episode.collected,
-            onToggle: () => toggle({ mediaKind: "episode", key: "collected", current: t.episode.collected }),
           },
         ],
       },

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSettingKey.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSettingKey.ts
@@ -1,0 +1,6 @@
+export type PlexSettingKey =
+  | 'watching'
+  | 'watched'
+  | 'rated'
+  | 'collected'
+  | 'watchlist';

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncSettings.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncSettings.svelte
@@ -3,33 +3,16 @@
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useQuery } from "$lib/features/query/useQuery.ts";
-  import { InvalidateAction } from "$lib/requests/models/InvalidateAction.ts";
   import { plexSettingsQuery } from "$lib/requests/plex/plexSettingsQuery.ts";
-  import { plexUpdateSettingsRequest } from "$lib/requests/plex/plexUpdateSettingsRequest.ts";
-  import { useInvalidator } from "$lib/stores/useInvalidator.ts";
   import { map } from "rxjs";
   import PlexToggleSettings from "./PlexToggleSettings.svelte";
+  import { usePlexSettingsToggle } from "./usePlexSettingsToggle.ts";
 
-  const { invalidate } = useInvalidator();
+  const toggle = usePlexSettingsToggle("sync");
 
   const settingsQuery = useQuery(plexSettingsQuery());
   const settings = settingsQuery.pipe(map((q) => q.data?.sync.toggles));
   const isLoading = settingsQuery.pipe(map((q) => q.isLoading));
-
-  type MediaKind = "movie" | "show" | "season" | "episode";
-
-  async function toggle(
-    { mediaKind, key, current }: {
-      mediaKind: MediaKind;
-      key: string;
-      current: boolean;
-    },
-  ) {
-    await plexUpdateSettingsRequest({
-      settings: { sync: { toggles: { [mediaKind]: { [key]: !current } } } },
-    });
-    await invalidate(InvalidateAction.Plex.Settings);
-  }
 </script>
 
 {#snippet movieIcon()}<MovieIcon />{/snippet}
@@ -41,6 +24,7 @@
     description={m.description_plex_sync_settings()}
     isLoading={true}
     rows={[]}
+    onToggle={toggle}
   />
 {:else}
   {@const t = $settings}
@@ -48,88 +32,93 @@
     title={m.header_plex_sync_settings()}
     description={m.description_plex_sync_settings()}
     isLoading={false}
+    onToggle={toggle}
     rows={[
       {
+        mediaKind: "movie",
         icon: movieIcon,
         title: m.button_text_browse_movies(),
         chips: [
           {
+            settingKey: "watched",
             label: m.button_plex_toggle_watched(),
             ariaLabel: m.button_label_plex_toggle_movie_watched(),
             isActive: t.movie.watched,
-            onToggle: () => toggle({ mediaKind: "movie", key: "watched", current: t.movie.watched }),
           },
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_toggle_movie_rated(),
             isActive: t.movie.rated,
-            onToggle: () => toggle({ mediaKind: "movie", key: "rated", current: t.movie.rated }),
           },
           {
+            settingKey: "watchlist",
             label: m.button_text_watchlist(),
             ariaLabel: m.button_label_plex_toggle_movie_watchlist(),
             isActive: t.movie.watchlist,
-            onToggle: () => toggle({ mediaKind: "movie", key: "watchlist", current: t.movie.watchlist }),
           },
           {
+            settingKey: "collected",
             label: m.text_library(),
             ariaLabel: m.button_label_plex_toggle_movie_library(),
             isActive: t.movie.collected,
-            onToggle: () => toggle({ mediaKind: "movie", key: "collected", current: t.movie.collected }),
           },
         ],
       },
       {
+        mediaKind: "show",
         icon: showIcon,
         title: m.button_text_browse_shows(),
         chips: [
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_toggle_show_rated(),
             isActive: t.show.rated,
-            onToggle: () => toggle({ mediaKind: "show", key: "rated", current: t.show.rated }),
           },
           {
+            settingKey: "watchlist",
             label: m.button_text_watchlist(),
             ariaLabel: m.button_label_plex_toggle_show_watchlist(),
             isActive: t.show.watchlist,
-            onToggle: () => toggle({ mediaKind: "show", key: "watchlist", current: t.show.watchlist }),
           },
         ],
       },
       {
+        mediaKind: "season",
         icon: showIcon,
         title: m.list_title_seasons(),
         chips: [
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_toggle_season_rated(),
             isActive: t.season.rated,
-            onToggle: () => toggle({ mediaKind: "season", key: "rated", current: t.season.rated }),
           },
         ],
       },
       {
+        mediaKind: "episode",
         icon: showIcon,
         title: m.list_title_episodes(),
         chips: [
           {
+            settingKey: "watched",
             label: m.button_plex_toggle_watched(),
             ariaLabel: m.button_label_plex_toggle_episode_watched(),
             isActive: t.episode.watched,
-            onToggle: () => toggle({ mediaKind: "episode", key: "watched", current: t.episode.watched }),
           },
           {
+            settingKey: "rated",
             label: m.header_ratings(),
             ariaLabel: m.button_label_plex_toggle_episode_rated(),
             isActive: t.episode.rated,
-            onToggle: () => toggle({ mediaKind: "episode", key: "rated", current: t.episode.rated }),
           },
           {
+            settingKey: "collected",
             label: m.text_library(),
             ariaLabel: m.button_label_plex_toggle_episode_library(),
             isActive: t.episode.collected,
-            onToggle: () => toggle({ mediaKind: "episode", key: "collected", current: t.episode.collected }),
           },
         ],
       },

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleParams.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleParams.ts
@@ -1,0 +1,8 @@
+import type { PlexMediaKind } from './PlexMediaKind.ts';
+import type { PlexSettingKey } from './PlexSettingKey.ts';
+
+export type PlexToggleParams = {
+  mediaKind: PlexMediaKind;
+  settingKey: PlexSettingKey;
+  current: boolean;
+};

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleSettings.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleSettings.spec.ts
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import PlexToggleSettings from './PlexToggleSettings.svelte';
+
+const icon = createRawSnippet(() => ({ render: () => '<span></span>' }));
+
+const DUPLICATE_TITLE = 'Shows';
+const DUPLICATE_LABEL = 'Ratings';
+
+function renderWithDuplicateText() {
+  const onToggle = vi.fn();
+
+  render(PlexToggleSettings, {
+    props: {
+      title: 'Sync',
+      description: 'Sync settings',
+      isLoading: false,
+      onToggle,
+      rows: [
+        {
+          mediaKind: 'show' as const,
+          icon,
+          title: DUPLICATE_TITLE,
+          chips: [
+            {
+              settingKey: 'rated',
+              label: DUPLICATE_LABEL,
+              ariaLabel: 'Toggle show ratings',
+              isActive: true,
+            },
+          ],
+        },
+        {
+          mediaKind: 'episode' as const,
+          icon,
+          title: DUPLICATE_TITLE,
+          chips: [
+            {
+              settingKey: 'rated',
+              label: DUPLICATE_LABEL,
+              ariaLabel: 'Toggle episode ratings',
+              isActive: false,
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  return onToggle;
+}
+
+describe('PlexToggleSettings', () => {
+  it('should render every row when two rows share the same title', () => {
+    renderWithDuplicateText();
+
+    expect(screen.getAllByText(DUPLICATE_TITLE)).toHaveLength(2);
+  });
+
+  it('should render every chip when two chips share the same label', () => {
+    renderWithDuplicateText();
+
+    expect(screen.getAllByText(DUPLICATE_LABEL)).toHaveLength(2);
+  });
+
+  it('should report the media kind and setting key of the toggled chip', async () => {
+    const user = userEvent.setup();
+    const onToggle = renderWithDuplicateText();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle episode ratings' }),
+    );
+
+    expect(onToggle).toHaveBeenCalledWith({
+      mediaKind: 'episode',
+      settingKey: 'rated',
+      current: false,
+    });
+  });
+});

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleSettings.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleSettings.svelte
@@ -1,33 +1,16 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
-  import type { Snippet } from "svelte";
   import SettingsGroupCard from "../SettingsGroupCard.svelte";
   import SettingsGroupRow from "../SettingsGroupRow.svelte";
-
-  type ToggleChip = {
-    label: string;
-    ariaLabel: string;
-    isActive: boolean;
-    onToggle: () => void;
-  };
-
-  type ToggleRow = {
-    icon: Snippet;
-    title: string;
-    chips: ReadonlyArray<ToggleChip>;
-  };
+  import type { PlexToggleSettingsProps } from "./PlexToggleSettingsProps.ts";
 
   const {
     title,
     description,
     isLoading,
     rows,
-  }: {
-    title: string;
-    description: string;
-    isLoading: boolean;
-    rows: ReadonlyArray<ToggleRow>;
-  } = $props();
+    onToggle,
+  }: PlexToggleSettingsProps = $props();
 
   const skeletonRows = [{ tags: 4 }, { tags: 1 }, { tags: 1 }, { tags: 4 }];
 </script>
@@ -46,16 +29,21 @@
       </div>
     {/each}
   {:else}
-    {#each rows as row (row.title)}
+    {#each rows as row (row.mediaKind)}
       <SettingsGroupRow title={row.title} variant="custom">
         {#snippet icon()}{@render row.icon()}{/snippet}
         <div class="plex-toggle-tags">
-          {#each row.chips as chip (chip.ariaLabel)}
+          {#each row.chips as chip (chip.settingKey)}
             <Button
               size="tag"
               label={chip.ariaLabel}
               color={chip.isActive ? "purple" : "default"}
-              onclick={chip.onToggle}
+              onclick={() =>
+              onToggle({
+                mediaKind: row.mediaKind,
+                settingKey: chip.settingKey,
+                current: chip.isActive,
+              })}
             >
               {chip.label}
             </Button>

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleSettingsProps.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexToggleSettingsProps.ts
@@ -1,0 +1,26 @@
+import type { Snippet } from 'svelte';
+import type { PlexMediaKind } from './PlexMediaKind.ts';
+import type { PlexSettingKey } from './PlexSettingKey.ts';
+import type { PlexToggleParams } from './PlexToggleParams.ts';
+
+type ToggleChip = {
+  settingKey: PlexSettingKey;
+  label: string;
+  ariaLabel: string;
+  isActive: boolean;
+};
+
+type ToggleRow = {
+  mediaKind: PlexMediaKind;
+  icon: Snippet;
+  title: string;
+  chips: ReadonlyArray<ToggleChip>;
+};
+
+export type PlexToggleSettingsProps = {
+  title: string;
+  description: string;
+  isLoading: boolean;
+  rows: ReadonlyArray<ToggleRow>;
+  onToggle: (params: PlexToggleParams) => void;
+};

--- a/projects/client/src/lib/sections/settings/_internal/plex/usePlexSettingsToggle.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/usePlexSettingsToggle.ts
@@ -1,0 +1,19 @@
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { plexUpdateSettingsRequest } from '$lib/requests/plex/plexUpdateSettingsRequest.ts';
+import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import type { PlexToggleParams } from './PlexToggleParams.ts';
+
+type PlexSettingsSection = 'sync' | 'scrobbler';
+
+export function usePlexSettingsToggle(section: PlexSettingsSection) {
+  const { invalidate } = useInvalidator();
+
+  return async ({ mediaKind, settingKey, current }: PlexToggleParams) => {
+    await plexUpdateSettingsRequest({
+      settings: {
+        [section]: { toggles: { [mediaKind]: { [settingKey]: !current } } },
+      },
+    });
+    await invalidate(InvalidateAction.Plex.Settings);
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <DetailsGrid>
-  {#each mediaDetails as { title, values } (title)}
+  {#each mediaDetails as { key, title, values } (key)}
     {#if values && values.length > 0}
       <CollapsableValues category={title} {values}>
         <p class="bold secondary">{title}</p>

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -42,6 +42,7 @@ function originalTitle(media: MediaEntry) {
 function mediaAirDate(media: MediaEntry) {
   if (isMaxDate(media.airDate)) {
     return {
+      key: 'air-date',
       title: m.header_expected_premiere(),
       values: [m.tag_text_tba()],
     };
@@ -49,6 +50,7 @@ function mediaAirDate(media: MediaEntry) {
 
   const isUpcomingItem = media.airDate > new Date();
   return {
+    key: 'air-date',
     title: isUpcomingItem ? m.header_expected_premiere() : m.header_premiered(),
     values: [toHumanDay({ date: media.airDate, locale: getLocale() })],
   };
@@ -56,6 +58,7 @@ function mediaAirDate(media: MediaEntry) {
 
 function mediaStatus(media: MediaEntry) {
   return {
+    key: 'status',
     title: m.header_status(),
     values: media.year && media.type === 'movie'
       ? undefined
@@ -67,6 +70,7 @@ function episodeType(episode: EpisodeEntry): MediaDetail {
   const label = EpisodeIntlProvider.episodeTypeText(episode.type);
 
   return {
+    key: 'episode-type',
     title: m.header_episode_type(),
     values: label ? [label] : undefined,
   };
@@ -77,6 +81,7 @@ function episodeAirDate(episode: EpisodeEntry) {
   const isTba = isMaxDate(episode.effectiveReleaseDate);
 
   return {
+    key: 'air-date',
     title: isUpcomingItem ? m.header_airs() : m.header_aired(),
     values: [
       isTba ? m.tag_text_tba() : toHumanDay({
@@ -90,6 +95,7 @@ function episodeAirDate(episode: EpisodeEntry) {
 
 function runtime(entry: MediaEntry | EpisodeEntry) {
   return {
+    key: 'runtime',
     title: m.header_runtime(),
     values: [toHumanDuration({ minutes: entry.runtime }, languageTag())],
   };
@@ -97,6 +103,7 @@ function runtime(entry: MediaEntry | EpisodeEntry) {
 
 function networks(entries: MediaNetwork[] | undefined) {
   return {
+    key: 'network',
     title: m.header_network(),
     values: entries?.map((network) => network.name),
   };
@@ -104,15 +111,16 @@ function networks(entries: MediaNetwork[] | undefined) {
 
 function showAirs(show: ShowEntry, now: Date): MediaDetail {
   if (!show.airs || !isCurrentlyAiring(show, now)) {
-    return { title: m.header_airs() };
+    return { key: 'airs', title: m.header_airs() };
   }
 
   const local = toHumanDayTime({ ...show.airs, locale: languageTag() });
   if (!local) {
-    return { title: m.header_airs() };
+    return { key: 'airs', title: m.header_airs() };
   }
 
   return {
+    key: 'airs',
     title: m.header_airs(),
     values: [m.text_airs_day_time(local)],
   };
@@ -122,7 +130,7 @@ function totalRuntime(show: ShowEntry): MediaDetail {
   const totalMinutes = show.totalRuntime;
 
   if (!Number.isFinite(totalMinutes) || totalMinutes <= 0) {
-    return { title: m.header_total_runtime() };
+    return { key: 'total-runtime', title: m.header_total_runtime() };
   }
 
   const duration = toHumanDuration({ minutes: totalMinutes }, languageTag());
@@ -130,6 +138,7 @@ function totalRuntime(show: ShowEntry): MediaDetail {
   const episodes = m.tag_text_number_of_episodes({ count });
 
   return {
+    key: 'total-runtime',
     title: m.header_total_runtime(),
     values: [`${duration} (${episodes})`],
   };
@@ -137,6 +146,7 @@ function totalRuntime(show: ShowEntry): MediaDetail {
 
 function postCredits(entry: MediaEntry | EpisodeEntry) {
   return {
+    key: 'post-credits',
     title: m.header_post_credits(),
     values: entry.postCredits
       .map((scene) => {
@@ -156,6 +166,7 @@ function mainCredits(type: ExtendedMediaType, crew: MediaCrew) {
       case 'movie':
       case 'episode':
         return {
+          key: 'creator-or-director',
           title: m.header_director(),
           values: crew.directors
             .filter((director) => onJob(director, 'Director'))
@@ -169,6 +180,7 @@ function mainCredits(type: ExtendedMediaType, crew: MediaCrew) {
         };
       case 'show':
         return {
+          key: 'creator-or-director',
           title: m.header_creator(),
           values: crew.creators
             .filter((creator) => onJob(creator, 'Creator'))
@@ -186,6 +198,7 @@ function mainCredits(type: ExtendedMediaType, crew: MediaCrew) {
   return [
     creatorOrDirector(),
     {
+      key: 'writer',
       title: m.header_writer(),
       values: crew.writers.map((writer) =>
         toCrewMemberWithJob({
@@ -204,26 +217,31 @@ function metaDetails(
 ) {
   return [
     {
+      key: 'country',
       title: m.header_country(),
       values: media.country
         ? [toCountryName(media.country, languageTag())]
         : undefined,
     },
     {
+      key: 'language',
       title: m.header_language(),
       values: media.languages?.map((language) =>
         toLanguageName(language, languageTag())
       ),
     },
     {
+      key: 'original-title',
       title: m.header_original_title(),
       values: originalTitle(media),
     },
     {
+      key: 'studio',
       title: m.header_studio(),
       values: studios.map((studio) => studio.name),
     },
     {
+      key: 'genre',
       title: m.header_genre(),
       values: media.genres.map(GenreIntlProvider.genre),
     },
@@ -231,6 +249,7 @@ function metaDetails(
 }
 
 type MediaDetail = {
+  key: string;
   title: string;
   values?: Array<string | { label: string; link: string }>;
 };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes TRAKT-WEB-BC7
- Plex sync/scrobbler toggle rows were keyed on their translated title. Any locale where two titles resolve to the same string threw `each_key_duplicate` and blanked the page. Rows now key on media kind, chips on setting key.
- Same bug in the summary media details, keyed on the translated header. Each detail carries its own `key` now.
  - Matched the open `/movies/[slug]` reports by route only, not by frame. Unconfirmed for now.
- Unrelated to #3153, that one is duplicate ids coming from the backend and is handled in trakt/trakt-rails#2411.
- Added the rule to `components.md` and the styleguide. `svelte/require-each-key` only checks that a key exists, nothing catches an unstable one.
