### PR TITLE
Media: use the canonical year field for media card release years

### DIFF
--- a/projects/client/src/lib/components/media/tags/AirDateTag.spec.ts
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.spec.ts
@@ -31,6 +31,34 @@ describe('AirDateTag', () => {
     expect(screen.getByText(`${currentYear - 1}`)).toBeDefined();
   });
 
+  it('should prefer the canonical year over the air date year once released', () => {
+    const airDate = new Date(Date.now() - time.years(1));
+
+    render(AirDateTag, {
+      props: {
+        airDate,
+        year: 1976,
+        i18n: TagIntlProvider,
+      },
+    });
+
+    expect(screen.getByText('1976')).toBeDefined();
+  });
+
+  it('should ignore the canonical year for an unreleased date', () => {
+    const airDate = new Date(new Date().getTime() + time.days(6));
+
+    render(AirDateTag, {
+      props: {
+        airDate,
+        year: new Date().getFullYear(),
+        i18n: TagIntlProvider,
+      },
+    });
+
+    expect(screen.getByText('in 6 days')).toBeDefined();
+  });
+
   it('should display relative date if it is released in the upcoming week', () => {
     const airDate = new Date(new Date().getTime() + time.days(6));
 

--- a/projects/client/src/lib/components/media/tags/AirDateTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirDateTag.svelte
@@ -2,24 +2,17 @@
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import { isMaxDate } from "$lib/utils/date/isMaxDate";
-  import type { TagType } from "./models/TagType";
-  import type { TagIntl } from "./TagIntl";
+  import type { AirDateTagProps } from "./_internal/AirDateTagProps.ts";
 
-  const {
-    airDate,
-    i18n,
-    type = "text",
-  }: {
-    airDate: Date;
-    i18n: TagIntl;
-    type?: TagType;
-  } = $props();
+  const { airDate, year, i18n, type = "text" }: AirDateTagProps = $props();
 </script>
 
 {#snippet content()}
   <p class="bold capitalize no-wrap">
     {#if isMaxDate(airDate)}
       {i18n.tbaLabel()}
+    {:else if airDate.getTime() <= Date.now() && year != null}
+      {year}
     {:else}
       {i18n.toReleaseEstimate(airDate)}
     {/if}

--- a/projects/client/src/lib/components/media/tags/_internal/AirDateTagProps.ts
+++ b/projects/client/src/lib/components/media/tags/_internal/AirDateTagProps.ts
@@ -1,0 +1,9 @@
+import type { TagType } from '../models/TagType.ts';
+import type { TagIntl } from '../TagIntl.ts';
+
+export type AirDateTagProps = {
+  airDate: Date;
+  year?: number | Nil;
+  i18n: TagIntl;
+  type?: TagType;
+};

--- a/projects/client/src/lib/features/search/_internal/SearchResultItem.svelte
+++ b/projects/client/src/lib/features/search/_internal/SearchResultItem.svelte
@@ -32,7 +32,7 @@
 </script>
 
 {#snippet mediaTag(item: MediaInputDefault)}
-  <AirDateTag i18n={TagIntlProvider} airDate={item.airDate} />
+  <AirDateTag i18n={TagIntlProvider} airDate={item.airDate} year={item.year} />
 
   {#if $mode === "movie"}
     <DurationTag i18n={TagIntlProvider} runtime={item.runtime} />

--- a/projects/client/src/lib/sections/lists/components/CreditMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMediaItem.svelte
@@ -34,7 +34,7 @@
 </script>
 
 {#snippet tag()}
-  <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+  <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} year={media.year} />
 
   {#if media.type === "show" && mediaCredit.episodeCount}
     <EpisodeCountTag i18n={TagIntlProvider} count={mediaCredit.episodeCount} />

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -56,10 +56,10 @@
 
 {#snippet defaultTag()}
   {#if "episode" in media}
-    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} year={media.year} />
     <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
   {:else if type === "movie" && rest.variant !== "activity" && rest.variant !== "next"}
-    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} year={media.year} />
     {#if media.airDate < new Date()}
       <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
     {/if}

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/StartWatchingItem.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/StartWatchingItem.svelte
@@ -73,7 +73,7 @@
 
 {#snippet summaryTag()}
   <TagBar>
-    <AirDateTag i18n={TagIntlProvider} airDate={entry.airDate} />
+    <AirDateTag i18n={TagIntlProvider} airDate={entry.airDate} year={entry.year} />
 
     {#if "episode" in entry}
       <EpisodeCountTag i18n={TagIntlProvider} count={entry.episode.count} />


### PR DESCRIPTION
# Description

Fixes #3145.

The release year on media cards was derived from the release date: `AirDateTag` formats past dates via `toHumanETA`, which returns the year of `airDate` (`released` for movies, `first_aired` for shows). The summary page instead shows Trakt's canonical `year` field. For movies that premiered late in one year and reached theaters the next, the two surfaces disagreed: Freaky Friday has `year` 1976 but `released` 1977-01-21, so search said 1977 while the movie page said 1976. Same story for Memento (2000 vs 2001).

IMDb and TMDB both headline the premiere year (TMDB shows "Freaky Friday (1976)" directly above a 01/21/1977 release date), so the canonical `year` field is the right source and the card derivation is the outlier.

# Changes

- `AirDateTag` accepts an optional `year` prop. Once `airDate` is in the past, it displays that canonical year instead of the year derived from the date. TBA handling and future release estimates ("in 6 days", "next month") are unchanged, and callers that omit `year` keep the old behavior.
- Props moved to `_internal/AirDateTagProps.ts` now that the component has 4 props.
- Every media-entry call site passes the canonical year: `SearchResultItem`, `DefaultMediaItem` (both the movie and show branches), `CreditMediaItem`, and `StartWatchingItem`.
- Calendar surfaces and `EpisodeItem` are intentionally untouched: those are genuinely date-based displays, and episodes have no separate canonical year.

# Testing

Added two `AirDateTag` spec cases: a released date prefers the passed canonical year, and an unreleased date ignores it and keeps the relative estimate.