### PR TITLE
fix(stats): adds placeholders to empty screen time cards

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8161,6 +8161,10 @@
       "default": "Today",
       "description": "Label for the current day in stats charts."
     },
+    "text_stats_no_screen_time": {
+      "default": "No screen time this week",
+      "description": "Empty-state text shown inside a Screen Time graph card when nothing was watched during the selected week."
+    },
     "text_stats_time_morning": {
       "default": "Morning",
       "description": "Label for morning time bucket (5am-12pm) in watch clock chart."

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
@@ -23,7 +23,9 @@
   <div class="trakt-pulse-graph">
     <p class="small secondary">{title}</p>
 
-    {#if item.kind === "peakHours"}
+    {#if item.isEmpty}
+      <p class="graph-empty small secondary">{m.text_stats_no_screen_time()}</p>
+    {:else if item.kind === "peakHours"}
       <PulseGraphPeakHours data={item.data} />
     {:else if item.kind === "screenTimeDaily"}
       <PulseGraphScreenTimeDaily data={item.data} />
@@ -40,5 +42,14 @@
     overflow: hidden;
     height: 100%;
     box-sizing: border-box;
+  }
+
+  .graph-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin: 0;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
-  import { getLocale, languageTag } from "$lib/features/i18n/index.ts";
-  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration.ts";
+  import { languageTag } from "$lib/features/i18n/index.ts";
   import { ratio } from "$lib/utils/number/ratio.ts";
   import { time } from "$lib/utils/timing/time.ts";
   import { STRENGTH_RAMP_COLOR } from "./strengthRampColor.ts";
+  import { toScreenTimeDuration } from "./utils/toScreenTimeDuration.ts";
   import type { ScreenTimeDailyData } from "./models/ScreenTimeDailyData";
 
   // Grace period before the label glides back to the peak, so crossing the gap
@@ -14,28 +14,19 @@
 
   const { data }: { data: ScreenTimeDailyData } = $props();
 
-  const locale = $derived(getLocale());
   const lang = $derived(languageTag());
 
-  const maxPct = $derived(Math.max(...data.percentages, 1));
-
-  const zeroMinutes = $derived(
-    new Intl.NumberFormat(locale, {
-      style: "unit",
-      unit: "minute",
-      unitDisplay: "narrow",
-    }).format(0),
-  );
+  const maxPct = $derived(Math.max(...data.days.map((day) => day.percentage), 1));
 
   // Index of the day with the most screen time; label defaults to it. -1's
   // guard is `hasPeak`: nothing watched -> no default label.
   const peakIndex = $derived(
-    data.minutesPerDay.reduce(
-      (best, minutes, i, all) => (minutes > (all[best] ?? -1) ? i : best),
+    data.days.reduce(
+      (best, day, i, all) => (day.minutes > (all[best]?.minutes ?? -1) ? i : best),
       0,
     ),
   );
-  const hasPeak = $derived((data.minutesPerDay[peakIndex] ?? 0) > 0);
+  const hasPeak = $derived((data.days[peakIndex]?.minutes ?? 0) > 0);
 
   // Only one value is ever labelled at a time: the peak by default, or the day
   // the user hovers / focuses / taps. A single label glides between columns
@@ -43,15 +34,13 @@
   let activeIndex = $state<number | null>(null);
   const shownIndex = $derived(activeIndex ?? (hasPeak ? peakIndex : null));
 
-  // Cache the formatted durations so hover/focus re-renders don't rebuild an
-  // Intl.NumberFormat per column on every tick.
+  // Cache the formatted durations so hover/focus re-renders don't reformat every
+  // column on every tick.
   const durations = $derived(
-    data.minutesPerDay.map(
-      (minutes) => toHumanDuration({ minutes }, lang) || zeroMinutes,
-    ),
+    data.days.map((day) => toScreenTimeDuration(day.minutes, lang)),
   );
   const shownDuration = $derived(
-    shownIndex == null ? "" : durations[shownIndex] ?? zeroMinutes,
+    shownIndex == null ? "" : durations[shownIndex] ?? "",
   );
 
   let returnTimer: ReturnType<typeof setTimeout> | undefined;
@@ -73,21 +62,20 @@
 <div
   class="trakt-pulse-graph-screen-time-daily"
   class:has-value={shownIndex != null}
-  style="--column-count: {data.labels.length}; --active-column: {shownIndex ??
+  style="--column-count: {data.days.length}; --active-column: {shownIndex ??
     0};"
 >
   <div class="value-track" aria-hidden="true">
     <span class="screen-time-value tag bold no-wrap">{shownDuration}</span>
   </div>
 
-  {#each data.labels as label, i (i)}
-    {@const pct = data.percentages[i] ?? 0}
-    {@const fraction = ratio({ value: pct, total: maxPct })}
-    {@const duration = durations[i] ?? zeroMinutes}
+  {#each data.days as day, i (i)}
+    {@const fraction = ratio({ value: day.percentage, total: maxPct })}
+    {@const duration = durations[i] ?? ""}
     <button
       type="button"
       class="screen-time-column"
-      aria-label="{label}: {duration}"
+      aria-label="{day.label}: {duration}"
       onpointerenter={(e) => e.pointerType !== "touch" && reveal(i)}
       onpointerleave={(e) => e.pointerType !== "touch" && scheduleReturn()}
       onclick={() => reveal(i)}
@@ -106,12 +94,12 @@
           index={i}
           active={i === activeIndex}
           minVisible={0.03}
-          label="{label}: {duration}"
+          label="{day.label}: {duration}"
           --distribution-bar-thickness="100%"
           --viz-bar-strength={fraction}
         />
       </div>
-      <span class="screen-time-label tag ellipsis no-wrap">{label}</span>
+      <span class="screen-time-label tag ellipsis no-wrap">{day.label}</span>
     </button>
   {/each}
 </div>

--- a/projects/client/src/lib/sections/stats/_internal/getGraphItems.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getGraphItems.spec.ts
@@ -1,0 +1,66 @@
+import { WAKING_HOURS_PER_DAY } from '$lib/sections/stats/_internal/constants/index.ts';
+import type { WeekData } from '$lib/sections/stats/_internal/models/WeekData.ts';
+import { buildWeekData } from '$test/beds/stats/buildWeekData.ts';
+import { describe, expect, it } from 'vitest';
+import { getGraphItems } from './getGraphItems.ts';
+
+const now = new Date(2026, 0, 7, 12);
+
+function getGraphs(thisWeek: WeekData) {
+  return getGraphItems({
+    thisWeek,
+    now,
+    wakingHoursPerDay: WAKING_HOURS_PER_DAY,
+  });
+}
+
+function getKey(items: ReturnType<typeof getGraphItems>, key: string) {
+  return items.find((item) => item.key === key);
+}
+
+describe('getGraphItems', () => {
+  describe('isEmpty', () => {
+    it('should flag both graphs as empty when nothing was watched', () => {
+      const items = getGraphs(buildWeekData());
+
+      expect(getKey(items, 'screenTimeDaily')?.isEmpty).toBe(true);
+      expect(getKey(items, 'peakHours')?.isEmpty).toBe(true);
+    });
+
+    it('should flag the daily graph as empty when minutes are missing', () => {
+      const items = getGraphs(buildWeekData({ dailyMinutes: [] }));
+
+      expect(getKey(items, 'screenTimeDaily')?.isEmpty).toBe(true);
+    });
+
+    it('should pair every day label with its own minutes', () => {
+      const items = getGraphs(
+        buildWeekData({ dailyMinutes: [0, 0, 0, 0, 0, 0, 120] }),
+      );
+      const entry = getKey(items, 'screenTimeDaily');
+
+      expect(entry?.kind).toBe('screenTimeDaily');
+      if (entry?.kind !== 'screenTimeDaily') return;
+
+      expect(entry.data.days).toHaveLength(7);
+      expect(entry.data.days.at(-1)?.minutes).toBe(120);
+      expect(entry.data.days.at(-1)?.label).toBeTruthy();
+    });
+
+    it('should not flag the daily graph as empty when a day has watch time', () => {
+      const items = getGraphs(
+        buildWeekData({ dailyMinutes: [0, 0, 0, 0, 0, 0, 120] }),
+      );
+
+      expect(getKey(items, 'screenTimeDaily')?.isEmpty).toBe(false);
+    });
+
+    it('should not flag peak hours as empty when a title was watched', () => {
+      const items = getGraphs(
+        buildWeekData({ movieDates: [new Date(2026, 0, 7, 20)] }),
+      );
+
+      expect(getKey(items, 'peakHours')?.isEmpty).toBe(false);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/getGraphItems.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getGraphItems.ts
@@ -18,30 +18,39 @@ export function getGraphItems(
 
   const { labels } = countByCalendarDay({ dates: twAll, now, locale });
   const wakingMinutesPerDay = wakingHoursPerDay * 60;
-  const percentages = thisWeek.dailyMinutes.map((minutes) =>
-    Math.round((minutes / wakingMinutesPerDay) * 100)
-  );
+
+  const days = labels.map((label, index) => {
+    const minutes = thisWeek.dailyMinutes[index] ?? 0;
+
+    return {
+      label,
+      minutes,
+      percentage: Math.round((minutes / wakingMinutesPerDay) * 100),
+    };
+  });
+
+  const buckets = bucketByTimeOfDay({
+    movieDates: thisWeek.movieDates,
+    showDates: thisWeek.showDates,
+  });
 
   return [
     {
       type: 'graph',
       key: 'screenTimeDaily',
       kind: 'screenTimeDaily',
+      isEmpty: days.every((day) => day.minutes === 0),
       data: {
-        percentages,
-        minutesPerDay: thisWeek.dailyMinutes,
-        labels,
+        days,
       },
     },
     {
       type: 'graph',
       key: 'peakHours',
       kind: 'peakHours',
+      isEmpty: buckets.every((bucket) => bucket.count === 0),
       data: {
-        buckets: bucketByTimeOfDay({
-          movieDates: thisWeek.movieDates,
-          showDates: thisWeek.showDates,
-        }),
+        buckets,
       },
     },
   ];

--- a/projects/client/src/lib/sections/stats/_internal/getStatItems.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getStatItems.spec.ts
@@ -1,24 +1,11 @@
 import { WAKING_HOURS_PER_DAY } from '$lib/sections/stats/_internal/constants/index.ts';
+import { buildWeekData } from '$test/beds/stats/buildWeekData.ts';
 import { describe, expect, it } from 'vitest';
 import { getStatItems } from './getStatItems.ts';
-import type { WeekData } from './models/WeekData.ts';
 
 const wakingMinutesPerWeek = WAKING_HOURS_PER_DAY * 7 * 60;
 
-const emptyWeek: WeekData = {
-  movieDates: [],
-  showDates: [],
-  uniqueShows: 0,
-  ratings: [],
-  totalMinutes: 0,
-  movieMinutes: 0,
-  showMinutes: 0,
-  dailyMinutes: [],
-};
-
-function makeWeek(overrides: Partial<WeekData> = {}): WeekData {
-  return { ...emptyWeek, ...overrides };
-}
+const emptyWeek = buildWeekData();
 
 function getKey(
   items: ReturnType<typeof getStatItems>,
@@ -101,7 +88,7 @@ describe('getStatItems', () => {
   describe('rawValue', () => {
     it('screenTimeTotal rawValue equals totalMinutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ totalMinutes: 300 }),
+        thisWeek: buildWeekData({ totalMinutes: 300 }),
         lastWeek: emptyWeek,
         mode: 'movie',
       });
@@ -110,7 +97,7 @@ describe('getStatItems', () => {
 
     it('screenTimeShare rawValue is percentage of waking minutes per week', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ totalMinutes: wakingMinutesPerWeek / 2 }),
+        thisWeek: buildWeekData({ totalMinutes: wakingMinutesPerWeek / 2 }),
         lastWeek: emptyWeek,
         mode: 'movie',
       });
@@ -130,7 +117,7 @@ describe('getStatItems', () => {
       const day1 = new Date(2026, 0, 1, 10);
       const day2 = new Date(2026, 0, 2, 10);
       const items = getStatItems({
-        thisWeek: makeWeek({
+        thisWeek: buildWeekData({
           totalMinutes: 120,
           movieDates: [day1, day2],
         }),
@@ -151,7 +138,7 @@ describe('getStatItems', () => {
 
     it('movieTime rawValue equals movieMinutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ movieMinutes: 120 }),
+        thisWeek: buildWeekData({ movieMinutes: 120 }),
         lastWeek: emptyWeek,
         mode: 'movie',
       });
@@ -160,7 +147,7 @@ describe('getStatItems', () => {
 
     it('showTime rawValue equals showMinutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ showMinutes: 90 }),
+        thisWeek: buildWeekData({ showMinutes: 90 }),
         lastWeek: emptyWeek,
         mode: 'show',
       });
@@ -168,11 +155,44 @@ describe('getStatItems', () => {
     });
   });
 
+  describe('value', () => {
+    it('should render a zero duration for time stats with no watch time', () => {
+      const items = getStatItems({
+        thisWeek: emptyWeek,
+        lastWeek: emptyWeek,
+        mode: 'media',
+      });
+      expect(getKey(items, 'screenTimeTotal')?.value).toBe('0m');
+      expect(getKey(items, 'avgPerDay')?.value).toBe('0m');
+      expect(getKey(items, 'movieTime')?.value).toBe('0m');
+      expect(getKey(items, 'showTime')?.value).toBe('0m');
+    });
+
+    it('should render a zero percentage for screenTimeShare with no watch time', () => {
+      const items = getStatItems({
+        thisWeek: emptyWeek,
+        lastWeek: emptyWeek,
+        mode: 'media',
+      });
+      expect(getKey(items, 'screenTimeShare')?.value).toBe('0%');
+    });
+
+    it('should render a zero duration for a mode with no matching watch time', () => {
+      const items = getStatItems({
+        thisWeek: buildWeekData({ totalMinutes: 120, showMinutes: 120 }),
+        lastWeek: emptyWeek,
+        mode: 'media',
+      });
+      expect(getKey(items, 'movieTime')?.value).toBe('0m');
+      expect(getKey(items, 'showTime')?.value).toBe('2h');
+    });
+  });
+
   describe('delta', () => {
     it('screenTimeTotal delta is difference between weeks', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ totalMinutes: 300 }),
-        lastWeek: makeWeek({ totalMinutes: 200 }),
+        thisWeek: buildWeekData({ totalMinutes: 300 }),
+        lastWeek: buildWeekData({ totalMinutes: 200 }),
         mode: 'movie',
       });
       expect(getKey(items, 'screenTimeTotal')?.delta).toBe(100);
@@ -182,8 +202,8 @@ describe('getStatItems', () => {
       const half = wakingMinutesPerWeek / 2;
       const quarter = wakingMinutesPerWeek / 4;
       const items = getStatItems({
-        thisWeek: makeWeek({ totalMinutes: half }),
-        lastWeek: makeWeek({ totalMinutes: quarter }),
+        thisWeek: buildWeekData({ totalMinutes: half }),
+        lastWeek: buildWeekData({ totalMinutes: quarter }),
         mode: 'movie',
       });
       expect(getKey(items, 'screenTimeShare')?.delta).toBe(25);
@@ -191,8 +211,8 @@ describe('getStatItems', () => {
 
     it('movieTime delta is difference in movie minutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ movieMinutes: 120 }),
-        lastWeek: makeWeek({ movieMinutes: 60 }),
+        thisWeek: buildWeekData({ movieMinutes: 120 }),
+        lastWeek: buildWeekData({ movieMinutes: 60 }),
         mode: 'movie',
       });
       expect(getKey(items, 'movieTime')?.delta).toBe(60);
@@ -200,8 +220,8 @@ describe('getStatItems', () => {
 
     it('showTime delta is difference in show minutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ showMinutes: 30 }),
-        lastWeek: makeWeek({ showMinutes: 90 }),
+        thisWeek: buildWeekData({ showMinutes: 30 }),
+        lastWeek: buildWeekData({ showMinutes: 90 }),
         mode: 'show',
       });
       expect(getKey(items, 'showTime')?.delta).toBe(-60);

--- a/projects/client/src/lib/sections/stats/_internal/getStatItems.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getStatItems.ts
@@ -2,13 +2,13 @@ import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts'
 import { getLocale, languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import { WAKING_HOURS_PER_DAY } from '$lib/sections/stats/_internal/constants/index.ts';
-import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 import { toPercentage } from '$lib/utils/formatting/number/toPercentage.ts';
 import type { PulseStat } from './models/PulseStat.ts';
 import type { PulseStatItem } from './models/PulseStatItem.ts';
 import type { WeekData } from './models/WeekData.ts';
 import { computeDelta } from './utils/computeDelta.ts';
 import { countUniqueDays } from './utils/countUniqueDays.ts';
+import { toScreenTimeDuration } from './utils/toScreenTimeDuration.ts';
 
 function allDates(week: WeekData): readonly Date[] {
   return [...week.movieDates, ...week.showDates];
@@ -49,7 +49,7 @@ export function getStatItems(
     {
       key: 'screenTimeTotal',
       rawValue: thisWeek.totalMinutes,
-      value: toHumanDuration({ minutes: thisWeek.totalMinutes }, languageTag()),
+      value: toScreenTimeDuration(thisWeek.totalMinutes, languageTag()),
       label: m.label_stats_screen_time_total(),
       tooltip: m.tooltip_stats_screen_time_total(),
       delta: computeDelta(thisWeek.totalMinutes, lastWeek.totalMinutes),
@@ -70,7 +70,7 @@ export function getStatItems(
     {
       key: 'avgPerDay',
       rawValue: avgMinutesPerDay,
-      value: toHumanDuration({ minutes: avgMinutesPerDay }, languageTag()),
+      value: toScreenTimeDuration(avgMinutesPerDay, languageTag()),
       label: m.label_stats_avg_per_day(),
       tooltip: m.tooltip_stats_avg_per_day(),
       delta: computeDelta(avgMinutesPerDay, lastWeekAvgMinutes),
@@ -82,7 +82,7 @@ export function getStatItems(
     {
       key: 'movieTime',
       rawValue: thisWeek.movieMinutes,
-      value: toHumanDuration({ minutes: thisWeek.movieMinutes }, languageTag()),
+      value: toScreenTimeDuration(thisWeek.movieMinutes, languageTag()),
       label: m.label_stats_movies(),
       tooltip: m.tooltip_stats_movies(),
       delta: computeDelta(thisWeek.movieMinutes, lastWeek.movieMinutes),
@@ -94,7 +94,7 @@ export function getStatItems(
     {
       key: 'showTime',
       rawValue: thisWeek.showMinutes,
-      value: toHumanDuration({ minutes: thisWeek.showMinutes }, languageTag()),
+      value: toScreenTimeDuration(thisWeek.showMinutes, languageTag()),
       label: m.label_stats_shows(),
       tooltip: m.tooltip_stats_shows(),
       delta: computeDelta(thisWeek.showMinutes, lastWeek.showMinutes),

--- a/projects/client/src/lib/sections/stats/_internal/models/PulseGraphItem.ts
+++ b/projects/client/src/lib/sections/stats/_internal/models/PulseGraphItem.ts
@@ -1,16 +1,18 @@
 import type { PeakHoursData } from './PeakHoursData.ts';
 import type { ScreenTimeDailyData } from './ScreenTimeDailyData.ts';
 
+type PulseGraphItemBase = {
+  readonly type: 'graph';
+  readonly key: string;
+  readonly isEmpty: boolean;
+};
+
 export type PulseGraphItem =
-  | {
-    readonly type: 'graph';
-    readonly key: string;
+  | (PulseGraphItemBase & {
     readonly kind: 'peakHours';
     readonly data: PeakHoursData;
-  }
-  | {
-    readonly type: 'graph';
-    readonly key: string;
+  })
+  | (PulseGraphItemBase & {
     readonly kind: 'screenTimeDaily';
     readonly data: ScreenTimeDailyData;
-  };
+  });

--- a/projects/client/src/lib/sections/stats/_internal/models/ScreenTimeDailyData.ts
+++ b/projects/client/src/lib/sections/stats/_internal/models/ScreenTimeDailyData.ts
@@ -1,5 +1,5 @@
+import type { ScreenTimeDay } from './ScreenTimeDay.ts';
+
 export type ScreenTimeDailyData = {
-  readonly percentages: readonly number[];
-  readonly minutesPerDay: readonly number[];
-  readonly labels: readonly string[];
+  readonly days: ReadonlyArray<ScreenTimeDay>;
 };

--- a/projects/client/src/lib/sections/stats/_internal/models/ScreenTimeDay.ts
+++ b/projects/client/src/lib/sections/stats/_internal/models/ScreenTimeDay.ts
@@ -1,0 +1,5 @@
+export type ScreenTimeDay = {
+  readonly label: string;
+  readonly minutes: number;
+  readonly percentage: number;
+};

--- a/projects/client/src/lib/sections/stats/_internal/utils/toScreenTimeDuration.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/toScreenTimeDuration.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { toScreenTimeDuration } from './toScreenTimeDuration.ts';
+
+describe('util: toScreenTimeDuration', () => {
+  describe('with watch time', () => {
+    it('should format hours and minutes', () => {
+      expect(toScreenTimeDuration(131, 'en')).toBe('2h 11m');
+    });
+
+    it('should format minutes only', () => {
+      expect(toScreenTimeDuration(45, 'en')).toBe('45m');
+    });
+  });
+
+  describe('without watch time', () => {
+    it('should render a zero duration instead of an empty string', () => {
+      expect(toScreenTimeDuration(0, 'en')).toBe('0m');
+    });
+
+    it('should localise the zero duration', () => {
+      expect(toScreenTimeDuration(0, 'de')).not.toBe('');
+    });
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/utils/toScreenTimeDuration.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/toScreenTimeDuration.ts
@@ -1,0 +1,22 @@
+import {
+  type AvailableLanguage,
+  getIntlLocale,
+} from '$lib/features/i18n/index.ts';
+import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
+
+export function toScreenTimeDuration(
+  minutes: number,
+  language: AvailableLanguage,
+): string {
+  const duration = toHumanDuration({ minutes }, language);
+
+  if (duration) {
+    return duration;
+  }
+
+  return new Intl.NumberFormat(getIntlLocale(language), {
+    style: 'unit',
+    unit: 'minute',
+    unitDisplay: 'narrow',
+  }).format(0);
+}

--- a/projects/client/test/beds/stats/buildWeekData.ts
+++ b/projects/client/test/beds/stats/buildWeekData.ts
@@ -1,0 +1,15 @@
+import type { WeekData } from '$lib/sections/stats/_internal/models/WeekData.ts';
+
+export function buildWeekData(overrides: Partial<WeekData> = {}): WeekData {
+  return {
+    movieDates: [],
+    showDates: [],
+    uniqueShows: 0,
+    ratings: [],
+    totalMinutes: 0,
+    movieMinutes: 0,
+    showMinutes: 0,
+    dailyMinutes: [0, 0, 0, 0, 0, 0, 0],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- `toHumanDuration` returns an empty string for 0 minutes, so any period without watch history rendered blank stat cards and flat, unlabelled graphs
- new `toScreenTimeDuration` renders zero as `0m`. The daily chart's inline zero fallback goes through it now too, so there's one source of truth
- graph items carry an `isEmpty` flag computed in `getGraphItems`, and `PulseGraph` swaps the chart for a placeholder instead of a zeroed axis
- also covers partial gaps, not just fully empty weeks. Movie mode with only episodes watched used to blank the Movies card
- tightened `ScreenTimeDailyData` to one entry per day, so labels / minutes / percentages can't drift apart. Kills the defensive index fallbacks in the chart
- drawer gets all of it for free, it renders the same `PulseGraph` / `PulseCell`
- new `text_stats_no_screen_time` key, plus specs for the zero formatting and the `isEmpty` flags

## 👀 Example 👀
With no data:
<img width="476" height="739" alt="Screenshot 2026-08-19 at 12 25 44" src="https://github.com/user-attachments/assets/773c83bb-02bf-4bd0-a2e9-21fcfece40b1" />
