### PR TITLE
fix(show): count aired episodes only for season progress

### DIFF
--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -12,16 +12,20 @@
     variant = "opaque",
     classList = "",
     action,
+    eager = false,
   }: ChildrenProps & {
     variant?: "transparent" | "opaque";
     classList?: string;
     action?: (element: HTMLElement) => void;
+    eager?: boolean;
   } = $props();
 
   const isVisible = writable(false);
   const { navigation } = useNavigation();
 
   const customAction = $derived(action ? action : NOOP_FN);
+
+  const isRendered = $derived(eager || $isVisible);
 </script>
 
 <div
@@ -36,9 +40,9 @@
   <div
     class="trakt-card-content"
     class:trakt-card-transparent={variant === "transparent"}
-    class:is-visible={$isVisible}
+    class:is-visible={isRendered}
   >
-    {#if $isVisible}
+    {#if isRendered}
       {@render children()}
     {/if}
   </div>

--- a/projects/client/src/lib/components/tabs/TabView.svelte
+++ b/projects/client/src/lib/components/tabs/TabView.svelte
@@ -33,7 +33,7 @@
     {#each tabs as tab (tab.value)}
       <Tabs.Content value={tab.value}>
         {#snippet child({ props })}
-          {#if tab.value === value}
+          {#if tab.value === value || tab.keepMounted}
             <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
             <div {...props} class="trakt-tab-content" tabindex={-1}>
               {@render tab.content()}

--- a/projects/client/src/lib/components/tabs/models/TabViewProps.ts
+++ b/projects/client/src/lib/components/tabs/models/TabViewProps.ts
@@ -5,6 +5,7 @@ type TabView = {
   label: string;
   icon?: Snippet;
   content: Snippet;
+  keepMounted?: boolean;
 };
 
 export type TabViewProps = {

--- a/projects/client/src/lib/models/MediaStoreProps.ts
+++ b/projects/client/src/lib/models/MediaStoreProps.ts
@@ -17,7 +17,9 @@ type EpisodeCount = {
 
 type SeasonProps<T> = {
   type: 'season';
-  media: ArrayOrSingle<T & { number: number; episodes: { count: number } }>;
+  media: ArrayOrSingle<
+    T & { number: number; episodes: { count: number; aired: number } }
+  >;
   show: { id: number };
 };
 

--- a/projects/client/src/lib/requests/_internal/mapToSeason.ts
+++ b/projects/client/src/lib/requests/_internal/mapToSeason.ts
@@ -21,13 +21,16 @@ export const mapToSeason = (item: SeasonsResponse[0]): Season => {
     ...(item.images?.poster ?? []),
   );
 
+  const episodeCount = item.episode_count ?? 0;
+
   return {
     id: item.ids.trakt,
     key: `season-${item.ids.trakt}`,
     number: item.number,
     title: toDistinctSeasonTitle(item),
     episodes: {
-      count: item.episode_count ?? 0,
+      count: episodeCount,
+      aired: Math.min(item.aired_episodes ?? episodeCount, episodeCount),
     },
     poster: poster ? mapToPoster(item.images) : undefined,
     airDate: new Date(item.first_aired ?? MAX_DATE),

--- a/projects/client/src/lib/requests/models/Season.ts
+++ b/projects/client/src/lib/requests/models/Season.ts
@@ -8,6 +8,7 @@ export const SeasonSchema = z.object({
   title: z.string().nullish(),
   episodes: z.object({
     count: z.number(),
+    aired: z.number(),
   }),
   poster: z.object({
     url: ImageUrlsSchema,

--- a/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
@@ -121,6 +121,7 @@
 <div class="trakt-credit-member-item" role="listitem">
   <Card
     classList="trakt-credit-member-card"
+    eager
     --height-card={cardHeight}
     --width-card="100%"
   >
@@ -209,13 +210,8 @@
   }
 
   .credit-member-avatar {
-    --credit-member-avatar-height: var(--height-summary-card-cover-compact);
-    --credit-member-avatar-width: calc(
-      var(--credit-member-avatar-height) * 0.6667
-    );
-
-    width: var(--credit-member-avatar-width);
-    height: var(--credit-member-avatar-height);
+    width: var(--width-summary-card-cover-compact);
+    height: var(--height-summary-card-cover-compact);
 
     flex-shrink: 0;
     overflow: hidden;

--- a/projects/client/src/lib/sections/lists/season/SeasonDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonDropdown.svelte
@@ -6,8 +6,13 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { SeasonDropdownProps } from "./SeasonDropdownProps.ts";
 
-  const { showSlug, seasons, currentSeason, urlBuilder }: SeasonDropdownProps =
-    $props();
+  const {
+    showSlug,
+    seasons,
+    currentSeason,
+    variant = "default",
+    urlBuilder,
+  }: SeasonDropdownProps = $props();
 
   const buildUrl = $derived(
     urlBuilder ?? ((n: number) => UrlBuilder.show(showSlug, { season: n })),
@@ -27,6 +32,8 @@
   };
 
   const seasonText = (season: Season) => {
+    if (variant === "default") return seasonLabel(season);
+
     const episodes = m.tag_text_number_of_episodes({
       count: season.episodes.count,
     });

--- a/projects/client/src/lib/sections/lists/season/SeasonDropdownProps.ts
+++ b/projects/client/src/lib/sections/lists/season/SeasonDropdownProps.ts
@@ -4,5 +4,6 @@ export type SeasonDropdownProps = {
   showSlug: string;
   seasons: Season[];
   currentSeason: number;
+  variant?: 'default' | 'detailed';
   urlBuilder?: (seasonNumber: number) => string;
 };

--- a/projects/client/src/lib/sections/lists/season/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonList.svelte
@@ -56,7 +56,12 @@
 </RenderFor>
 
 {#snippet headerActions()}
-  <SeasonDropdown showSlug={show.slug} {seasons} {currentSeason} />
+  <SeasonDropdown
+    showSlug={show.slug}
+    {seasons}
+    {currentSeason}
+    variant="detailed"
+  />
 {/snippet}
 
 <SeasonEpisodeList

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
@@ -85,14 +85,15 @@ export function useIsWatched(props: IsWatchedProps) {
             new Map<number, number>();
 
           const watchedCount = seasons.filter((season) =>
-            (countBySeason.get(season.number) ?? 0) >= season.episodes.count
+            season.episodes.aired > 0 &&
+            (countBySeason.get(season.number) ?? 0) >= season.episodes.aired
           ).length;
 
           const hasSomeCompleteSeasons = watchedCount > 0 &&
             watchedCount < seasons.length;
           const hasSomePartialSeasons = seasons.some((season) => {
             const count = countBySeason.get(season.number) ?? 0;
-            return count > 0 && count < season.episodes.count;
+            return count > 0 && count < season.episodes.aired;
           });
 
           return {

--- a/projects/client/src/lib/sections/summary/components/_internal/DrawerCastSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DrawerCastSection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import DrawerSearchInput from "$lib/components/drawer/DrawerSearchInput.svelte";
-  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import type { ToggleOption } from "$lib/components/toggles/ToggleOption.ts";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -10,6 +9,7 @@
   import CreditMemberItem from "$lib/sections/lists/components/CreditMemberItem.svelte";
   import type { CreditMember } from "$lib/sections/lists/models/CreditMember.ts";
   import { toCreditMembers } from "$lib/sections/lists/toCreditMembers.ts";
+  import DrawerCreditListSkeleton from "./DrawerCreditListSkeleton.svelte";
   import DrawerTabTitle from "./DrawerTabTitle.svelte";
 
   type CreditsType = "cast" | "crew";
@@ -78,7 +78,7 @@
     {/snippet}
 
     {#snippet actions()}
-      {#if !isLoading && !isSearching}
+      {#if !isSearching}
         <Toggler
           value={creditsType}
           onChange={(value) => (creditsType = value)}
@@ -88,32 +88,30 @@
     {/snippet}
   </DrawerTabTitle>
 
-  {#if isLoading}
-    <LoadingIndicator />
-  {:else}
-    <DrawerSearchInput
-      bind:value={searchTerm}
-      label={m.input_label_search_credit_members()}
-      placeholder={m.input_placeholder_search_credit_members()}
-    />
+  <DrawerSearchInput
+    bind:value={searchTerm}
+    label={m.input_label_search_credit_members()}
+    placeholder={m.input_placeholder_search_credit_members()}
+  />
 
-    {#if visibleCredits.length > 0}
-      <div
-        id={`drawer-cast-list-${type}-${isSearching ? "search" : creditsType}`}
-        class="credit-list"
-        role="list"
-      >
-        {#each visibleCredits as item (toCreditMemberKey(item))}
-          <CreditMemberItem member={item} {type} />
-        {/each}
-      </div>
-    {:else}
-      <p class="credit-list-empty">
-        {isSearching
-          ? m.list_placeholder_no_filter_results()
-          : m.list_placeholder_empty()}
-      </p>
-    {/if}
+  {#if isLoading}
+    <DrawerCreditListSkeleton />
+  {:else if visibleCredits.length > 0}
+    <div
+      id={`drawer-cast-list-${type}-${isSearching ? "search" : creditsType}`}
+      class="credit-list"
+      role="list"
+    >
+      {#each visibleCredits as item (toCreditMemberKey(item))}
+        <CreditMemberItem member={item} {type} />
+      {/each}
+    </div>
+  {:else}
+    <p class="credit-list-empty">
+      {isSearching
+        ? m.list_placeholder_no_filter_results()
+        : m.list_placeholder_empty()}
+    </p>
   {/if}
 </div>
 

--- a/projects/client/src/lib/sections/summary/components/_internal/DrawerCreditListSkeleton.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DrawerCreditListSkeleton.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import Skeleton from "$lib/components/skeleton/Skeleton.svelte";
+
+  const skeletonCount = 3;
+</script>
+
+<div class="trakt-drawer-credit-list-skeleton" aria-hidden="true">
+  {#each Array(skeletonCount) as _, index (`credit-member-skeleton-${index}`)}
+    <div class="credit-skeleton-card">
+      <Skeleton
+        width="var(--width-summary-card-cover-compact)"
+        height="var(--height-summary-card-cover-compact)"
+        radius="var(--border-radius-m)"
+      />
+
+      <div class="credit-skeleton-lines">
+        <Skeleton width="40%" height="var(--ni-16)" />
+        <Skeleton width="70%" height="var(--ni-14)" />
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style lang="scss">
+  .trakt-drawer-credit-list-skeleton {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+  }
+
+  .credit-skeleton-card {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+
+    min-height: var(--height-summary-card-compact);
+    padding-block: var(--ni-4);
+    padding-inline: var(--ni-4) var(--ni-12);
+    box-sizing: border-box;
+
+    background: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+  }
+
+  .credit-skeleton-lines {
+    flex: 1;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte
@@ -14,6 +14,7 @@
   import SeasonProgressCard from "$lib/sections/summary/components/seasons/SeasonProgressCard.svelte";
   import { summaryDrawerNavigation } from "$lib/sections/summary/summaryDrawerNavigation.ts";
   import { countWatchedEpisodes } from "$lib/utils/media/countWatchedEpisodes";
+  import { sumRemainingRuntime } from "$lib/utils/media/sumRemainingRuntime.ts";
   import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
 
   const {
@@ -60,8 +61,16 @@
   const currentSeasonData = $derived(
     seasons.find((s) => s.number === currentSeason),
   );
-  const currentSeasonWatched = $derived(
-    $watchedBySeason?.get(currentSeason)?.size ?? 0,
+  const currentSeasonWatchedNumbers = $derived(
+    $watchedBySeason?.get(currentSeason) ?? new Set<number>(),
+  );
+  const currentSeasonWatched = $derived(currentSeasonWatchedNumbers.size);
+  const currentSeasonMinutesLeft = $derived(
+    sumRemainingRuntime({
+      episodes: $episodes,
+      airedCount: currentSeasonData?.episodes.aired ?? 0,
+      watchedEpisodeNumbers: currentSeasonWatchedNumbers,
+    }),
   );
 </script>
 
@@ -85,8 +94,8 @@
         <SeasonProgressCard
           seasonNumber={currentSeason}
           watched={currentSeasonWatched}
-          total={currentSeasonData.episodes.count}
-          totalRuntime={currentSeasonData.totalRuntime}
+          total={currentSeasonData.episodes.aired}
+          minutesLeft={currentSeasonMinutesLeft}
           loading={$isWatchedLoading}
         />
       {/if}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
@@ -12,7 +12,7 @@
     seasonNumber: number;
     watched: number;
     total: number;
-    totalRuntime: number;
+    minutesLeft: number;
     loading?: boolean;
   };
 
@@ -20,7 +20,7 @@
     seasonNumber,
     watched,
     total,
-    totalRuntime,
+    minutesLeft,
     loading = false,
   }: SeasonProgressCardProps = $props();
 
@@ -37,17 +37,12 @@
   const remaining = $derived(Math.max(0, total - watched));
   const isComplete = $derived(total > 0 && watched >= total);
   const isStarted = $derived(watched > 0);
-  const minutesLeft = $derived(
-    !isNaN(totalRuntime) && remaining > 0 && total > 0
-      ? Math.round((totalRuntime / total) * remaining)
-      : 0,
-  );
 </script>
 
 {#snippet tags()}
   {#if !isComplete && remaining > 0}
     <EpisodeRemainingTag i18n={EpisodeIntlProvider} {remaining} />
-    {#if !isNaN(totalRuntime) && minutesLeft > 0}
+    {#if minutesLeft > 0}
       <EpisodeDurationTag i18n={EpisodeIntlProvider} {minutesLeft} />
     {/if}
   {/if}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
@@ -137,6 +137,7 @@
             label: m.tab_text_seasons_info(),
             icon: overviewIcon,
             content: overviewContent,
+            keepMounted: true,
           },
           {
             value: "reviews",

--- a/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonOverviewTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonOverviewTab.svelte
@@ -5,7 +5,7 @@
   import DrawerCastSection from "$lib/sections/summary/components/_internal/DrawerCastSection.svelte";
   import SeasonInfoSection from "./SeasonInfoSection.svelte";
   import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
-  import { useSeasonPeople } from "./useSeasonPeople";
+  import { useSeasonPeople } from "./useSeasonPeople.ts";
 
   const {
     show,

--- a/projects/client/src/lib/utils/media/sumRemainingRuntime.spec.ts
+++ b/projects/client/src/lib/utils/media/sumRemainingRuntime.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { sumRemainingRuntime } from './sumRemainingRuntime.ts';
+
+const episodes = [
+  { number: 1, runtime: 55 },
+  { number: 2, runtime: 47 },
+  { number: 3, runtime: 62 },
+];
+
+describe('util: sumRemainingRuntime', () => {
+  it('should return 0 without episodes', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes: [],
+        airedCount: 3,
+        watchedEpisodeNumbers: new Set(),
+      }),
+    ).toBe(0);
+  });
+
+  it('should sum the runtime of unwatched aired episodes', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes,
+        airedCount: 3,
+        watchedEpisodeNumbers: new Set(),
+      }),
+    ).toBe(164);
+  });
+
+  it('should exclude watched episodes', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes,
+        airedCount: 3,
+        watchedEpisodeNumbers: new Set([1, 3]),
+      }),
+    ).toBe(47);
+  });
+
+  it('should exclude episodes beyond the aired count', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes,
+        airedCount: 2,
+        watchedEpisodeNumbers: new Set(),
+      }),
+    ).toBe(102);
+  });
+
+  it('should return 0 when nothing aired yet', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes,
+        airedCount: 0,
+        watchedEpisodeNumbers: new Set(),
+      }),
+    ).toBe(0);
+  });
+
+  it('should return 0 when every aired episode is watched', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes,
+        airedCount: 2,
+        watchedEpisodeNumbers: new Set([1, 2]),
+      }),
+    ).toBe(0);
+  });
+
+  it('should count by episode number regardless of input order', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes: [episodes[2], episodes[0], episodes[1]],
+        airedCount: 1,
+        watchedEpisodeNumbers: new Set(),
+      }),
+    ).toBe(55);
+  });
+
+  it('should ignore episodes with an unknown runtime', () => {
+    expect(
+      sumRemainingRuntime({
+        episodes: [{ number: 1, runtime: NaN }, { number: 2, runtime: 47 }],
+        airedCount: 2,
+        watchedEpisodeNumbers: new Set(),
+      }),
+    ).toBe(47);
+  });
+});

--- a/projects/client/src/lib/utils/media/sumRemainingRuntime.ts
+++ b/projects/client/src/lib/utils/media/sumRemainingRuntime.ts
@@ -1,0 +1,19 @@
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+
+type SumRemainingRuntimeProps = {
+  episodes: ReadonlyArray<Pick<EpisodeEntry, 'number' | 'runtime'>>;
+  airedCount: number;
+  watchedEpisodeNumbers: ReadonlySet<number>;
+};
+
+export function sumRemainingRuntime({
+  episodes,
+  airedCount,
+  watchedEpisodeNumbers,
+}: SumRemainingRuntimeProps): number {
+  return [...episodes]
+    .sort((a, b) => a.number - b.number)
+    .slice(0, Math.max(0, airedCount))
+    .filter((episode) => !watchedEpisodeNumbers.has(episode.number))
+    .reduce((total, episode) => total + (episode.runtime || 0), 0);
+}

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
@@ -9,6 +9,7 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'title': null,
     'episodes': {
       'count': 10,
+      'aired': 10,
     },
     'poster': {
       'url': {
@@ -32,6 +33,7 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'title': null,
     'episodes': {
       'count': 10,
+      'aired': 10,
     },
     'poster': {
       'url': {
@@ -55,6 +57,7 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'title': null,
     'episodes': {
       'count': 1,
+      'aired': 0,
     },
     'poster': undefined,
     'airDate': MAX_DATE,

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -330,6 +330,9 @@
 
   --width-summary-card-compact: 100%;
   --height-summary-card-cover-compact: var(--ni-88);
+  --width-summary-card-cover-compact: calc(
+    var(--height-summary-card-cover-compact) * 0.6667
+  );
   --height-summary-card-compact: var(--ni-96);
 
   @include for-tablet-sm-and-below {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Season progress no longer counts unaired episodes. Marked all 7 released episodes of Silo S3 as watched: 100% now, was 70%
- `Season.episodes.aired` maps the API's `aired_episodes`, the same source show progress already uses. Single definition, so the drawer card, the poster check and show progress can't disagree
- Remaining time is a real sum of the unwatched aired runtimes instead of `totalRuntime / count * remaining`, so a long finale reports honestly
- Season watched state on the posters uses the aired count too. A fully watched season with unaired episodes gets its check now
- Drawer season select drops the appended episode counts. Only the summary page passes `variant="detailed"` for those
- Info section no longer shifts while the people list loads:
  - credit rows render eagerly (new `eager` opt-out on `Card`), so their height is final from the first paint. They were sitting at 0 height until scrolled into view, since `Card` resets itself to `all: unset` and its reserved `min-height` is inert on an inline box
  - the overview tab keeps its content mounted (`keepMounted` on `TabView`), so people load with the drawer instead of on first tab open (measured: request now fires at drawer open, was 3s later on click)
  - the cast list reserves space with a skeleton instead of swapping a spinner for the full list
  - ⚠️ Could not reproduce the micro-jumping locally, only with an injected 4s delay on the people request. The two mechanisms are verified though, so this should hold on a slow connection

##  👀 Examples 👀
Before/after:
<img width="487" height="434" alt="Screenshot 2026-08-19 at 12 32 41" src="https://github.com/user-attachments/assets/e456c82f-53a4-493d-aee1-e2dc1c93377a" />

<img width="487" height="434" alt="Screenshot 2026-08-19 at 12 32 27" src="https://github.com/user-attachments/assets/5129431f-5bf3-4b79-96cc-8788f19e14ed" />
