### PR TITLE
feat(ds): text labels and a sliding underline replace the pill tab track

### DIFF
--- a/projects/client/src/lib/components/tabs/TabView.svelte
+++ b/projects/client/src/lib/components/tabs/TabView.svelte
@@ -1,34 +1,93 @@
 <script lang="ts">
   import { Tabs } from "bits-ui";
-  import { lineClamp } from "../text/lineClamp";
+  import { languageTag } from "$lib/features/i18n/index.ts";
+  import { toHumanCount } from "$lib/utils/formatting/number/toHumanCount.ts";
   import type { TabViewProps } from "./models/TabViewProps";
 
   const { value, tabs, onChange, tabPosition = "top" }: TabViewProps = $props();
 
-  const activeIndex = $derived(tabs.findIndex((t) => t.value === value));
+  let rail = $state<HTMLElement>();
+  let underline = $state({ offset: 0, width: 0 });
+
+  const captureRail = (node: HTMLElement) => {
+    rail = node;
+    return () => (rail = undefined);
+  };
+
+  /*
+   * The underline hugs the active label instead of a fixed column, so its box
+   * has to be measured. The offset is taken from the rail's inline-start edge
+   * and replayed through --rtl-sign, keeping the slide direction-correct.
+   */
+  const measure = (node: HTMLElement) => {
+    const triggers = node.querySelectorAll<HTMLElement>(".trakt-tab-trigger");
+    const active = Array.from(triggers).find(
+      (trigger) => trigger.dataset.value === value,
+    );
+
+    if (!active) {
+      return;
+    }
+
+    const railBox = node.getBoundingClientRect();
+    const activeBox = active.getBoundingClientRect();
+    const isRtl = getComputedStyle(node).direction === "rtl";
+
+    underline = {
+      offset: isRtl
+        ? railBox.right - activeBox.right
+        : activeBox.left - railBox.left,
+      width: activeBox.width,
+    };
+  };
+
+  $effect(() => {
+    const node = rail;
+
+    if (!node) {
+      return;
+    }
+
+    measure(node);
+
+    /*
+     * Label widths move with font loading, container resizes and count
+     * updates - observing the triggers covers all three.
+     */
+    const observer = new ResizeObserver(() => measure(node));
+    observer.observe(node);
+    node
+      .querySelectorAll(".trakt-tab-trigger")
+      .forEach((trigger) => observer.observe(trigger));
+
+    return () => observer.disconnect();
+  });
 </script>
 
-<div
-  class="trakt-tab-view"
-  data-tab-position={tabPosition}
-  style="--tab-count: {tabs.length}; --active-index: {activeIndex}"
->
+<div class="trakt-tab-view" data-tab-position={tabPosition}>
   <Tabs.Root {value} onValueChange={onChange} class="trakt-tabs-root">
-    <Tabs.List class="trakt-tabs-list">
-      <div class="trakt-tab-indicator"></div>
-      {#each tabs as tab (tab.value)}
-        <Tabs.Trigger class="trakt-tab-trigger" value={tab.value}>
-          {#if tab.icon}
-            <span class="trakt-tab-icon">
-              {@render tab.icon()}
+    <div class="tab-rail" {@attach captureRail}>
+      <Tabs.List class="trakt-tabs-list">
+        {#each tabs as tab (tab.value)}
+          <Tabs.Trigger class="trakt-tab-trigger" value={tab.value}>
+            <span class="tab-label uppercase bold small ellipsis">
+              {tab.label}
             </span>
-          {/if}
-          <span class="capitalize ellipsis" use:lineClamp={{ lines: 2 }}>
-            {tab.label}
-          </span>
-        </Tabs.Trigger>
-      {/each}
-    </Tabs.List>
+            {#if tab.count != null}
+              <span class="tab-count">
+                {toHumanCount(tab.count, languageTag())}
+              </span>
+            {/if}
+          </Tabs.Trigger>
+        {/each}
+      </Tabs.List>
+
+      <div
+        class="tab-underline"
+        class:is-measured={underline.width > 0}
+        style="--tab-underline-offset: {underline.offset}px; --tab-underline-width: {underline.width}px"
+      ></div>
+    </div>
 
     {#each tabs as tab (tab.value)}
       <Tabs.Content value={tab.value}>
@@ -47,9 +106,13 @@
 
 <style>
   .trakt-tab-view {
-    --tab-list-padding: var(--ni-4);
-    --tab-list-gap: var(--gap-xxs);
-    --tab-border-radius: var(--border-radius-m);
+    --tab-rule-thickness: var(--border-thickness-xxs);
+    /*
+     * The label rides close to its underline; the slack that keeps the tap
+     * target at 40px is pushed to the far side of the label instead.
+     */
+    --tab-label-gap: var(--gap-xs);
+    --tab-label-inset: var(--ni-16);
 
     :global(.trakt-tabs-root) {
       display: flex;
@@ -57,103 +120,108 @@
       gap: var(--gap-m);
     }
 
-    :global(.trakt-tabs-list) {
-      background-color: var(--color-tablist-background);
-      padding: var(--tab-list-padding);
-      border-radius: var(--tab-border-radius);
-
-      display: grid;
-      grid-template-columns: repeat(var(--tab-count), minmax(0, 1fr));
-      gap: var(--tab-list-gap);
-
+    .tab-rail {
       position: relative;
+      border-block-end: var(--tab-rule-thickness) solid var(--color-tab-rule);
     }
 
-    .trakt-tab-indicator {
-      --horizontal-padding: calc(2 * var(--tab-list-padding));
-      --total-gap-size: calc((var(--tab-count) - 1) * var(--tab-list-gap));
-      --available-width: calc(
-        100% - var(--horizontal-padding) - var(--total-gap-size)
-      );
-      --tab-width: calc(var(--available-width) / var(--tab-count));
-
-      position: absolute;
-      margin-inline-start: var(--tab-list-padding);
-
-      top: var(--tab-list-padding);
-      bottom: var(--tab-list-padding);
-      inset-inline-start: 0;
-      width: var(--tab-width);
-      transform: translateX(
-        calc(
-          var(--rtl-sign) * var(--active-index) * (100% + var(--tab-list-gap))
-        )
-      );
-
-      /* Shorthand so consumers can supply a gradient via the token. */
-      background: var(--color-tab-background);
-      border-radius: var(--tab-border-radius);
-
-      transition: transform var(--transition-increment) ease-in-out;
-      will-change: transform;
-      pointer-events: none;
+    :global(.trakt-tabs-list) {
+      display: flex;
+      align-items: flex-end;
+      gap: var(--gap-l);
     }
 
     :global(.trakt-tab-trigger) {
       -webkit-tap-highlight-color: transparent;
 
       display: flex;
-      align-items: center;
-      justify-content: center;
+      align-items: baseline;
       gap: var(--gap-xxs);
 
+      min-width: 0;
       min-height: var(--ni-40);
-      position: relative;
+      padding-block: var(--tab-label-inset) var(--tab-label-gap);
+      padding-inline: 0;
 
       border: none;
-      background-color: transparent;
+      background: none;
 
-      color: var(--color-text-primary);
-      border-radius: var(--tab-border-radius);
-
-      transition: background-color var(--transition-increment) ease-in-out;
+      color: var(--color-tab-text);
+      transition: color var(--transition-increment) ease-in-out;
 
       &[data-state="inactive"] {
         cursor: pointer;
       }
 
-      &[data-state="active"] {
+      &[data-state="active"],
+      &:hover {
         color: var(--color-tab-active-text);
       }
 
-      &:hover:not([data-state="active"]) {
-        background-color: var(--color-tab-hover-background);
-      }
-
       &:focus-visible {
-        outline: var(--border-thickness-xs) solid var(--shade-10);
-        color: var(--shade-10);
-        background-color: var(--shade-700);
+        outline: var(--border-thickness-xxs) solid var(--color-tab-indicator);
+        outline-offset: var(--ni-2);
+        border-radius: var(--border-radius-xs);
+
+        color: var(--color-tab-active-text);
       }
     }
 
-    .trakt-tab-icon {
-      display: flex;
-      flex-shrink: 0;
-
-      :global(svg) {
-        width: var(--ni-16);
-        height: var(--ni-16);
-      }
+    .tab-label {
+      /* Uppercase labels need the extra tracking to stay readable. */
+      letter-spacing: 0.08em;
     }
 
-    .trakt-tab-content {
-      padding: 0 var(--ni-8);
+    .tab-count {
+      color: var(--color-tab-count);
+    }
+
+    .tab-underline {
+      position: absolute;
+      inset-block-end: calc(-1 * var(--tab-rule-thickness));
+      inset-inline-start: 0;
+
+      width: var(--tab-underline-width);
+      height: var(--border-thickness-xs);
+      transform: translateX(
+        calc(var(--rtl-sign) * var(--tab-underline-offset))
+      );
+
+      background: var(--color-tab-indicator);
+      border-radius: var(--border-radius-xs);
+
+      /* Hidden until the first measurement lands, so it never flashes at 0. */
+      opacity: 0;
+      pointer-events: none;
+
+      transition:
+        transform var(--transition-increment) ease-in-out,
+        width var(--transition-increment) ease-in-out,
+        opacity var(--transition-increment) ease-in-out;
+
+      &.is-measured {
+        opacity: 1;
+      }
     }
 
     &[data-tab-position="bottom"] {
       :global(.trakt-tabs-root) {
         flex-direction: column-reverse;
+      }
+
+      .tab-rail {
+        border-block-end: none;
+        border-block-start: var(--tab-rule-thickness) solid
+          var(--color-tab-rule);
+      }
+
+      .tab-underline {
+        inset-block-end: auto;
+        inset-block-start: calc(-1 * var(--tab-rule-thickness));
+      }
+
+      :global(.trakt-tab-trigger) {
+        padding-block: var(--tab-label-gap) var(--tab-label-inset);
       }
     }
   }

--- a/projects/client/src/lib/components/tabs/models/TabViewProps.ts
+++ b/projects/client/src/lib/components/tabs/models/TabViewProps.ts
@@ -3,7 +3,7 @@ import type { Snippet } from 'svelte';
 type TabView = {
   value: string;
   label: string;
-  icon?: Snippet;
+  count?: number;
   content: Snippet;
   keepMounted?: boolean;
 };

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterTabs.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterTabs.svelte
@@ -106,18 +106,6 @@
 </div>
 
 <style>
-  .trakt-filter-tabs {
-    --color-tablist-background: var(--color-filter-tablist-background);
-    --color-tab-background: var(--color-filter-tab-background);
-    --color-tab-active-text: var(--color-filter-tab-active-text);
-    --tab-list-padding: 0;
-
-    :global(.trakt-tabs-list) {
-      width: 100%;
-      height: var(--ni-40);
-    }
-  }
-
   .trakt-filters-content {
     display: flex;
     flex-direction: column;

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -342,7 +342,7 @@
     aspect-ratio: 2 / 3;
     overflow: hidden;
 
-    background: var(--color-tablist-background);
+    background: var(--color-card-background);
     border: var(--border-thickness-m) solid transparent;
     border-radius: var(--border-radius-m);
 

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import Drawer from "$lib/components/drawer/Drawer.svelte";
-  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
-  import InfoIcon from "$lib/components/icons/InfoIcon.svelte";
-  import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
   import TabView from "$lib/components/tabs/TabView.svelte";
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -161,18 +158,6 @@
   </Tooltip>
 {/snippet}
 
-{#snippet infoIcon()}
-  <InfoIcon />
-{/snippet}
-
-{#snippet reviewsIcon()}
-  <CommentIcon />
-{/snippet}
-
-{#snippet episodesIcon()}
-  <PlayIcon />
-{/snippet}
-
 {#snippet infoContent()}
   <div class="episode-info-content">
     {#if $episodeEntry}
@@ -263,19 +248,16 @@
           {
             value: "info",
             label: m.tab_text_seasons_info(),
-            icon: infoIcon,
             content: infoContent,
           },
           {
             value: "reviews",
             label: m.tab_text_seasons_reviews(),
-            icon: reviewsIcon,
             content: reviewsContent,
           },
           {
             value: "episodes",
             label: m.tab_text_seasons_episodes(),
-            icon: episodesIcon,
             content: episodesContent,
           },
         ]}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Drawer from "$lib/components/drawer/Drawer.svelte";
-  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
-  import InfoIcon from "$lib/components/icons/InfoIcon.svelte";
-  import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import TabView from "$lib/components/tabs/TabView.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -56,18 +53,6 @@
     {currentSeason}
     urlBuilder={buildSeasonLink}
   />
-{/snippet}
-
-{#snippet episodesIcon()}
-  <PlayIcon />
-{/snippet}
-
-{#snippet overviewIcon()}
-  <InfoIcon />
-{/snippet}
-
-{#snippet reviewsIcon()}
-  <CommentIcon />
 {/snippet}
 
 {#snippet episodesContent()}
@@ -129,20 +114,17 @@
           {
             value: "episodes",
             label: m.tab_text_seasons_episodes(),
-            icon: episodesIcon,
             content: episodesContent,
           },
           {
             value: "overview",
             label: m.tab_text_seasons_info(),
-            icon: overviewIcon,
             content: overviewContent,
             keepMounted: true,
           },
           {
             value: "reviews",
             label: m.tab_text_seasons_reviews(),
-            icon: reviewsIcon,
             content: reviewsContent,
           },
         ]}

--- a/projects/client/src/lib/sections/vip/_internal/UsageTabs.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageTabs.svelte
@@ -77,14 +77,6 @@
 
     :global(.trakt-tab-view) {
       width: 100%;
-
-      // The default gray tab chrome clashes with the purple VIP surface;
-      // recess the tab list into the card, give the active pill the VIP badge
-      // gradient, and swap the gray hover for a purple tint.
-      --color-tablist-background: var(--color-vip-tablist-background);
-      --color-tab-background: var(--background-vip-tab);
-      --color-tab-hover-background: var(--color-vip-tab-hover-background);
-      --color-tab-active-text: var(--color-foreground-vip-badge);
     }
   }
 </style>

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -309,28 +309,15 @@
     var(--purple-60),
     var(--purple-90)
   );
-  --color-vip-tablist-background: color-mix(
-    in srgb,
-    var(--purple-900) 6%,
-    transparent
-  );
-  --background-vip-tab: linear-gradient(
-    135deg,
-    var(--purple-400),
-    var(--purple-600)
-  );
-  --color-vip-tab-hover-background: color-mix(
-    in srgb,
-    var(--purple-500) 10%,
-    transparent
-  );
   /*
    * Tab view
    */
-  --color-tablist-background: var(--shade-100);
-  --color-tab-background: var(--shade-10);
-  --color-tab-hover-background: var(--shade-70);
+  /* Lighter than --color-text-secondary so the active label reads as active. */
+  --color-tab-text: var(--shade-600);
   --color-tab-active-text: var(--color-text-primary);
+  --color-tab-count: var(--shade-600);
+  --color-tab-indicator: var(--purple-600);
+  --color-tab-rule: var(--shade-100);
 
   /*
    * Streak
@@ -369,13 +356,6 @@
    */
   --color-confirmation-destructive-background: var(--red-300);
   --color-confirmation-destructive-foreground: var(--red-1000);
-
-  /*
-   * Filters
-   */
-  --color-filter-tablist-background: var(--shade-100);
-  --color-filter-tab-background: var(--purple-700);
-  --color-filter-tab-active-text: var(--shade-10);
 
   /*
    * Data visualization
@@ -817,28 +797,14 @@
     color-mix(in srgb, var(--purple-500) 10%, var(--shade-910)),
     color-mix(in srgb, var(--purple-500) 7%, var(--shade-940))
   );
-  --color-vip-tablist-background: color-mix(
-    in srgb,
-    var(--shade-1000) 35%,
-    transparent
-  );
-  --background-vip-tab: linear-gradient(
-    135deg,
-    var(--purple-400),
-    var(--purple-600)
-  );
-  --color-vip-tab-hover-background: color-mix(
-    in srgb,
-    var(--purple-400) 10%,
-    transparent
-  );
   /*
    * Tab view
    */
-  --color-tablist-background: var(--shade-800);
-  --color-tab-background: var(--shade-500);
-  --color-tab-hover-background: var(--shade-700);
+  --color-tab-text: var(--color-text-secondary);
   --color-tab-active-text: var(--color-text-primary);
+  --color-tab-count: var(--color-text-secondary);
+  --color-tab-indicator: var(--purple-400);
+  --color-tab-rule: var(--shade-900);
 
   /*
    * Streak
@@ -877,13 +843,6 @@
    */
   --color-confirmation-destructive-background: var(--red-200);
   --color-confirmation-destructive-foreground: var(--red-1000);
-
-  /*
-   * Filters
-   */
-  --color-filter-tablist-background: var(--shade-910);
-  --color-filter-tab-background: var(--purple-700);
-  --color-filter-tab-active-text: var(--shade-10);
 
   /*
    * Data visualization (dark surfaces)


### PR DESCRIPTION
## Visuals

Filters

<img width="401" height="731" alt="Screenshot 2026-08-21 at 15 12 37" src="https://github.com/user-attachments/assets/e7ca769f-9ab9-4eaa-a667-74eff9f50b05" />

Seasons

<img width="484" height="823" alt="Screenshot 2026-08-21 at 15 12 53" src="https://github.com/user-attachments/assets/5395fb12-2e89-458f-be15-1919c37e053f" />

Settings/Data

<img width="670" height="384" alt="Screenshot 2026-08-21 at 15 13 38" src="https://github.com/user-attachments/assets/a707e42f-ad6f-400f-ac97-664ad9844c56" />


## The Setup

Every tabbed surface in the app wears the same grey pill track: a recessed
`--color-tablist-background` bar, equal-width columns, and a filled pill sliding
behind the active label. Three problems with it.

It is a lot of chrome for a two-word choice. `Simple`/`Advanced` gets the same
40px slab as five import sources. Equal columns mean `Info` is padded out to the
width of `Episodes` whether it needs it or not.

And the pill fights whatever it sits on. `UsageTabs` had to override four
tokens to keep the grey from clashing with the VIP card's purple glow;
`FilterTabs` overrode three more plus the list geometry. Every surface that
wanted to look right had to re-skin the component.

This swaps the whole thing for type: bold uppercase labels on a hairline rule,
with a purple underline that slides to the active one.

## What Changes

One component, so all seven surfaces move together:

| Surface                        | Tabs                              |
| ------------------------------ | --------------------------------- |
| Season drawer                  | Episodes · Info · Reviews         |
| Episode drawer                 | Info · Reviews · Episodes         |
| Filter sidebar                 | Simple · Advanced                 |
| Settings → Data → Import       | TV Time · IMDb · Letterboxd · JSON · CSV |
| Import results                 | Matches · Skipped                 |
| Settings → Plex                | Sync · Webhook                    |
| VIP account                    | Usage · History                   |

Icons come out of the two drawers — the label and its underline carry the state
now, and the mockup this follows is text-only.

## How It Works

**The underline is measured, not gridded.** Labels no longer share equal
columns, so there is no column arithmetic to position it with. The component
reads the active trigger's box against the rail and drives the underline from
two custom properties. Offsets are taken from the rail's *inline-start* edge and
replayed through `--rtl-sign`, so the slide points the right way in RTL (checked
in `fa-IR` direction, not assumed). A `ResizeObserver` on the triggers
re-measures on font load, container resize and label changes, and the underline
stays at `opacity: 0` until the first measurement lands so it never flashes at
position 0.

**Spacing puts the slack on the far side of the label.** The trigger keeps a
40px tap target, but its padding is asymmetric: the label sits ~8px from its
underline and the remaining height goes above it. `tabPosition="bottom"` (the
mobile filter drawer) flips both the rule and the padding, so its labels hug
their underline the same way.

**Tokens, not per-surface overrides.** Deleted: `--color-tablist-background`,
`--color-tab-background`, `--color-tab-hover-background`, the three
`--color-filter-tab-*` and the three VIP tab tokens — all dead once the pill is
gone. Added to both themes: `--color-tab-text`, `--color-tab-count`,
`--color-tab-indicator`, `--color-tab-rule`. Light mode deliberately uses
`--shade-600` for inactive labels rather than `--color-text-secondary`, which is
`--shade-800` and sits so close to the active `--shade-900` that the two states
were indistinguishable without the underline.

`ImportComplete` borrowed the old tablist colour for its candidate-poster
placeholder; that now points at `--color-card-background`.

**One thing to argue about:** the tab model gained an optional `count` (the
mockup showed `EPISODES 8`), rendered beside the label through `toHumanCount`.
No caller wires one — we tried it on the season drawer's Episodes tab and it
read as noise next to the `10 eps.` heading right below it. Reviews is where a
count would actually earn its place, and that needs the comments query lifted
out of `InlineComments`. Happy to strip the field until then if you'd rather not
carry it.

## Testing

`deno fmt` and `svelte-check` clean (9551 files, 0 errors, 0 warnings). The unit
suite passes on this code, though it was run from the main worktree — a fresh
worktree resolves a different `vite` and every spec dies loading vitest's
reporter. No spec touches these files.

Visually verified in dark, light and RTL, plus hover and tab-switching, on the
real season and episode drawers and on the VIP glow card — the surface that
needed the most overrides before now needs none.
