### PR TITLE
List: link to lists from the manage lists drawer

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2444,6 +2444,27 @@
         }
       }
     },
+    "link_label_view_list": {
+      "default": "View list {name}",
+      "description": "Aria-label for the link that opens a list from the manage lists drawer.",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "tooltip_view_list": {
+      "default": "View list",
+      "description": "Tooltip for the link that opens a list from the manage lists drawer."
+    },
+    "link_label_view_watchlist": {
+      "default": "View watchlist",
+      "description": "Aria-label for the link that opens the watchlist from the manage lists drawer."
+    },
+    "tooltip_view_watchlist": {
+      "default": "View watchlist",
+      "description": "Tooltip for the link that opens the watchlist from the manage lists drawer."
+    },
     "button_label_add_to_personal_list": {
       "default": "Add \"{title}\" to {list}",
       "description": "Aria-label for the button that allows users to add a movie or show to a personal list.",

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
@@ -21,6 +21,7 @@
     type,
     onAdd,
     onRemove,
+    action,
     ...props
   }: WatchlistButtonProps = $props();
 
@@ -82,7 +83,7 @@
 {/if}
 
 {#if type === "dropdown-item"}
-  <DropdownItem {...commonProps} style="flat">
+  <DropdownItem {...commonProps} style="flat" {action}>
     {i18n.text({ isWatchlisted, title })}
     {#if isQueued}<QueuedTag />{/if}
     {#snippet icon()}

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
@@ -22,6 +22,7 @@
     onAdd,
     onRemove,
     action,
+    flash,
     ...props
   }: WatchlistButtonProps = $props();
 
@@ -83,7 +84,7 @@
 {/if}
 
 {#if type === "dropdown-item"}
-  <DropdownItem {...commonProps} style="flat" {action}>
+  <DropdownItem {...commonProps} style="flat" {action} {flash}>
     {i18n.text({ isWatchlisted, title })}
     {#if isQueued}<QueuedTag />{/if}
     {#snippet icon()}

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
@@ -1,4 +1,5 @@
 import type { WatchlistButtonIntl } from '$lib/components/buttons/watchlist/WatchlistButtonIntl.ts';
+import type { DropdownItemFlash } from '$lib/components/dropdown/DropdownItemFlash.ts';
 import type { Snippet } from 'svelte';
 
 export type WatchlistButtonProps = {
@@ -13,4 +14,6 @@ export type WatchlistButtonProps = {
   onRemove: (event: MouseEvent) => void;
   // Trailing action segment - only rendered for the dropdown-item type.
   action?: Snippet;
+  // Briefly flashes the row background - only for the dropdown-item type.
+  flash?: DropdownItemFlash | Nil;
 } & Omit<ButtonProps, 'children' | 'onclick' | 'label' | 'value' | 'type'>;

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
@@ -1,4 +1,5 @@
 import type { WatchlistButtonIntl } from '$lib/components/buttons/watchlist/WatchlistButtonIntl.ts';
+import type { Snippet } from 'svelte';
 
 export type WatchlistButtonProps = {
   i18n?: WatchlistButtonIntl;
@@ -10,4 +11,6 @@ export type WatchlistButtonProps = {
   size: 'small' | 'normal';
   onAdd: () => void;
   onRemove: (event: MouseEvent) => void;
+  // Trailing action segment - only rendered for the dropdown-item type.
+  action?: Snippet;
 } & Omit<ButtonProps, 'children' | 'onclick' | 'label' | 'value' | 'type'>;

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -9,6 +9,7 @@
     tabindex?: number;
     icon?: Snippet;
     end?: Snippet;
+    action?: Snippet;
     subtitle?: Snippet;
     style?: "ghost" | "flat";
     variant?: "primary" | "secondary";
@@ -26,6 +27,7 @@
     children,
     icon,
     end,
+    action,
     subtitle,
     ...props
   }: DropdownItemProps | DropdownItemAnchorProps = $props();
@@ -41,6 +43,10 @@
     (props as DropdownItemAnchorProps).replacestate,
   );
   const target = $derived((props as DropdownItemAnchorProps).target);
+
+  // Keep the action segment's events from reaching the item, so the item's
+  // handler and hover state only respond to the main area.
+  const stopPropagation = (event: Event) => event.stopPropagation();
 
   // FIXME: use button when not href & update selectors in applicable icons
 </script>
@@ -94,6 +100,19 @@
       </div>
     {/if}
   {/if}
+  {#if action}
+    <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events, a11y_mouse_events_have_key_events -->
+    <div
+      class="item-action"
+      onclick={stopPropagation}
+      onmouseover={stopPropagation}
+      onmouseout={stopPropagation}
+      onfocusin={stopPropagation}
+      onfocusout={stopPropagation}
+    >
+      {@render action()}
+    </div>
+  {/if}
 </li>
 
 <style lang="scss">
@@ -119,9 +138,7 @@
     justify-self: center;
 
     display: flex;
-    flex-direction: var(--dropdown-item-direction, row);
     align-items: center;
-    justify-content: var(--dropdown-item-justify, flex-start);
     gap: var(--icon-gap);
 
     cursor: pointer;
@@ -220,6 +237,52 @@
       text-decoration: none;
     }
 
+    .item-action {
+      display: flex;
+      align-items: stretch;
+      align-self: stretch;
+      margin-inline-start: auto;
+      margin-block: calc(-1 * var(--item-padding-block));
+      margin-inline-end: calc(-1 * var(--item-padding-inline));
+      border-inline-start: var(--ni-1) solid
+        var(--color-option-list-separator);
+
+      transition: var(--transition-increment) ease-in-out;
+      transition-property: background;
+
+      :global(.trakt-link) {
+        width: auto;
+        height: auto;
+        padding: 0 var(--item-padding-inline);
+
+        display: flex;
+        align-items: center;
+      }
+
+      @include for-mouse {
+        &:hover {
+          background: var(
+            --dropdown-item-background-hover,
+            var(--color-select-item-hover)
+          );
+        }
+      }
+    }
+
+    &:has(.item-action:hover) {
+      --dropdown-item-background-hover: var(
+        --dropdown-item-background,
+        transparent
+      );
+    }
+
+    &:has(.item-action:active) {
+      --dropdown-item-background-active: var(
+        --dropdown-item-background,
+        transparent
+      );
+    }
+
     @mixin variant($color, $bg-color) {
       color: var(--dropdown-item-foreground, #{$color});
 
@@ -280,6 +343,11 @@
       &:focus-visible,
       &:has(> :global(.trakt-link:focus-visible)) {
         outline: var(--border-thickness-xs) solid $outline-color;
+      }
+
+      .item-action:has(:global(.trakt-link:focus-visible)) {
+        outline: var(--border-thickness-xs) solid $outline-color;
+        outline-offset: calc(-1 * var(--border-thickness-xs));
       }
     }
 

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -3,6 +3,7 @@
   import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
   import type { Snippet } from "svelte";
   import Link from "../link/Link.svelte";
+  import type { DropdownItemFlash } from "./DropdownItemFlash";
 
   type DropdownItemProps = {
     color?: "red" | "purple" | "blue" | "orange" | "default";
@@ -14,6 +15,7 @@
     style?: "ghost" | "flat";
     variant?: "primary" | "secondary";
     selected?: boolean;
+    flash?: DropdownItemFlash | Nil;
   } & ChildrenProps &
     HTMLElementProps;
 
@@ -24,6 +26,7 @@
     style = "ghost",
     variant = "primary",
     selected = false,
+    flash,
     children,
     icon,
     end,
@@ -69,6 +72,7 @@
   data-color={color}
   data-style={style}
   data-variant={variant}
+  data-flash={flash}
   class:is-selected={selected}
   class:has-subtitle={subtitle != null}
   {...props}
@@ -281,6 +285,30 @@
         --dropdown-item-background,
         transparent
       );
+    }
+
+    &[data-flash] {
+      position: relative;
+
+      &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        border-radius: inherit;
+
+        opacity: 0;
+        animation: background-flash var(--animation-duration-background-flash)
+          ease-out;
+      }
+    }
+
+    &[data-flash="purple"]::after {
+      background: var(--color-background-purple);
+    }
+
+    &[data-flash="red"]::after {
+      background: var(--color-background-red);
     }
 
     @mixin variant($color, $bg-color) {

--- a/projects/client/src/lib/components/dropdown/DropdownItemFlash.ts
+++ b/projects/client/src/lib/components/dropdown/DropdownItemFlash.ts
@@ -1,0 +1,1 @@
+export type DropdownItemFlash = 'purple' | 'red';

--- a/projects/client/src/lib/requests/queries/users/userListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListsQuery.ts
@@ -6,11 +6,15 @@ import { InvalidateAction } from '../../models/InvalidateAction.ts';
 
 type UserListsParams = ApiParams;
 
+// slug/ownerSlug are absent from the minimal payload; useAllPersonalLists
+// overlays them from the list summary queries.
 const UserListSchema = z.object({
   id: z.number(),
   name: z.string(),
+  slug: z.string().nullish(),
   count: z.number(),
   ownerId: z.number(),
+  ownerSlug: z.string().nullish(),
 });
 
 export type UserList = z.infer<typeof UserListSchema>;

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { useDangerButton } from "$lib/components/buttons/_internal/useDangerButton";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import type { DropdownItemFlash } from "$lib/components/dropdown/DropdownItemFlash";
   import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
@@ -21,6 +22,7 @@
     i18n = ListDropdownItemIntlProvider,
     media,
     isListed,
+    flash,
   }: ListDropdownItemProps = $props();
 
   const { user } = useUser();
@@ -71,15 +73,19 @@
   );
   const state = $derived(isListed ? "added" : "missing");
 
-  const itemProps: Omit<ButtonProps, "children"> = $derived({
-    style: "flat",
-    label: i18n.label({ isListed, listName: list.name, title }),
-    color: $color,
-    variant: isListed ? variant : "primary",
-    onclick: handler,
-    disabled: $isListUpdating || (!isListed && !isBelowLimit),
-    ...events,
-  });
+  const itemProps:
+    & Omit<ButtonProps, "children">
+    & { flash?: DropdownItemFlash | Nil } =
+    $derived({
+      style: "flat",
+      label: i18n.label({ isListed, listName: list.name, title }),
+      color: $color,
+      variant: isListed ? variant : "primary",
+      onclick: handler,
+      disabled: $isListUpdating || (!isListed && !isBelowLimit),
+      flash,
+      ...events,
+    });
 </script>
 
 <DropdownItem {...itemProps}>

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
@@ -7,7 +7,9 @@
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { onMount } from "svelte";
+  import ViewListLink from "./_internal/ViewListLink.svelte";
   import { ListDropdownItemIntlProvider } from "./ListDropdownItemIntlProvider";
   import type { ListDropdownItemProps } from "./ListDropdownItemProps";
   import { useList } from "./useList";
@@ -55,6 +57,14 @@
     }),
   );
 
+  // Slugs are overlaid asynchronously from the list summaries; the numeric
+  // ids resolve to the same page until they land.
+  const listUrl = $derived(
+    list.ownerSlug && list.slug
+      ? UrlBuilder.users(list.ownerSlug).lists(list.slug)
+      : UrlBuilder.users(String(list.ownerId)).lists(String(list.id)),
+  );
+
   const handler = $derived(isListed ? confirmRemove : addToList);
   const { color, variant, ...events } = $derived(
     useDangerButton({ isActive: isListed, color: "default" }),
@@ -81,5 +91,13 @@
     {:else}
       <BookmarkIcon {state} size="normal" />
     {/if}
+  {/snippet}
+
+  {#snippet action()}
+    <ViewListLink
+      href={listUrl}
+      label={i18n.viewLabel({ isListed, listName: list.name, title })}
+      tooltip={i18n.viewTooltip()}
+    />
   {/snippet}
 </DropdownItem>

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemIntl.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemIntl.ts
@@ -7,4 +7,6 @@ export type ListDropdownItemMeta = {
 export type ListDropdownItemIntl = {
   label: (meta: ListDropdownItemMeta) => string;
   text: (meta: ListDropdownItemMeta) => string;
+  viewLabel: (meta: ListDropdownItemMeta) => string;
+  viewTooltip: () => string;
 };

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemIntlProvider.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemIntlProvider.ts
@@ -10,4 +10,7 @@ export const ListDropdownItemIntlProvider: ListDropdownItemIntl = {
       ? m.button_label_remove_from_personal_list({ list: listName, title })
       : m.button_label_add_to_personal_list({ list: listName, title }),
   text: ({ listName }: ListDropdownItemMeta) => listName,
+  viewLabel: ({ listName }: ListDropdownItemMeta) =>
+    m.link_label_view_list({ name: listName }),
+  viewTooltip: () => m.tooltip_view_list(),
 };

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemProps.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemProps.ts
@@ -1,3 +1,4 @@
+import type { DropdownItemFlash } from '$lib/components/dropdown/DropdownItemFlash.ts';
 import type { UserList } from '$lib/requests/queries/users/userListsQuery.ts';
 import type { ListDropdownItemIntl } from './ListDropdownItemIntl.ts';
 
@@ -10,5 +11,6 @@ export type ListDropdownItemProps = {
   onLoading?: (isLoading: boolean) => void;
   title: string;
   isListed: boolean;
+  flash?: DropdownItemFlash | Nil;
   i18n?: ListDropdownItemIntl;
 };

--- a/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
@@ -2,6 +2,7 @@
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import DropdownGroup from "$lib/components/dropdown/DropdownGroup.svelte";
+  import type { DropdownItemFlash } from "$lib/components/dropdown/DropdownItemFlash";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -9,6 +10,7 @@
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import { useWatchlist } from "$lib/sections/media-actions/watchlist/useWatchlist";
   import { useAllPersonalLists } from "$lib/stores/useAllPersonalLists";
+  import { useBackgroundFlash } from "$lib/stores/useBackgroundFlash.svelte";
   import { useListedOnIds } from "$lib/stores/useListedOnIds";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -62,8 +64,49 @@
   const isLoading = $derived($isLoadingIds || $isLoadingLists);
   const isEmpty = $derived($lists.length === 0);
 
+  const watchlistFlash = useBackgroundFlash<DropdownItemFlash>();
+  let wasWatchlistUpdating = false;
+
   $effect(() => {
-    onLoading?.($isWatchlistUpdating);
+    const isUpdating = $isWatchlistUpdating;
+    onLoading?.(isUpdating);
+
+    if (wasWatchlistUpdating && !isUpdating) {
+      watchlistFlash.flash($isWatchlisted ? "purple" : "red");
+    }
+    wasWatchlistUpdating = isUpdating;
+  });
+
+  // Rows flash off the listed-ids diff instead of the request lifecycle -
+  // add/remove re-sorts the rows, and the server-state change is the one
+  // signal that survives that churn.
+  const rowFlash = useBackgroundFlash<{ id: number; color: DropdownItemFlash }>();
+  let previousListedIds: Set<number> | null = null;
+
+  $effect(() => {
+    if ($isLoadingIds) {
+      return;
+    }
+
+    const current = listedOnIdsSet;
+    const previous = previousListedIds;
+    previousListedIds = current;
+
+    if (previous == null) {
+      return;
+    }
+
+    const addedId = [...current].find((id) => !previous.has(id));
+    const removedId = [...previous].find((id) => !current.has(id));
+
+    if (addedId != null) {
+      rowFlash.flash({ id: addedId, color: "purple" });
+      return;
+    }
+
+    if (removedId != null) {
+      rowFlash.flash({ id: removedId, color: "red" });
+    }
   });
 </script>
 
@@ -76,6 +119,7 @@
         size="normal"
         isWatchlistUpdating={$isWatchlistUpdating}
         isWatchlisted={$isWatchlisted}
+        flash={watchlistFlash.flashing}
         onAdd={addToWatchlist}
         onRemove={confirmRemove}
       >
@@ -98,6 +142,9 @@
             {onLoading}
             {media}
             isListed={listedOnIdsSet.has(list.id)}
+            flash={rowFlash.flashing?.id === list.id
+              ? rowFlash.flashing.color
+              : undefined}
           />
         {/each}
       {/if}

--- a/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
@@ -11,6 +11,8 @@
   import { useAllPersonalLists } from "$lib/stores/useAllPersonalLists";
   import { useListedOnIds } from "$lib/stores/useListedOnIds";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import ViewListLink from "./_internal/ViewListLink.svelte";
   import ListDropdownItem from "./ListDropdownItem.svelte";
 
   const {
@@ -76,7 +78,15 @@
         isWatchlisted={$isWatchlisted}
         onAdd={addToWatchlist}
         onRemove={confirmRemove}
-      />
+      >
+        {#snippet action()}
+          <ViewListLink
+            href={UrlBuilder.lists.watchlist("me")}
+            label={m.link_label_view_watchlist()}
+            tooltip={m.tooltip_view_watchlist()}
+          />
+        {/snippet}
+      </WatchlistButton>
 
       {#if isEmpty && isLoading}
         <LoadingIndicator />
@@ -97,7 +107,9 @@
 
 <style>
   .lists-layout {
-    --dropdown-item-direction: row-reverse;
-    --dropdown-item-justify: space-between;
+    /* The group's list is overflow: hidden, which zeroes its automatic
+       min-size inside the drawer's scroll flexbox - without this wrapper the
+       group shrinks to fit and clips instead of letting the drawer scroll. */
+    flex-shrink: 0;
   }
 </style>

--- a/projects/client/src/lib/sections/components/lists-drawer/_internal/ViewListLink.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/_internal/ViewListLink.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import type { ViewListLinkProps } from "./ViewListLinkProps";
+
+  const { href, label, tooltip }: ViewListLinkProps = $props();
+
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+</script>
+
+<Tooltip content={tooltip} variant="compact" disabled={!$isMouse}>
+  <Link {href} {label} color="inherit">
+    <CaretRightIcon />
+  </Link>
+</Tooltip>

--- a/projects/client/src/lib/sections/components/lists-drawer/_internal/ViewListLinkProps.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/_internal/ViewListLinkProps.ts
@@ -1,0 +1,5 @@
+export type ViewListLinkProps = {
+  href: string;
+  label: string;
+  tooltip: string;
+};

--- a/projects/client/src/lib/sections/lists/user/_internal/ReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ReorderDrawer.svelte
@@ -7,10 +7,9 @@
   import { useConfirm } from "$lib/features/confirmation/useConfirm.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { useBackgroundFlash } from "$lib/stores/useBackgroundFlash.svelte";
   import { MEDIA_POSTER_PLACEHOLDER } from "$lib/utils/assets.ts";
   import { clamp } from "$lib/utils/number/clamp.ts";
-  import { time } from "$lib/utils/timing/time.ts";
-  import { onDestroy, tick } from "svelte";
   import { flip } from "svelte/animate";
   import { cubicOut } from "svelte/easing";
   import type { ReorderableListItem } from "./models/ReorderableListItem.ts";
@@ -43,8 +42,6 @@
 
   const { confirm } = useConfirm();
 
-  const flashDuration = time.seconds(1.5);
-
   let localOrder = $state<{
     signature: string;
     items: ReorderableListItem[];
@@ -54,8 +51,7 @@
   let instantPosterKeys = $state<readonly string[]>([]);
   let placeholderIndex = $state<number | null>(null);
   let dragGhost = $state<DragGhost | null>(null);
-  let flashKey = $state<string | null>(null);
-  let flashTimeout: ReturnType<typeof setTimeout> | null = null;
+  const movedRowFlash = useBackgroundFlash<string>();
 
   const rankOrderedItems = $derived(sortReorderableItems(items));
   const rankSignature = $derived(itemOrderSignature(rankOrderedItems));
@@ -153,7 +149,7 @@
     dragGhost = null;
 
     if (!cancelled && key != null) {
-      highlightMovedRow(key);
+      movedRowFlash.flash(key);
     }
   }
 
@@ -185,30 +181,8 @@
     }
 
     moveItemToIndex(key, targetIndex);
-    highlightMovedRow(key);
+    movedRowFlash.flash(key);
   }
-
-  async function highlightMovedRow(key: string) {
-    if (flashTimeout != null) {
-      clearTimeout(flashTimeout);
-    }
-
-    flashKey = null;
-
-    await tick();
-
-    flashKey = key;
-    flashTimeout = setTimeout(() => {
-      flashKey = null;
-      flashTimeout = null;
-    }, flashDuration);
-  }
-
-  onDestroy(() => {
-    if (flashTimeout != null) {
-      clearTimeout(flashTimeout);
-    }
-  });
 
   async function handleApply() {
     if (!canApply) {
@@ -303,10 +277,7 @@
     </ActionButton>
   {/snippet}
 
-  <div
-    class="reorder-drawer"
-    style="--reorder-flash-duration: {flashDuration}ms"
-  >
+  <div class="reorder-drawer">
     {#if !isLoaded}
       <div class="reorder-loading" role="status" aria-live="polite">
         <LoadingIndicator />
@@ -328,7 +299,7 @@
         >
           {#each renderRows as row (row.key)}
             {@const isFlashing = row.type === "item" &&
-            row.item.key === flashKey}
+            row.item.key === movedRowFlash.flashing}
             <tr
               data-reorder-key={row.type === "item" ? row.item.key : undefined}
               class:drag-placeholder={row.type === "placeholder"}
@@ -506,7 +477,8 @@
       pointer-events: none;
       background: var(--color-background-purple);
       opacity: 0;
-      animation: reorder-flash var(--reorder-flash-duration) ease-out;
+      animation: background-flash var(--animation-duration-background-flash)
+        ease-out;
     }
 
     &:first-child::after {
@@ -517,26 +489,6 @@
     &:last-child::after {
       border-start-end-radius: var(--border-radius-m);
       border-end-end-radius: var(--border-radius-m);
-    }
-  }
-
-  @keyframes reorder-flash {
-    0% {
-      opacity: 0.28;
-    }
-
-    35% {
-      opacity: 0.28;
-    }
-
-    100% {
-      opacity: 0;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .is-flashing td::after {
-      animation: none;
     }
   }
 

--- a/projects/client/src/lib/stores/useAllPersonalLists.ts
+++ b/projects/client/src/lib/stores/useAllPersonalLists.ts
@@ -1,15 +1,66 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
-import { userListsQuery } from '$lib/requests/queries/users/userListsQuery.ts';
+import {
+  useAllPagesInfiniteQuery,
+  useQuery,
+} from '$lib/features/query/useQuery.ts';
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+import { collaborationListsQuery } from '$lib/requests/queries/users/collaborationListsQuery.ts';
+import { personalListsQuery } from '$lib/requests/queries/users/personalListsQuery.ts';
+import {
+  type UserList,
+  userListsQuery,
+} from '$lib/requests/queries/users/userListsQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
+
+// The minimal lists payload carries no slugs, so overlay them from the list
+// summary queries - rows link to canonical list URLs once the summaries land
+// and fall back to id-based URLs until then.
+function withListSlugs(
+  list: UserList,
+  summary: MediaListSummary | undefined,
+): UserList {
+  if (!summary) {
+    return list;
+  }
+
+  return {
+    ...list,
+    slug: list.slug ?? summary.slug,
+    ownerSlug: list.ownerSlug ?? summary.user.slug,
+  };
+}
 
 export function useAllPersonalLists() {
   const lists = useQuery(userListsQuery());
+  const personal = useAllPagesInfiniteQuery(
+    personalListsQuery({ slug: 'me', limit: 1000 }),
+  );
+  const collaborations = useAllPagesInfiniteQuery(
+    collaborationListsQuery({ slug: 'me' }),
+  );
+
+  const summaries = combineLatest([personal, collaborations]).pipe(
+    map(([$personal, $collaborations]) =>
+      new Map(
+        [$personal, $collaborations]
+          .flatMap((query) =>
+            query.data?.pages.flatMap((page) => page.entries) ?? []
+          )
+          .map((summary) => [summary.id, summary] as const),
+      )
+    ),
+  );
 
   const isLoading = lists.pipe(map(toLoadingState));
 
   return {
-    lists: lists.pipe(map(($lists) => $lists.data ?? [])),
+    lists: combineLatest([lists, summaries]).pipe(
+      map(([$lists, $summaries]) =>
+        ($lists.data ?? []).map((list) =>
+          withListSlugs(list, $summaries.get(list.id))
+        )
+      ),
+    ),
     isLoading,
   };
 }

--- a/projects/client/src/lib/stores/useBackgroundFlash.svelte.ts
+++ b/projects/client/src/lib/stores/useBackgroundFlash.svelte.ts
@@ -1,0 +1,37 @@
+import { BACKGROUND_FLASH_DURATION } from '$lib/utils/constants.ts';
+import { onDestroy, tick } from 'svelte';
+
+export function useBackgroundFlash<T>(duration = BACKGROUND_FLASH_DURATION) {
+  let flashing = $state<T | null>(null);
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const clearFlashTimeout = () => {
+    if (timeout != null) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+
+  const flash = async (value: T) => {
+    clearFlashTimeout();
+
+    // Drop the value for a tick so consecutive flashes restart the animation.
+    flashing = null;
+    await tick();
+
+    flashing = value;
+    timeout = setTimeout(() => {
+      flashing = null;
+      timeout = null;
+    }, duration);
+  };
+
+  onDestroy(clearFlashTimeout);
+
+  return {
+    get flashing() {
+      return flashing;
+    },
+    flash,
+  };
+}

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -1,3 +1,11 @@
+import { time } from '$lib/utils/timing/time.ts';
+
+/**
+ * Keep in sync with --animation-duration-background-flash in
+ * style/animations/index.css.
+ */
+export const BACKGROUND_FLASH_DURATION = time.seconds(1.5);
+
 /**
  * This cover is the Alien Isolation cover.
  */

--- a/projects/client/src/style/animations/index.css
+++ b/projects/client/src/style/animations/index.css
@@ -1,6 +1,18 @@
 :root {
   --animation-duration-jiggle-wiggle: calc(var(--transition-increment) * 3);
   --animation-duration-loopy-loop: calc(var(--transition-increment) * 3);
+  /* Keep in sync with BACKGROUND_FLASH_DURATION in lib/utils/constants.ts. */
+  --animation-duration-background-flash: calc(var(--transition-increment) * 10);
+}
+
+@keyframes background-flash {
+  0%,
+  35% {
+    opacity: 0.28;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 @keyframes jiggle-wiggle {


### PR DESCRIPTION
# Summary

Adds direct navigation to lists from the **Manage lists** drawer (closes #3105). Each row is now a split control: the main area still toggles membership, and a new divided caret segment on the trailing edge links to the list page, with a "View list" tooltip on hover. The watchlist row gets the same treatment, linking to `/users/me/watchlist`.

As a follow-up sprinkle, adding or removing an item now flashes the row background using the same effect as list reordering: purple when added, muted red when removed.

# Changes

- `DropdownItem` gains an `action` snippet rendered as a divided trailing segment whose pointer/focus events never reach the row, with its own hover, active, and focus-ring styling, plus a `flash` variant (`data-flash`) that overlays the purple/red background animation.
- `ListDropdownItem` builds the list URL from `ownerSlug`/`slug` with a numeric-id fallback, and the drawer's rows read canonical slugs overlaid by `useAllPersonalLists` from the personal + collaboration list summary queries (the minimal v3 payload carries no slugs).
- `WatchlistButton` forwards `action` and `flash` to its dropdown-item rendering.
- `ListsDrawer` flashes rows off the listed-ids diff (survives the re-sort after toggling) and the watchlist row off the update lifecycle; the row layout switches from `row-reverse` to bookmark-leading with the caret trailing.
- The reorder flash is now shared: `background-flash` keyframes + `--animation-duration-background-flash` token in `style/animations`, a `useBackgroundFlash` rune hook, and `BACKGROUND_FLASH_DURATION`; `ReorderDrawer` consumes all three instead of its local copies.
- New i18n keys: `link_label_view_list`, `tooltip_view_list`, `link_label_view_watchlist`, `tooltip_view_watchlist`.

# Screenshots

#### View list icon + tooltip
<img width="1788" height="969" alt="image" src="https://github.com/user-attachments/assets/fa1eb143-5478-4376-a4b8-3757e626c34c" />

#### Highlight after adding to a list
<img width="1788" height="1144" alt="Xnapper-2026-08-20-13 20 29" src="https://github.com/user-attachments/assets/f370a913-3615-4ffe-86e5-7be5dd2652ef" />

#### What it looked like before
<img width="1788" height="965" alt="before" src="https://github.com/user-attachments/assets/8435dbda-9660-4602-ab2e-32ad6c0ed05a" />

# Notes

- Reduced motion is respected for free: the flash duration token derives from `--transition-increment`, which collapses to `0ms` under `prefers-reduced-motion`.
- Cancelling the remove confirmation never flashes, since the listed-ids never change.