### PR TITLE
feat(settings): export before clearing, cleaning up or deleting

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5144,6 +5144,55 @@
         }
       }
     },
+    "switch_label_export_before_destructive": {
+      "default": "Export my data first",
+      "description": "Label for the switch, enabled by default, that runs a raw data export before a destructive action such as clearing data, cleaning up history or deleting an account."
+    },
+    "description_export_before_destructive": {
+      "default": "Downloads a ZIP of your data before anything is removed.",
+      "description": "Hint explaining what the export switch inside a destructive confirmation dialog does."
+    },
+    "header_exporting_data": {
+      "default": "Exporting your data",
+      "description": "Title of the notification shown while a raw data export runs ahead of a destructive action."
+    },
+    "button_text_stop_export": {
+      "default": "Stop Exporting",
+      "description": "Text for the button that stops an in-progress data export."
+    },
+    "confirmation_title_proceed_after_partial_export": {
+      "default": "Export incomplete",
+      "description": "Title of the confirmation dialog shown when a data export finished with failures, asking whether the destructive action should still run."
+    },
+    "warning_prompt_partial_export_one": {
+      "default": "1 of {total} sections failed to export. Continue anyway?",
+      "description": "Warning prompt shown when exactly one section failed to export, asking whether the destructive action should still run.",
+      "variables": {
+        "total": {
+          "type": "number"
+        }
+      }
+    },
+    "warning_prompt_partial_export_other": {
+      "default": "{failed} of {total} sections failed to export. Continue anyway?",
+      "description": "Warning prompt shown when several sections failed to export, asking whether the destructive action should still run.",
+      "variables": {
+        "failed": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        }
+      }
+    },
+    "confirmation_title_stop_export": {
+      "default": "Stop exporting?",
+      "description": "Title of the confirmation shown when navigating away while a data export is running."
+    },
+    "warning_prompt_cancel_export": {
+      "default": "Navigating away will stop exporting your data. Are you sure?",
+      "description": "Warning prompt shown when navigating away while a data export is running ahead of a destructive action."
+    },
     "header_import": {
       "default": "Import",
       "description": "Header for the settings section that allows users to import their data from third-party services."

--- a/projects/client/src/lib/components/buttons/AutoCloseButton.svelte
+++ b/projects/client/src/lib/components/buttons/AutoCloseButton.svelte
@@ -8,6 +8,7 @@
     onclick: () => void;
     label: string;
     durationMs?: number;
+    persistent?: boolean;
   } & Pick<TraktActionButtonProps, "style" | "color">;
 
   const {
@@ -16,6 +17,7 @@
     style = "ghost",
     color,
     durationMs,
+    persistent,
   }: AutoCloseButtonProps = $props();
 </script>
 
@@ -24,6 +26,7 @@
   use:autoDismiss={{
     onDismiss: onclick,
     durationMs,
+    persistent,
   }}
 >
   <ActionButton {onclick} {label} {style} {color} size="small">

--- a/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
+++ b/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
@@ -4,6 +4,7 @@
   import type { Confirmation } from "$lib/features/confirmation/models/Confirmation";
   import type { ConfirmationAction } from "$lib/features/confirmation/models/ConfirmationAction";
   import * as m from "$lib/features/i18n/messages.ts";
+  import Switch from "$lib/components/toggles/Switch.svelte";
   import type { Snippet } from "svelte";
   import Modal from "./Modal.svelte";
 
@@ -16,17 +17,22 @@
     onAction,
     operation,
     challenge,
+    preflight,
     content,
   }: Omit<Confirmation, "message"> & {
     message: string;
     content?: Snippet;
-    onAction: (action: ConfirmationAction) => void;
+    onAction: (action: ConfirmationAction, isPreflightEnabled: boolean) => void;
   } = $props();
 
   const isDestructive = $derived(operation === "destructive");
   const isPreventative = $derived(operation === "preventative");
   const cancelText = $derived(externalCancelText ?? m.button_text_cancel());
 
+  let preflightOverride = $state<boolean | null>(null);
+  const isPreflightEnabled = $derived(
+    preflightOverride ?? preflight?.isEnabledByDefault ?? false,
+  );
   let challengeInput = $state("");
   const isConfirmDisabled = $derived(
     challenge != null &&
@@ -34,7 +40,7 @@
   );
 </script>
 
-<Modal onClose={() => onAction("cancel")}>
+<Modal onClose={() => onAction("cancel", isPreflightEnabled)}>
   <div class="trakt-confirmation-content">
     <h2 class="title bold">{title}</h2>
     <p class="trakt-confirmation-message secondary">{message}</p>
@@ -45,6 +51,22 @@
     {#if content}
       <div class="trakt-confirmation-slot">
         {@render content()}
+      </div>
+    {/if}
+
+    {#if preflight}
+      <div class="trakt-confirmation-preflight">
+        <div class="preflight-copy">
+          <p aria-hidden="true">{preflight.label}</p>
+          {#if preflight.hint}
+            <p class="small secondary">{preflight.hint}</p>
+          {/if}
+        </div>
+        <Switch
+          label={preflight.label}
+          checked={isPreflightEnabled}
+          onclick={() => (preflightOverride = !isPreflightEnabled)}
+        />
       </div>
     {/if}
 
@@ -68,7 +90,7 @@
         style={isPreventative ? "flat" : "outline"}
         color={isPreventative ? "blue" : "default"}
         label={cancelText}
-        onclick={() => onAction("cancel")}
+        onclick={() => onAction("cancel", isPreflightEnabled)}
       >
         {cancelText}
       </Button>
@@ -79,7 +101,7 @@
         color={isDestructive ? "custom" : "default"}
         label={buttonText}
         disabled={isConfirmDisabled}
-        onclick={() => onAction("confirm")}
+        onclick={() => onAction("confirm", isPreflightEnabled)}
       >
         {buttonText}
       </Button>
@@ -98,6 +120,36 @@
 
   .trakt-confirmation-slot {
     margin-top: var(--ni-8);
+  }
+
+  .trakt-confirmation-preflight {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-m);
+
+    box-sizing: border-box;
+    padding: var(--gap-m);
+    margin-top: var(--ni-8);
+
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-text-primary) 8%, transparent);
+    border-radius: var(--border-radius-m);
+    background: color-mix(in srgb, var(--color-text-primary) 3%, transparent);
+  }
+
+  .trakt-confirmation-preflight :global(.trakt-switch) {
+    flex-shrink: 0;
+  }
+
+  .preflight-copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-4);
+  }
+
+  .preflight-copy p {
+    margin: 0;
   }
 
   .trakt-confirmation-challenge {

--- a/projects/client/src/lib/components/snackbar/Snackbar.svelte
+++ b/projects/client/src/lib/components/snackbar/Snackbar.svelte
@@ -3,7 +3,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
-  import { onMount } from "svelte";
+  import { onMount, type Snippet } from "svelte";
   import { fly } from "svelte/transition";
 
   type SnackbarAction = {
@@ -12,16 +12,22 @@
     onAction: () => void;
   };
 
-  type SnackbarProps = {
-    open: boolean;
-    onDismiss: () => void;
-    title?: string;
-    message: string;
-    href?: string;
-    action?: SnackbarAction;
-    variant?: "default" | "error";
-    dismissDurationMs?: number;
-  };
+  type SnackbarContent =
+    | { message: string; href?: string; children?: never }
+    | { message?: never; href?: never; children: Snippet };
+
+  type SnackbarProps =
+    & {
+      open: boolean;
+      onDismiss: () => void;
+      title?: string;
+      action?: SnackbarAction;
+      variant?: "default" | "error";
+      dismissDurationMs?: number;
+      persistent?: boolean;
+      dismissible?: boolean;
+    }
+    & SnackbarContent;
 
   const {
     open,
@@ -29,9 +35,12 @@
     title,
     message,
     href,
+    children,
     action,
     variant = "default",
     dismissDurationMs,
+    persistent,
+    dismissible = true,
   }: SnackbarProps = $props();
 
   let navbarHeight = $state(0);
@@ -101,19 +110,28 @@
     {/if}
 
     <div class="snackbar-content">
-      <p class="snackbar-message">
-        {#if href}
-          <MessageWithLink {message} {href} target="_blank" />
-        {:else}
-          {message}
-        {/if}
-      </p>
+      {#if children}
+        <div class="snackbar-message">
+          {@render children()}
+        </div>
+      {:else}
+        <p class="snackbar-message">
+          {#if href}
+            <MessageWithLink {message} {href} target="_blank" />
+          {:else}
+            {message}
+          {/if}
+        </p>
+      {/if}
       {@render actionButton()}
-      <AutoCloseButton
-        onclick={onDismiss}
-        label={m.button_label_close()}
-        durationMs={dismissDurationMs}
-      />
+      {#if dismissible}
+        <AutoCloseButton
+          onclick={onDismiss}
+          label={m.button_label_close()}
+          durationMs={dismissDurationMs}
+          {persistent}
+        />
+      {/if}
     </div>
   </div>
 {/if}

--- a/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
+++ b/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
@@ -31,10 +31,11 @@
     cancelText={$activeConfirmation.cancelText}
     operation={$activeConfirmation.operation}
     challenge={$activeConfirmation.challenge}
+    preflight={$activeConfirmation.preflight}
     content={ContentComponent ? contentSlot : undefined}
-    onAction={(action) => {
+    onAction={(action, isPreflightEnabled) => {
       if (action === "confirm") {
-        $activeConfirmation.onConfirm();
+        $activeConfirmation.onConfirm(isPreflightEnabled);
       }
 
       if (action === "cancel") {

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
@@ -4,7 +4,7 @@ import type { ConfirmationParams } from '../models/ConfirmationParams.ts';
 import type { ConfirmationType } from '../models/ConfirmationType.ts';
 
 export type ConfirmationRequest = Confirmation & {
-  onConfirm: () => void;
+  onConfirm: (isPreflightEnabled: boolean) => void;
   onCancel?: () => void;
   params: ConfirmationParams<ConfirmationType>;
 };

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -1,5 +1,6 @@
 import * as m from '$lib/features/i18n/messages.ts';
 import type { Confirmation } from '../models/Confirmation.ts';
+import type { ConfirmationPreflight } from '../models/ConfirmationPreflight.ts';
 import type { ConfirmationParams } from '../models/ConfirmationParams.ts';
 import { ConfirmationType } from '../models/ConfirmationType.ts';
 import { getWarningMessage } from './getWarningMessage.ts';
@@ -7,6 +8,12 @@ import { getWarningMessage } from './getWarningMessage.ts';
 type ConfirmationBuilder<T extends ConfirmationType> = (
   props: ConfirmationParams<T>,
 ) => Confirmation;
+
+const toExportFirstPreflight = (): ConfirmationPreflight => ({
+  label: m.switch_label_export_before_destructive(),
+  hint: m.description_export_before_destructive(),
+  isEnabledByDefault: true,
+});
 
 type ConfirmationBuilders = {
   [T in ConfirmationType]: ConfirmationBuilder<T>;
@@ -137,6 +144,7 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
       value: props.username,
       placeholder: props.username,
     },
+    preflight: toExportFirstPreflight(),
   }),
   [ConfirmationType.SimpleFilters]: () => ({
     title: m.confirmation_title_reset_filters(),
@@ -163,11 +171,29 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     message: m.warning_prompt_cancel_clear(),
     operation: 'destructive',
   }),
+  [ConfirmationType.CancelExport]: () => ({
+    title: m.confirmation_title_stop_export(),
+    buttonText: m.button_text_stop_export(),
+    message: m.warning_prompt_cancel_export(),
+    operation: 'destructive',
+  }),
+  [ConfirmationType.ProceedAfterPartialExport]: (props) => ({
+    title: m.confirmation_title_proceed_after_partial_export(),
+    buttonText: m.button_text_continue(),
+    message: props.failed === 1
+      ? m.warning_prompt_partial_export_one({ total: props.total })
+      : m.warning_prompt_partial_export_other({
+        failed: props.failed,
+        total: props.total,
+      }),
+    operation: 'destructive',
+  }),
   [ConfirmationType.ClearData]: (props) => ({
     title: m.confirmation_title_clear_data(),
     buttonText: m.button_text_clear_now(),
     message: m.warning_prompt_clear_data({ source: props.sourceText }),
     operation: 'destructive',
+    preflight: toExportFirstPreflight(),
   }),
   [ConfirmationType.CleanUpHistory]: (props) => ({
     title: m.confirmation_title_clean_up_history(),
@@ -176,6 +202,7 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
       ? m.warning_prompt_clean_up_history({ count: props.count })
       : m.warning_prompt_clean_up_history_newest({ count: props.count }),
     operation: 'destructive',
+    preflight: toExportFirstPreflight(),
   }),
   [ConfirmationType.HideRecommendation]: (props) => ({
     title: m.confirmation_title_hide_recommendation(),

--- a/projects/client/src/lib/features/confirmation/models/Confirmation.ts
+++ b/projects/client/src/lib/features/confirmation/models/Confirmation.ts
@@ -1,4 +1,5 @@
 import type { ConfirmationChallenge } from './ConfirmationChallenge.ts';
+import type { ConfirmationPreflight } from './ConfirmationPreflight.ts';
 import type { ConfirmationOperation } from './ConfirmationOperation.ts';
 
 export type Confirmation = {
@@ -9,4 +10,5 @@ export type Confirmation = {
   cancelText?: string;
   operation: ConfirmationOperation;
   challenge?: ConfirmationChallenge;
+  preflight?: ConfirmationPreflight;
 };

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -85,6 +85,14 @@ interface ConfirmationParamsMap {
   [ConfirmationType.CancelClear]: {
     type: ConfirmationType.CancelClear;
   };
+  [ConfirmationType.CancelExport]: {
+    type: ConfirmationType.CancelExport;
+  };
+  [ConfirmationType.ProceedAfterPartialExport]: {
+    type: ConfirmationType.ProceedAfterPartialExport;
+    failed: number;
+    total: number;
+  };
   [ConfirmationType.ClearData]: {
     type: ConfirmationType.ClearData;
     sourceText: string;

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationPreflight.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationPreflight.ts
@@ -1,0 +1,5 @@
+export type ConfirmationPreflight = {
+  label: string;
+  hint?: string;
+  isEnabledByDefault: boolean;
+};

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
@@ -34,4 +34,6 @@ export enum ConfirmationType {
   DeleteAccount = 'delete-account',
   ResetCoverImage = 'reset-cover-image',
   SetCoverImage = 'set-cover-image',
+  ProceedAfterPartialExport = 'proceed-after-partial-export',
+  CancelExport = 'cancel-export',
 }

--- a/projects/client/src/lib/features/confirmation/useConfirm.ts
+++ b/projects/client/src/lib/features/confirmation/useConfirm.ts
@@ -8,7 +8,7 @@ export function useConfirm() {
 
   const confirm = <T extends ConfirmationType>(
     props: ConfirmationParams<T> & {
-      onConfirm: () => void;
+      onConfirm: (isPreflightEnabled: boolean) => void;
       onCancel?: () => void;
     },
   ) => {
@@ -17,7 +17,7 @@ export function useConfirm() {
 
       // If there is no message, confirm immediately
       if (!confirmation.message) {
-        props.onConfirm();
+        props.onConfirm(confirmation.preflight?.isEnabledByDefault ?? false);
         return;
       }
 

--- a/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
@@ -25,7 +25,7 @@
       type: ConfirmationType.MarkAsWatched,
       title: media.title,
       target,
-      onConfirm: markAsWatched,
+      onConfirm: () => markAsWatched(),
     }),
   );
 

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -31,7 +31,7 @@
       type: ConfirmationType.MarkAsWatched,
       title,
       target,
-      onConfirm: markAsWatched,
+      onConfirm: () => markAsWatched(),
     }),
   );
   const confirmRemoveFromWatched = $derived(

--- a/projects/client/src/lib/sections/settings/AdvancedSettings.svelte
+++ b/projects/client/src/lib/sections/settings/AdvancedSettings.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
   import ClearData from "./_internal/ClearData.svelte";
+  import ExportGateProvider from "./_internal/export-gate/ExportGateProvider.svelte";
   import DeleteAccount from "./_internal/DeleteAccount.svelte";
   import HistoryAnalysis from "./_internal/HistoryAnalysis.svelte";
-  import RawExport from "./_internal/RawExport.svelte";
 </script>
 
-<div class="trakt-advanced-settings-page">
-  <HistoryAnalysis />
+<ExportGateProvider>
+  <div class="trakt-advanced-settings-page">
+    <HistoryAnalysis />
 
-  <ClearData />
+    <ClearData />
 
-  <!-- FIXME: remove this from here when clearing/deduping forces an export -->
-  <RawExport />
-
-  <DeleteAccount />
-</div>
+    <DeleteAccount />
+  </div>
+</ExportGateProvider>
 
 <style>
   .trakt-advanced-settings-page {

--- a/projects/client/src/lib/sections/settings/_internal/ClearData.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/ClearData.svelte
@@ -20,14 +20,16 @@
   import type { ClearSource } from "./clear/models/ClearSource";
   import type { ClearSourceType } from "./clear/models/ClearSourceType";
   import SyncProgress from "./components/SyncProgress.svelte";
+  import { useExportGate } from "./export-gate/useExportGate.ts";
   import SettingsSection from "./SettingsSection.svelte";
   import SettingsRow from "./SettingsRow.svelte";
 
-  const { watchlist, ratings, history, collection } = useUser();
+  const { user, watchlist, ratings, history, collection } = useUser();
   const { invalidateAll } = useInvalidator();
   const { clearInProgress } = useClearInProgress();
   const { confirm } = useConfirm();
   const { record } = useAnalytics();
+  const exportGate = useExportGate();
 
   type ClearStatus = "idle" | "clearing" | "done";
 
@@ -53,6 +55,7 @@
   });
 
   const isClearing = $derived(syncState.status === "clearing");
+  let isRunning = $state(false);
 
   const { totalCount, invalidations } = $derived(
     getClearProperties(activeSource),
@@ -63,14 +66,24 @@
   }
 
   let abortController: AbortController | null = null;
-  async function startClear() {
+  async function startClear(shouldExport: boolean) {
     const source = activeSource;
     if (!isClearDataInput(source)) return;
+
+    isRunning = true;
+    clearInProgress.next(true);
+
+    const canProceed = await exportGate.run({ shouldExport, user: $user });
+
+    if (!canProceed) {
+      isRunning = false;
+      clearInProgress.next(false);
+      return;
+    }
 
     record(AnalyticsEvent.ClearInitiated, { source: source.type });
 
     abortController = new AbortController();
-    clearInProgress.next(true);
     syncState.status = "clearing";
     syncState.processedCount = 0;
     syncState.totalCount = totalCount;
@@ -89,6 +102,7 @@
       onComplete: async (success) => {
         if (!success) {
           clearInProgress.next(false);
+          isRunning = false;
           record(AnalyticsEvent.ClearFailed, {
             source: source.type,
             error: "aborted or fully failed",
@@ -109,14 +123,17 @@
 
         await invalidateAll(invalidations);
         clearInProgress.next(false);
+        isRunning = false;
         syncState.status = "done";
       },
     });
   }
 
   function stopClear() {
+    exportGate.stop();
     abortController?.abort();
     clearInProgress.next(false);
+    isRunning = false;
     syncState.status = "idle";
     syncState.processedCount = 0;
     syncState.totalCount = 0;
@@ -127,7 +144,7 @@
   };
 
   const onSourceChange = (type: ClearSourceType) => {
-    if (!isClearing) {
+    if (!isRunning) {
       applySourceChange(type);
       return;
     }
@@ -189,8 +206,8 @@
                 sourceText: currentSourceText,
                 onConfirm: startClear,
               })}
-              disabled={isLoading || isClearing || totalCount === 0}
-              icon={isLoading ? loadingIcon : undefined}
+              disabled={isLoading || $clearInProgress || totalCount === 0}
+              icon={isLoading || isRunning ? loadingIcon : undefined}
             >
               {m.button_text_clear_now()}
             </Button>

--- a/projects/client/src/lib/sections/settings/_internal/DeleteAccount.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/DeleteAccount.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
   import DeleteIcon from "$lib/components/icons/DeleteIcon.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import InfoIcon from "$lib/components/icons/InfoIcon.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import { useAuth } from "$lib/features/auth/stores/useAuth.ts";
   import { useUser } from "$lib/features/auth/stores/useUser.ts";
+  import { useClearInProgress } from "$lib/stores/useClearInProgress.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType.ts";
   import { useConfirm } from "$lib/features/confirmation/useConfirm.ts";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -14,11 +16,14 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import { map } from "rxjs";
   import { slide } from "svelte/transition";
+  import { useExportGate } from "./export-gate/useExportGate.ts";
   import SettingsGroupCard from "./SettingsGroupCard.svelte";
   import SettingsGroupRow from "./SettingsGroupRow.svelte";
 
   const { confirm } = useConfirm();
+  const exportGate = useExportGate();
   const { logout } = useAuth();
+  const { clearInProgress } = useClearInProgress();
   const { user } = useUser();
 
   const vipSubscription = useQuery(vipSubscriptionQuery()).pipe(
@@ -35,15 +40,25 @@
 
   let isDeleting = $state(false);
   let hasError = $state(false);
-
-  async function deleteAccount() {
+  async function deleteAccount(shouldExport: boolean) {
     isDeleting = true;
     hasError = false;
+
+    clearInProgress.next(true);
+
+    const canProceed = await exportGate.run({ shouldExport, user: $user });
+
+    if (!canProceed) {
+      clearInProgress.next(false);
+      isDeleting = false;
+      return;
+    }
 
     try {
       const success = await deleteAccountRequest();
 
       if (!success) {
+        clearInProgress.next(false);
         isDeleting = false;
         hasError = true;
         return;
@@ -52,13 +67,19 @@
       // Deletion revokes the account's authorizations server-side, so the
       // current token is already dead. Log out to clear local state and end the
       // session.
+      clearInProgress.next(false);
       await logout();
     } catch {
+      clearInProgress.next(false);
       isDeleting = false;
       hasError = true;
     }
   }
 </script>
+
+{#snippet loadingIcon()}
+  <LoadingIndicator />
+{/snippet}
 
 <SettingsGroupCard title={m.header_delete_account()}>
   {#if hasActiveVip}
@@ -89,7 +110,9 @@
       label={m.button_label_delete_account()}
       color="red"
       size="small"
-      disabled={isDeleting || $vipSubscription === undefined || hasActiveVip}
+      disabled={isDeleting || $clearInProgress ||
+        $vipSubscription === undefined || hasActiveVip}
+      icon={isDeleting ? loadingIcon : undefined}
       onclick={confirm({
         type: ConfirmationType.DeleteAccount,
         username: $user?.username ?? "",

--- a/projects/client/src/lib/sections/settings/_internal/HistoryAnalysis.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/HistoryAnalysis.svelte
@@ -22,6 +22,7 @@
   import { cleanUpHistoryPlays } from "../sync/cleanUpHistoryPlays.ts";
   import type { SyncState } from "../sync/models/SyncState.ts";
   import SyncProgress from "./components/SyncProgress.svelte";
+  import { useExportGate } from "./export-gate/useExportGate.ts";
   import {
     getPlaysSummary,
     type PlaysSummary,
@@ -30,10 +31,11 @@
   import PlayRetentionToggler from "./history-analysis/PlayRetentionToggler.svelte";
   import SettingsSection from "./SettingsSection.svelte";
 
-  const { limits } = useUser();
+  const { user, limits } = useUser();
   const { invalidateAll } = useInvalidator();
   const { clearInProgress } = useClearInProgress();
   const { confirm } = useConfirm();
+  const exportGate = useExportGate();
 
   const moviePlays = useQuery(currentUserWatchedMoviePlaysQuery({}));
   const showPlays = useQuery(currentUserWatchedShowPlaysQuery({}));
@@ -90,16 +92,31 @@
   let removedCount = $state(0);
 
   const isCleaning = $derived(syncState.status === "cleaning");
+  let isRunning = $state(false);
 
   let abortController: AbortController | null = null;
-  async function startCleanUp(category: AnalysisCategory) {
+  async function startCleanUp(
+    category: AnalysisCategory,
+    shouldExport: boolean,
+  ) {
     const { duplicateIds } = category.summary;
     if (duplicateIds.length === 0) return;
 
-    abortController = new AbortController();
+    isRunning = true;
     clearInProgress.next(true);
     activeTarget = category.target;
     doneTarget = null;
+
+    const canProceed = await exportGate.run({ shouldExport, user: $user });
+
+    if (!canProceed) {
+      isRunning = false;
+      clearInProgress.next(false);
+      activeTarget = null;
+      return;
+    }
+
+    abortController = new AbortController();
     syncState.status = "cleaning";
     syncState.processedCount = 0;
     syncState.totalCount = duplicateIds.length;
@@ -121,6 +138,7 @@
         removedCount = syncState.totalCount - failedCount;
         await invalidateAll(category.invalidations);
         clearInProgress.next(false);
+        isRunning = false;
         doneTarget = category.target;
         activeTarget = null;
         syncState.status = "done";
@@ -129,7 +147,9 @@
   }
 
   function stopCleanUp() {
+    exportGate.stop();
     abortController?.abort();
+    isRunning = false;
     clearInProgress.next(false);
     activeTarget = null;
     syncState.status = "idle";
@@ -217,14 +237,15 @@
                     variant="secondary"
                     disabled={$clearInProgress ||
                       category.summary.duplicates === 0}
-                    icon={isCleaning && activeTarget === category.target
+                    icon={isRunning && activeTarget === category.target
                       ? loadingIcon
                       : undefined}
                     onclick={confirm({
                       type: ConfirmationType.CleanUpHistory,
                       count: category.summary.duplicates,
                       keeps: retention,
-                      onConfirm: () => startCleanUp(category),
+                      onConfirm: (shouldExport) =>
+                        startCleanUp(category, shouldExport),
                     })}
                   >
                     {m.button_text_clean_up()}

--- a/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
@@ -1,66 +1,53 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
+  import NavigationGuard from "$lib/components/NavigationGuard.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent.ts";
   import { useAnalytics } from "$lib/features/analytics/useAnalytics";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import { time } from "$lib/utils/timing/time.ts";
-  import { slide } from "svelte/transition";
   import { runRawExport } from "../export/runRawExport.ts";
-  import { toExportStatusText } from "../export/toExportStatusText.ts";
+  import { createExportProgressState } from "./export-progress/createExportProgressState.ts";
+  import ExportProgressSnackbar from "./export-progress/ExportProgressSnackbar.svelte";
   import SettingsRow from "./SettingsRow.svelte";
   import SettingsSection from "./SettingsSection.svelte";
 
   const { user } = useUser();
   const { record } = useAnalytics();
 
-  type ExportState = {
-    isExporting: boolean;
-    statusText: string;
-    processed: number;
-    total: number;
-    page: number;
-  };
+  const state = $state(createExportProgressState());
 
-  const state = $state<ExportState>({
-    isExporting: false,
-    statusText: "",
-    processed: 0,
-    total: 0,
-    page: 0,
-  });
+  let abortController: AbortController | null = null;
 
-  const progressText = $derived.by(() => {
-    if (state.total === 0) {
-      return "";
-    }
+  const reset = () => Object.assign(state, createExportProgressState());
 
-    const counts = `${state.processed}/${state.total}`;
-
-    return state.page > 0 ? `(${counts} · ${state.page})` : `(${counts})`;
-  });
+  function stopExport() {
+    abortController?.abort();
+    reset();
+  }
 
   async function startExport() {
     if (!$user) return;
 
     const startTime = Date.now();
+    reset();
     state.isExporting = true;
-    state.statusText = "";
-    state.processed = 0;
-    state.total = 0;
-    state.page = 0;
     let failedCount = 0;
 
     record(AnalyticsEvent.ExportInitiated, {});
 
+    abortController = new AbortController();
+
     await runRawExport({
       user: { slug: $user.slug, isVip: $user.isVip },
+      signal: abortController.signal,
       onStatus: (status) => {
         if (status.type === "partial") {
           failedCount = status.failed;
         }
 
-        state.statusText = toExportStatusText({ status, total: state.total });
+        state.status = status;
       },
       onProgress: ({ processed, total, page }) => {
         state.processed = processed;
@@ -75,42 +62,35 @@
           failedCount,
         });
 
+        state.isExporting = false;
+
         if (failedCount > 0) {
-          state.isExporting = false;
           return;
         }
 
-        setTimeout(() => {
-          state.isExporting = false;
-          state.statusText = "";
-          state.processed = 0;
-          state.total = 0;
-          state.page = 0;
-        }, time.seconds(3));
+        setTimeout(reset, time.seconds(3));
       },
       onError: (err) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
         record(AnalyticsEvent.ExportFailed, { error: errorMessage });
 
-        state.statusText = m.text_export_status_fail();
+        state.hasFailed = true;
         state.isExporting = false;
       },
     });
   }
 </script>
 
-{#snippet exportLabel(message: string)}
-  <p class="secondary" transition:slide={{ duration: 150, axis: "y" }}>
-    {message}
-  </p>
-{/snippet}
-
-<SettingsSection
-  title={m.header_export()}
-  description={m.description_export()}
+<NavigationGuard
+  isActive={state.isExporting}
+  confirmationParams={{ type: ConfirmationType.CancelExport }}
+  onreset={stopExport}
 >
-  <SettingsRow title={m.text_raw_export()}>
-    <div class="trakt-raw-export">
+  <SettingsSection
+    title={m.header_export()}
+    description={m.description_export()}
+  >
+    <SettingsRow title={m.text_raw_export()}>
       <Button
         label={m.button_label_raw_export()}
         disabled={state.isExporting}
@@ -120,22 +100,8 @@
       >
         {m.button_text_raw_export()}
       </Button>
-      <div>
-        {#if state.isExporting}
-          {@render exportLabel(m.text_exporting({ progress: progressText }))}
-        {/if}
-        {#if state.statusText}
-          {@render exportLabel(state.statusText)}
-        {/if}
-      </div>
-    </div>
-  </SettingsRow>
-</SettingsSection>
+    </SettingsRow>
+  </SettingsSection>
+</NavigationGuard>
 
-<style>
-  .trakt-raw-export {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-s);
-  }
-</style>
+<ExportProgressSnackbar {state} onStop={stopExport} onDismiss={reset} />

--- a/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
@@ -7,6 +7,7 @@
   import { time } from "$lib/utils/timing/time.ts";
   import { slide } from "svelte/transition";
   import { runRawExport } from "../export/runRawExport.ts";
+  import { toExportStatusText } from "../export/toExportStatusText.ts";
   import SettingsRow from "./SettingsRow.svelte";
   import SettingsSection from "./SettingsSection.svelte";
 
@@ -16,15 +17,27 @@
   type ExportState = {
     isExporting: boolean;
     statusText: string;
-    progress: string;
-    endpointCount: number;
+    processed: number;
+    total: number;
+    page: number;
   };
 
   const state = $state<ExportState>({
     isExporting: false,
     statusText: "",
-    progress: "",
-    endpointCount: 0,
+    processed: 0,
+    total: 0,
+    page: 0,
+  });
+
+  const progressText = $derived.by(() => {
+    if (state.total === 0) {
+      return "";
+    }
+
+    const counts = `${state.processed}/${state.total}`;
+
+    return state.page > 0 ? `(${counts} · ${state.page})` : `(${counts})`;
   });
 
   async function startExport() {
@@ -32,9 +45,10 @@
 
     const startTime = Date.now();
     state.isExporting = true;
-    state.endpointCount = 0;
     state.statusText = "";
-    state.progress = "";
+    state.processed = 0;
+    state.total = 0;
+    state.page = 0;
     let failedCount = 0;
 
     record(AnalyticsEvent.ExportInitiated, {});
@@ -42,49 +56,36 @@
     await runRawExport({
       user: { slug: $user.slug, isVip: $user.isVip },
       onStatus: (status) => {
-        switch (status.type) {
-          case "complete":
-            state.statusText = m.text_export_status_complete();
-            break;
-          case "partial":
-            failedCount = status.failed;
-            state.statusText = status.failed === 1
-              ? m.text_export_status_partial_one({ total: state.endpointCount })
-              : m.text_export_status_partial_other({
-                failed: status.failed,
-                total: state.endpointCount,
-              });
-            break;
-          case "zip":
-            state.statusText = m.text_export_status_zipping();
-            break;
-          case "fetch":
-            state.statusText = m.text_export_status_fetching({ item: status.item });
-            state.endpointCount += 1;
-            break;
+        if (status.type === "partial") {
+          failedCount = status.failed;
         }
+
+        state.statusText = toExportStatusText({ status, total: state.total });
       },
-      onProgress: (msg) => {
-        state.progress = msg;
+      onProgress: ({ processed, total, page }) => {
+        state.processed = processed;
+        state.total = total;
+        state.page = page ?? 0;
       },
       onComplete: () => {
         const exportDuration = Date.now() - startTime;
         record(AnalyticsEvent.ExportCompleted, {
           duration: exportDuration,
-          endpointCount: state.endpointCount,
+          endpointCount: state.total,
           failedCount,
         });
 
         if (failedCount > 0) {
           state.isExporting = false;
-          state.progress = "";
           return;
         }
 
         setTimeout(() => {
           state.isExporting = false;
           state.statusText = "";
-          state.progress = "";
+          state.processed = 0;
+          state.total = 0;
+          state.page = 0;
         }, time.seconds(3));
       },
       onError: (err) => {
@@ -121,7 +122,7 @@
       </Button>
       <div>
         {#if state.isExporting}
-          {@render exportLabel(m.text_exporting({ progress: state.progress }))}
+          {@render exportLabel(m.text_exporting({ progress: progressText }))}
         {/if}
         {#if state.statusText}
           {@render exportLabel(state.statusText)}

--- a/projects/client/src/lib/sections/settings/_internal/export-gate/ExportGateContext.ts
+++ b/projects/client/src/lib/sections/settings/_internal/export-gate/ExportGateContext.ts
@@ -1,0 +1,8 @@
+import type { ExportUser } from '../../export/models/ExportUser.ts';
+
+export type ExportGateContext = {
+  run: (
+    options: { shouldExport: boolean; user: ExportUser | Nil },
+  ) => Promise<boolean>;
+  stop: () => void;
+};

--- a/projects/client/src/lib/sections/settings/_internal/export-gate/ExportGateProvider.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/export-gate/ExportGateProvider.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import NavigationGuard from "$lib/components/NavigationGuard.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent.ts";
+  import { useAnalytics } from "$lib/features/analytics/useAnalytics";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType.ts";
+  import { useConfirm } from "$lib/features/confirmation/useConfirm.ts";
+  import type { Snippet } from "svelte";
+  import type { ExportGateResult } from "../../export/models/ExportGateResult.ts";
+  import { runExportGate } from "../../export/runExportGate.ts";
+  import type { ExportGateContext } from "./ExportGateContext.ts";
+  import { createExportGateContext } from "./createExportGateContext.ts";
+  import ExportProgressSnackbar from "../export-progress/ExportProgressSnackbar.svelte";
+  import { createExportProgressState } from "../export-progress/createExportProgressState.ts";
+
+  const { children }: { children: Snippet } = $props();
+
+  const { confirm } = useConfirm();
+  const { record } = useAnalytics();
+
+  const state = $state(createExportProgressState());
+
+  let abortController: AbortController | null = null;
+
+  const reset = () => Object.assign(state, createExportProgressState());
+
+  const stop = () => {
+    abortController?.abort();
+    reset();
+  };
+
+  const confirmProceed = (counts: { failed: number; total: number }) =>
+    new Promise<boolean>((resolve) => {
+      confirm({
+        type: ConfirmationType.ProceedAfterPartialExport,
+        failed: counts.failed,
+        total: counts.total,
+        onConfirm: () => resolve(true),
+        onCancel: () => resolve(false),
+      })();
+    });
+
+  const recordOutcome = (result: ExportGateResult, duration: number) => {
+    if (result.outcome === "failed") {
+      record(AnalyticsEvent.ExportFailed, { error: result.error });
+      return;
+    }
+
+    record(AnalyticsEvent.ExportCompleted, {
+      duration,
+      endpointCount: state.total,
+      failedCount: result.outcome === "partial" ? result.failed : 0,
+    });
+  };
+
+  const run: ExportGateContext["run"] = async ({ shouldExport, user }) => {
+    if (!shouldExport || !user) {
+      return true;
+    }
+
+    if (state.isExporting) {
+      return false;
+    }
+
+    reset();
+    abortController = new AbortController();
+    const { signal } = abortController;
+    state.isExporting = true;
+
+    const startTime = Date.now();
+    record(AnalyticsEvent.ExportInitiated, {});
+
+    const result = await runExportGate({
+      user,
+      signal,
+      onStatus: (status) => {
+        state.status = status;
+      },
+      onProgress: ({ processed, total, page }) => {
+        state.processed = processed;
+        state.total = total;
+        state.page = page ?? 0;
+      },
+    });
+
+    if (signal.aborted || result.outcome === "aborted") {
+      return false;
+    }
+
+    state.isExporting = false;
+    recordOutcome(result, Date.now() - startTime);
+
+    if (result.outcome === "proceed") {
+      reset();
+      return true;
+    }
+
+    if (result.outcome === "failed") {
+      state.hasFailed = true;
+      return false;
+    }
+
+    const shouldProceed = await confirmProceed({
+      failed: result.failed,
+      total: result.total,
+    });
+
+    if (shouldProceed) {
+      reset();
+    }
+
+    return shouldProceed;
+  };
+
+  createExportGateContext({ run, stop });
+</script>
+
+<NavigationGuard
+  isActive={state.isExporting}
+  confirmationParams={{ type: ConfirmationType.CancelExport }}
+  onreset={stop}
+>
+  {@render children()}
+</NavigationGuard>
+
+<ExportProgressSnackbar {state} onStop={stop} onDismiss={reset} />

--- a/projects/client/src/lib/sections/settings/_internal/export-gate/createExportGateContext.ts
+++ b/projects/client/src/lib/sections/settings/_internal/export-gate/createExportGateContext.ts
@@ -1,0 +1,8 @@
+import { setContext } from 'svelte';
+import type { ExportGateContext } from './ExportGateContext.ts';
+
+export const EXPORT_GATE_CONTEXT_KEY = Symbol('export-gate');
+
+export function createExportGateContext(context: ExportGateContext) {
+  setContext(EXPORT_GATE_CONTEXT_KEY, context);
+}

--- a/projects/client/src/lib/sections/settings/_internal/export-gate/useExportGate.ts
+++ b/projects/client/src/lib/sections/settings/_internal/export-gate/useExportGate.ts
@@ -1,0 +1,13 @@
+import { getContext } from 'svelte';
+import { EXPORT_GATE_CONTEXT_KEY } from './createExportGateContext.ts';
+import type { ExportGateContext } from './ExportGateContext.ts';
+
+export function useExportGate(): ExportGateContext {
+  const context = getContext<ExportGateContext>(EXPORT_GATE_CONTEXT_KEY);
+
+  if (!context) {
+    throw new Error('useExportGate must be used within an ExportGateProvider');
+  }
+
+  return context;
+}

--- a/projects/client/src/lib/sections/settings/_internal/export-progress/ExportProgressSnackbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/export-progress/ExportProgressSnackbar.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import Snackbar from "$lib/components/snackbar/Snackbar.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toExportStatusText } from "../../export/toExportStatusText.ts";
+  import type { ExportProgressState } from "./ExportProgressState.ts";
+
+  type ExportProgressSnackbarProps = {
+    state: ExportProgressState;
+    onStop: () => void;
+    onDismiss: () => void;
+  };
+
+  const { state, onStop, onDismiss }: ExportProgressSnackbarProps = $props();
+
+  const progressText = $derived.by(() => {
+    const counts = `${state.processed}/${state.total}`;
+    const progress = state.page > 0 ? `(${counts} · ${state.page})` : `(${counts})`;
+
+    return m.text_exporting({ progress });
+  });
+
+  const statusText = $derived.by(() => {
+    if (state.hasFailed) {
+      return m.text_export_status_fail();
+    }
+
+    if (!state.status) {
+      return "";
+    }
+
+    return toExportStatusText({ status: state.status, total: state.total });
+  });
+
+  const stopText = $derived(m.button_text_stop_export());
+</script>
+
+<Snackbar
+  open={state.isExporting || statusText !== ""}
+  persistent
+  dismissible={!state.isExporting}
+  title={m.header_exporting_data()}
+  variant={state.hasFailed ? "error" : "default"}
+  action={state.isExporting
+    ? { text: stopText, label: stopText, onAction: onStop }
+    : undefined}
+  {onDismiss}
+>
+  {#if state.isExporting}
+    <p>{progressText}</p>
+  {/if}
+
+  {#if statusText}
+    <p class="small secondary">{statusText}</p>
+  {/if}
+</Snackbar>

--- a/projects/client/src/lib/sections/settings/_internal/export-progress/ExportProgressState.ts
+++ b/projects/client/src/lib/sections/settings/_internal/export-progress/ExportProgressState.ts
@@ -1,0 +1,10 @@
+import type { ExportStatus } from '../../export/models/ExportStatus.ts';
+
+export type ExportProgressState = {
+  isExporting: boolean;
+  processed: number;
+  total: number;
+  page: number;
+  status: ExportStatus | Nil;
+  hasFailed: boolean;
+};

--- a/projects/client/src/lib/sections/settings/_internal/export-progress/createExportProgressState.ts
+++ b/projects/client/src/lib/sections/settings/_internal/export-progress/createExportProgressState.ts
@@ -1,0 +1,12 @@
+import type { ExportProgressState } from './ExportProgressState.ts';
+
+export function createExportProgressState(): ExportProgressState {
+  return {
+    isExporting: false,
+    processed: 0,
+    total: 0,
+    page: 0,
+    status: null,
+    hasFailed: false,
+  };
+}

--- a/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
+++ b/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
@@ -7,6 +7,7 @@ import { PAGE_LIMIT } from './constants.ts';
 type FetchWithRetryParams = {
   url: string;
   page?: number;
+  signal?: AbortSignal;
   timeout?: number;
   retryDelay?: number;
   maxTry?: number;
@@ -29,9 +30,20 @@ function toHttpError(status: number) {
     : new PermanentHttpError(status);
 }
 
+function toRequestSignal(timeout: number, signal?: AbortSignal) {
+  const timeoutSignal = AbortSignal.timeout(timeout);
+
+  if (!signal) {
+    return timeoutSignal;
+  }
+
+  return AbortSignal.any([signal, timeoutSignal]);
+}
+
 export function fetchWithRetry({
   url,
   page = 1,
+  signal,
   timeout = time.minutes(1),
   retryDelay = time.seconds(10),
   maxTry = 10,
@@ -41,13 +53,15 @@ export function fetchWithRetry({
 }> {
   return retryAsync(
     async () => {
+      signal?.throwIfAborted();
+
       const pageUrl = url.includes('?')
         ? `${url}&page=${page}&limit=${PAGE_LIMIT}`
         : `${url}?page=${page}&limit=${PAGE_LIMIT}`;
 
       const response = await rawApiFetch({
         path: `/${pageUrl}`,
-        init: { signal: AbortSignal.timeout(timeout) },
+        init: { signal: toRequestSignal(timeout, signal) },
       });
 
       if (response.status === 429) {
@@ -70,6 +84,10 @@ export function fetchWithRetry({
       delay: retryDelay,
       maxTry,
       onError: (err) => {
+        if (signal?.aborted) {
+          return false;
+        }
+
         if (err instanceof PermanentHttpError) {
           error('Fetch failed, giving up', err);
           return false;

--- a/projects/client/src/lib/sections/settings/export/models/ExportGateResult.ts
+++ b/projects/client/src/lib/sections/settings/export/models/ExportGateResult.ts
@@ -1,0 +1,5 @@
+export type ExportGateResult =
+  | { outcome: 'proceed' }
+  | { outcome: 'aborted' }
+  | { outcome: 'failed'; error: string }
+  | { outcome: 'partial'; failed: number; total: number };

--- a/projects/client/src/lib/sections/settings/export/models/ExportOptions.ts
+++ b/projects/client/src/lib/sections/settings/export/models/ExportOptions.ts
@@ -1,0 +1,12 @@
+import type { ExportProgress } from './ExportProgress.ts';
+import type { ExportStatus } from './ExportStatus.ts';
+import type { ExportUser } from './ExportUser.ts';
+
+export type ExportOptions = {
+  user: ExportUser;
+  signal?: AbortSignal;
+  onStatus: (status: ExportStatus) => void;
+  onProgress: (progress: ExportProgress) => void;
+  onComplete: () => void;
+  onError: (err: unknown) => void;
+};

--- a/projects/client/src/lib/sections/settings/export/models/ExportProgress.ts
+++ b/projects/client/src/lib/sections/settings/export/models/ExportProgress.ts
@@ -1,0 +1,5 @@
+export type ExportProgress = {
+  processed: number;
+  total: number;
+  page?: number;
+};

--- a/projects/client/src/lib/sections/settings/export/models/ExportStatus.ts
+++ b/projects/client/src/lib/sections/settings/export/models/ExportStatus.ts
@@ -1,0 +1,5 @@
+export type ExportStatus =
+  | { type: 'fetch'; item: string }
+  | { type: 'zip' }
+  | { type: 'partial'; failed: number }
+  | { type: 'complete' };

--- a/projects/client/src/lib/sections/settings/export/models/ExportUser.ts
+++ b/projects/client/src/lib/sections/settings/export/models/ExportUser.ts
@@ -1,0 +1,4 @@
+export type ExportUser = {
+  slug: string;
+  isVip: boolean;
+};

--- a/projects/client/src/lib/sections/settings/export/models/Pagination.ts
+++ b/projects/client/src/lib/sections/settings/export/models/Pagination.ts
@@ -1,0 +1,5 @@
+export type Pagination = {
+  page: number;
+  pageCount: number;
+  hasMore: boolean;
+};

--- a/projects/client/src/lib/sections/settings/export/processEndpoint.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/processEndpoint.spec.ts
@@ -1,3 +1,4 @@
+import { NOOP_FN } from '$lib/utils/constants.ts';
 import { server } from '$mocks/server.ts';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
@@ -25,8 +26,11 @@ describe('processEndpoint', () => {
     );
 
     const pages: Array<number> = [];
-    await processEndpoint(PATH, (_, { page }) => {
-      pages.push(page);
+    await processEndpoint({
+      path: PATH,
+      onPage: (_, { page }) => {
+        pages.push(page);
+      },
     });
 
     expect(pages).to.deep.equal([1, 2, 3]);
@@ -44,8 +48,11 @@ describe('processEndpoint', () => {
     );
 
     const pages: Array<number> = [];
-    await processEndpoint(PATH, (_, { page }) => {
-      pages.push(page);
+    await processEndpoint({
+      path: PATH,
+      onPage: (_, { page }) => {
+        pages.push(page);
+      },
     });
 
     expect(pages).to.deep.equal([1, 2, 3, 4]);
@@ -60,8 +67,11 @@ describe('processEndpoint', () => {
     );
 
     const pages: Array<number> = [];
-    await processEndpoint(PATH, (_, { page }) => {
-      pages.push(page);
+    await processEndpoint({
+      path: PATH,
+      onPage: (_, { page }) => {
+        pages.push(page);
+      },
     });
 
     expect(pages).to.deep.equal([1]);
@@ -85,8 +95,11 @@ describe('processEndpoint', () => {
     );
 
     const pages: Array<number> = [];
-    await processEndpoint(PATH, (_, { page }) => {
-      pages.push(page);
+    await processEndpoint({
+      path: PATH,
+      onPage: (_, { page }) => {
+        pages.push(page);
+      },
     });
 
     expect(pages).to.deep.equal([1, 2, 3]);
@@ -104,8 +117,11 @@ describe('processEndpoint', () => {
     );
 
     const pages: Array<number> = [];
-    await processEndpoint(PATH, (_, { page }) => {
-      pages.push(page);
+    await processEndpoint({
+      path: PATH,
+      onPage: (_, { page }) => {
+        pages.push(page);
+      },
     });
 
     expect(pages).to.deep.equal([1]);
@@ -119,17 +135,21 @@ describe('processEndpoint', () => {
         })),
     );
 
-    await expect(processEndpoint(PATH, () => {})).rejects.toThrow(
-      /past its reported page count/,
-    );
+    await expect(processEndpoint({ path: PATH, onPage: NOOP_FN })).rejects
+      .toThrow(
+        /past its reported page count/,
+      );
   });
 
   it('should stop after a single page when there is nothing to paginate', async () => {
     server.use(http.get(ENDPOINT, () => HttpResponse.json([])));
 
     const pages: Array<number> = [];
-    await processEndpoint(PATH, (_, { page }) => {
-      pages.push(page);
+    await processEndpoint({
+      path: PATH,
+      onPage: (_, { page }) => {
+        pages.push(page);
+      },
     });
 
     expect(pages).to.deep.equal([1]);

--- a/projects/client/src/lib/sections/settings/export/processEndpoint.ts
+++ b/projects/client/src/lib/sections/settings/export/processEndpoint.ts
@@ -1,21 +1,23 @@
-import { fetchWithRetry } from './fetchWithRetry.ts';
 import { PAGE_LIMIT } from './constants.ts';
+import { fetchWithRetry } from './fetchWithRetry.ts';
+import type { Pagination } from './models/Pagination.ts';
 
 const MAX_PAGES = 10_000;
 const MAX_UNREPORTED_PAGES = 100;
 
-export type Pagination = {
-  page: number;
-  pageCount: number;
-  hasMore: boolean;
+type ProcessEndpointOptions = {
+  path: string;
+  onPage: (data: unknown, pagination: Pagination) => Promise<void> | void;
+  signal?: AbortSignal;
 };
 
-export async function processEndpoint(
-  path: string,
-  onPage: (data: unknown, pagination: Pagination) => Promise<void> | void,
-): Promise<void> {
+export async function processEndpoint({
+  path,
+  onPage,
+  signal,
+}: ProcessEndpointOptions): Promise<void> {
   for (let page = 1; page <= MAX_PAGES; page++) {
-    const result = await fetchWithRetry({ url: path, page });
+    const result = await fetchWithRetry({ url: path, page, signal });
 
     const entries = Array.isArray(result.json) ? result.json : null;
     const hasMorePages = page < result.paginationPageCount;

--- a/projects/client/src/lib/sections/settings/export/runExportGate.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/runExportGate.spec.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExportOptions } from './models/ExportOptions.ts';
+import type { ExportProgress } from './models/ExportProgress.ts';
+import type { ExportStatus } from './models/ExportStatus.ts';
+import { runExportGate } from './runExportGate.ts';
+import { runRawExport } from './runRawExport.ts';
+
+vi.mock('./runRawExport.ts', () => ({ runRawExport: vi.fn() }));
+
+const USER = { slug: 'mega-collector', isVip: false };
+
+function stubExport(behaviour: (options: ExportOptions) => void) {
+  vi.mocked(runRawExport).mockImplementation((options) => {
+    behaviour(options);
+    return Promise.resolve();
+  });
+}
+
+function gateFor(signal = new AbortController().signal) {
+  const statuses: Array<ExportStatus> = [];
+  const progresses: Array<ExportProgress> = [];
+
+  const result = runExportGate({
+    user: USER,
+    signal,
+    onStatus: (status) => statuses.push(status),
+    onProgress: (progress) => progresses.push(progress),
+  });
+
+  return { result, statuses, progresses };
+}
+
+describe('runExportGate', () => {
+  beforeEach(() => {
+    vi.mocked(runRawExport).mockReset();
+  });
+
+  it('should proceed when the export completes cleanly', async () => {
+    stubExport(({ onProgress, onStatus, onComplete }) => {
+      onProgress({ processed: 48, total: 48 });
+      onStatus({ type: 'complete' });
+      onComplete();
+    });
+
+    expect(await gateFor().result).to.deep.equal({ outcome: 'proceed' });
+  });
+
+  it('should forward status and progress to the caller', async () => {
+    stubExport(({ onProgress, onStatus }) => {
+      onProgress({ processed: 1, total: 12 });
+      onStatus({ type: 'fetch', item: 'ratings-shows' });
+    });
+
+    const { result, statuses, progresses } = gateFor();
+    await result;
+
+    expect(progresses).to.deep.equal([{ processed: 1, total: 12 }]);
+    expect(statuses).to.deep.equal([{ type: 'fetch', item: 'ratings-shows' }]);
+  });
+
+  it('should report the counts when sections failed to export', async () => {
+    stubExport(({ onProgress, onStatus }) => {
+      onProgress({ processed: 48, total: 48 });
+      onStatus({ type: 'partial', failed: 3 });
+    });
+
+    expect(await gateFor().result).to.deep.equal({
+      outcome: 'partial',
+      failed: 3,
+      total: 48,
+    });
+  });
+
+  it('should report a failed export along with its reason', async () => {
+    stubExport(({ onError }) => onError(new Error('boom')));
+
+    expect(await gateFor().result).to.deep.equal({
+      outcome: 'failed',
+      error: 'boom',
+    });
+  });
+
+  it('should report an aborted export ahead of any error it raised', async () => {
+    const controller = new AbortController();
+    stubExport(({ onError }) => {
+      controller.abort();
+      onError(new Error('aborted'));
+    });
+
+    expect(await gateFor(controller.signal).result).to.deep.equal({
+      outcome: 'aborted',
+    });
+  });
+
+  it('should report an abort ahead of a partial result', async () => {
+    const controller = new AbortController();
+    stubExport(({ onStatus }) => {
+      onStatus({ type: 'partial', failed: 2 });
+      controller.abort();
+    });
+
+    expect(await gateFor(controller.signal).result).to.deep.equal({
+      outcome: 'aborted',
+    });
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/runExportGate.ts
+++ b/projects/client/src/lib/sections/settings/export/runExportGate.ts
@@ -1,0 +1,58 @@
+import { NOOP_FN } from '$lib/utils/constants.ts';
+import type { ExportGateResult } from './models/ExportGateResult.ts';
+import type { ExportProgress } from './models/ExportProgress.ts';
+import type { ExportStatus } from './models/ExportStatus.ts';
+import type { ExportUser } from './models/ExportUser.ts';
+import { runRawExport } from './runRawExport.ts';
+
+type RunExportGateOptions = {
+  user: ExportUser;
+  signal: AbortSignal;
+  onStatus: (status: ExportStatus) => void;
+  onProgress: (progress: ExportProgress) => void;
+};
+
+export async function runExportGate({
+  user,
+  signal,
+  onStatus,
+  onProgress,
+}: RunExportGateOptions): Promise<ExportGateResult> {
+  let total = 0;
+  let failed = 0;
+  let error: string | Nil = null;
+
+  await runRawExport({
+    user,
+    signal,
+    onStatus: (status) => {
+      if (status.type === 'partial') {
+        failed = status.failed;
+      }
+
+      onStatus(status);
+    },
+    onProgress: (progress) => {
+      total = progress.total;
+      onProgress(progress);
+    },
+    onComplete: NOOP_FN,
+    onError: (err) => {
+      error = err instanceof Error ? err.message : String(err);
+    },
+  });
+
+  if (signal.aborted) {
+    return { outcome: 'aborted' };
+  }
+
+  if (error) {
+    return { outcome: 'failed', error };
+  }
+
+  if (failed === 0) {
+    return { outcome: 'proceed' };
+  }
+
+  return { outcome: 'partial', failed, total };
+}

--- a/projects/client/src/lib/sections/settings/export/runRawExport.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/runRawExport.spec.ts
@@ -1,3 +1,4 @@
+import { NOOP_FN } from '$lib/utils/constants.ts';
 import { server } from '$mocks/server.ts';
 import { unzipSync } from 'fflate';
 import { http, HttpResponse } from 'msw';
@@ -12,16 +13,20 @@ const FAILING_ENDPOINT = `http://localhost/users/${SLUG}/collection/shows`;
 
 async function exportFor(user = { slug: SLUG, isVip: false }) {
   const statuses: Array<{ type: string; failed?: number }> = [];
+  const failures: Array<unknown> = [];
 
-  await new Promise<void>((resolve, reject) => {
-    runRawExport({
-      user,
-      onStatus: (status) => statuses.push(status),
-      onProgress: () => {},
-      onComplete: resolve,
-      onError: reject,
-    });
+  await runRawExport({
+    user,
+    onStatus: (status) => statuses.push(status),
+    onProgress: NOOP_FN,
+    onComplete: NOOP_FN,
+    onError: (err) => failures.push(err),
   });
+
+  const failure = failures.at(0);
+  if (failure) {
+    throw failure;
+  }
 
   const [blob] = vi.mocked(downloadFile).mock.calls.at(-1) ?? [];
   const bytes = new Uint8Array(await (blob as Blob).arrayBuffer());
@@ -78,5 +83,43 @@ describe('runRawExport', () => {
 
     expect(statuses.at(-1)).to.deep.equal({ type: 'complete' });
     expect(files['_errors.json']).to.equal(undefined);
+  });
+
+  it('should resolve only once the archive has been downloaded', async () => {
+    await runRawExport({
+      user: { slug: SLUG, isVip: false },
+      onStatus: NOOP_FN,
+      onProgress: NOOP_FN,
+      onComplete: NOOP_FN,
+      onError: NOOP_FN,
+    });
+
+    expect(vi.mocked(downloadFile)).toHaveBeenCalledOnce();
+  });
+
+  it('should abandon an aborted export silently', async () => {
+    const controller = new AbortController();
+    const statuses: Array<{ type: string }> = [];
+    const failures: Array<unknown> = [];
+
+    server.use(
+      http.get('http://localhost/*', () => {
+        controller.abort();
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await runRawExport({
+      user: { slug: SLUG, isVip: false },
+      signal: controller.signal,
+      onStatus: (status) => statuses.push(status),
+      onProgress: NOOP_FN,
+      onComplete: NOOP_FN,
+      onError: (err) => failures.push(err),
+    });
+
+    expect(failures).to.have.length(0);
+    expect(vi.mocked(downloadFile)).not.toHaveBeenCalled();
+    expect(statuses.some((status) => status.type === 'zip')).to.equal(false);
   });
 });

--- a/projects/client/src/lib/sections/settings/export/runRawExport.ts
+++ b/projects/client/src/lib/sections/settings/export/runRawExport.ts
@@ -2,14 +2,11 @@ import { error } from '$lib/utils/console/print.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { strToU8, zip, type Zippable } from 'fflate';
 import { downloadFile } from './downloadFile.ts';
-import { type Pagination, processEndpoint } from './processEndpoint.ts';
+import type { ExportOptions } from './models/ExportOptions.ts';
+import type { Pagination } from './models/Pagination.ts';
+import { processEndpoint } from './processEndpoint.ts';
 
 const FETCH_TIME_BUDGET = time.hours(2);
-
-type UserLike = {
-  slug: string;
-  isVip: boolean;
-};
 
 interface TraktList {
   ids: {
@@ -25,22 +22,9 @@ type ExportFailure = {
   totalPages: number;
 };
 
-type ExportStatus =
-  | { type: 'fetch'; item: string }
-  | { type: 'zip' }
-  | { type: 'partial'; failed: number }
-  | { type: 'complete' };
-
-interface ExportOptions {
-  user: UserLike;
-  onStatus: (status: ExportStatus) => void;
-  onProgress: (msg: string) => void;
-  onComplete: () => void;
-  onError: (err: unknown) => void;
-}
-
 export async function runRawExport({
   user,
+  signal,
   onStatus,
   onProgress,
   onComplete,
@@ -181,7 +165,9 @@ export async function runRawExport({
   const failures: Array<ExportFailure> = [];
 
   const fetchDeadline = Date.now() + FETCH_TIME_BUDGET;
-  const assertWithinBudget = () => {
+  const assertCanContinue = () => {
+    signal?.throwIfAborted();
+
     if (Date.now() < fetchDeadline) {
       return;
     }
@@ -200,18 +186,26 @@ export async function runRawExport({
     const progress = { fetchedPages: 0, totalPages: 0 };
 
     try {
-      assertWithinBudget();
+      assertCanContinue();
 
-      await processEndpoint(path, (data, pagination) => {
-        progress.fetchedPages = pagination.page;
-        progress.totalPages = pagination.pageCount;
-        onPage(data, pagination);
+      await processEndpoint({
+        path,
+        signal,
+        onPage: (data, pagination) => {
+          progress.fetchedPages = pagination.page;
+          progress.totalPages = pagination.pageCount;
+          onPage(data, pagination);
 
-        if (pagination.hasMore) {
-          assertWithinBudget();
-        }
+          if (pagination.hasMore) {
+            assertCanContinue();
+          }
+        },
       });
     } catch (e) {
+      if (signal?.aborted) {
+        throw e;
+      }
+
       error(`Export failed for ${path}`, e);
       failures.push({
         endpoint: path,
@@ -238,13 +232,13 @@ export async function runRawExport({
     let count = 0;
     for (const endpoint of endpoints) {
       count++;
-      onProgress(`(${count}/${endpoints.length})`);
+      onProgress({ processed: count, total: endpoints.length });
       onStatus({ type: 'fetch', item: endpoint.file });
 
       await collectEndpoint(endpoint.path, (data, { page, pageCount }) => {
         const isPaginated = page > 1 || pageCount > 1;
         if (isPaginated) {
-          onProgress(`(${count}/${endpoints.length} · ${page})`);
+          onProgress({ processed: count, total: endpoints.length, page });
         }
         const suffix = isPaginated ? `-${page}` : '';
         const filename = `${endpoint.file}${suffix}.json`;
@@ -257,25 +251,34 @@ export async function runRawExport({
     }
 
     onStatus({ type: 'zip' });
-    zip(files, (err, out) => {
-      if (err) {
-        error('Zip failed', err);
-        onError(err);
-        return;
-      }
-      const blob = new Blob([out as unknown as BlobPart], {
-        type: 'application/zip',
-      });
 
-      downloadFile(blob, `trakt-export-${slug}.zip`);
-      onStatus(
-        failures.length > 0
-          ? { type: 'partial', failed: failures.length }
-          : { type: 'complete' },
-      );
-      onComplete();
+    const archive = await new Promise<Uint8Array>((resolve, reject) => {
+      zip(files, (err, out) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve(out);
+      });
     });
+
+    const blob = new Blob([archive as unknown as BlobPart], {
+      type: 'application/zip',
+    });
+
+    downloadFile(blob, `trakt-export-${slug}.zip`);
+    onStatus(
+      failures.length > 0
+        ? { type: 'partial', failed: failures.length }
+        : { type: 'complete' },
+    );
+    onComplete();
   } catch (e) {
+    if (signal?.aborted) {
+      return;
+    }
+
     error('Export failed', e);
     onError(e);
   }

--- a/projects/client/src/lib/sections/settings/export/toExportStatusText.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/toExportStatusText.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { toExportStatusText } from './toExportStatusText.ts';
+
+describe('util: toExportStatusText', () => {
+  it('should name the section being fetched', () => {
+    const text = toExportStatusText({
+      status: { type: 'fetch', item: 'ratings-shows' },
+      total: 48,
+    });
+
+    expect(text).to.contain('ratings-shows');
+  });
+
+  it('should describe the zipping phase', () => {
+    const text = toExportStatusText({ status: { type: 'zip' }, total: 48 });
+
+    expect(text).to.not.equal('');
+    expect(text).to.not.contain('48');
+  });
+
+  it('should describe a clean export', () => {
+    const text = toExportStatusText({
+      status: { type: 'complete' },
+      total: 48,
+    });
+
+    expect(text).to.not.equal('');
+  });
+
+  it('should use the singular copy for a lone failure', () => {
+    const text = toExportStatusText({
+      status: { type: 'partial', failed: 1 },
+      total: 48,
+    });
+
+    expect(text).to.contain('1 of 48');
+  });
+
+  it('should use the plural copy when several sections fail', () => {
+    const text = toExportStatusText({
+      status: { type: 'partial', failed: 3 },
+      total: 48,
+    });
+
+    expect(text).to.contain('3 of 48');
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/toExportStatusText.ts
+++ b/projects/client/src/lib/sections/settings/export/toExportStatusText.ts
@@ -1,0 +1,25 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { ExportStatus } from './models/ExportStatus.ts';
+
+type ToExportStatusTextOptions = {
+  status: ExportStatus;
+  total: number;
+};
+
+export function toExportStatusText({
+  status,
+  total,
+}: ToExportStatusTextOptions): string {
+  switch (status.type) {
+    case 'fetch':
+      return m.text_export_status_fetching({ item: status.item });
+    case 'zip':
+      return m.text_export_status_zipping();
+    case 'partial':
+      return status.failed === 1
+        ? m.text_export_status_partial_one({ total })
+        : m.text_export_status_partial_other({ failed: status.failed, total });
+    case 'complete':
+      return m.text_export_status_complete();
+  }
+}

--- a/projects/client/src/lib/utils/actions/autoDismiss.spec.ts
+++ b/projects/client/src/lib/utils/actions/autoDismiss.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { autoDismiss } from './autoDismiss.ts';
+
+const DURATION = 1000;
+
+function mount({ persistent }: { persistent?: boolean } = {}) {
+  const node = document.createElement('div');
+  const onDismiss = vi.fn();
+
+  return {
+    node,
+    onDismiss,
+    action: autoDismiss(node, { onDismiss, durationMs: DURATION, persistent }),
+  };
+}
+
+describe('action: autoDismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should dismiss once the duration elapses', () => {
+    const { onDismiss, action } = mount();
+
+    vi.advanceTimersByTime(DURATION * 2);
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    action.destroy();
+  });
+
+  it('should report progress while counting down', () => {
+    const { node, action } = mount();
+
+    vi.advanceTimersByTime(DURATION / 2);
+
+    expect(Number(node.style.getPropertyValue('--progress'))).to.be.greaterThan(
+      0,
+    );
+    action.destroy();
+  });
+
+  it('should never dismiss when persistent', () => {
+    const { onDismiss, action } = mount({ persistent: true });
+
+    vi.advanceTimersByTime(DURATION * 10);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    action.destroy();
+  });
+
+  it('should not report progress when persistent', () => {
+    const { node, action } = mount({ persistent: true });
+
+    vi.advanceTimersByTime(DURATION * 10);
+
+    expect(node.style.getPropertyValue('--progress')).to.equal('');
+    action.destroy();
+  });
+
+  it('should start a fresh countdown when auto-dismiss resumes', () => {
+    const { onDismiss, action } = mount({ persistent: true });
+
+    vi.advanceTimersByTime(DURATION * 5);
+    action.update({ onDismiss, durationMs: DURATION, persistent: false });
+    vi.advanceTimersByTime(DURATION / 2);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(DURATION);
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    action.destroy();
+  });
+
+  it('should stop an in-flight countdown when it turns persistent', () => {
+    const { onDismiss, action } = mount();
+
+    vi.advanceTimersByTime(DURATION / 2);
+    action.update({ onDismiss, durationMs: DURATION, persistent: true });
+    vi.advanceTimersByTime(DURATION * 5);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    action.destroy();
+  });
+
+  it('should drop the reported progress when it turns persistent', () => {
+    const { node, onDismiss, action } = mount();
+
+    vi.advanceTimersByTime(DURATION / 2);
+    action.update({ onDismiss, durationMs: DURATION, persistent: true });
+
+    expect(node.style.getPropertyValue('--progress')).to.equal('');
+    action.destroy();
+  });
+
+  it('should stop counting down once destroyed', () => {
+    const { onDismiss, action } = mount();
+
+    action.destroy();
+    vi.advanceTimersByTime(DURATION * 2);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/projects/client/src/lib/utils/actions/autoDismiss.ts
+++ b/projects/client/src/lib/utils/actions/autoDismiss.ts
@@ -1,5 +1,5 @@
 import { time } from '$lib/utils/timing/time.ts';
-import { interval } from 'rxjs';
+import { interval, type Subscription } from 'rxjs';
 
 const defaultDuration = time.seconds(10);
 const fps = 30;
@@ -8,26 +8,51 @@ export type AutoDismissProps = {
   onDismiss: () => void;
   durationMs?: number;
   now?: () => number;
+  persistent?: boolean;
 };
 
 export function autoDismiss(
   node: HTMLElement,
-  { onDismiss, durationMs = defaultDuration, now = Date.now }: AutoDismissProps,
+  {
+    onDismiss,
+    durationMs = defaultDuration,
+    now = Date.now,
+    persistent = false,
+  }: AutoDismissProps,
 ) {
-  let params = { onDismiss, durationMs, now };
-  const startTime = now();
+  let params = { onDismiss, durationMs, now, persistent };
+  let subscription: Subscription | null = null;
 
-  const subscription = interval(time.fps(fps)).subscribe(() => {
-    const elapsedMs = params.now() - startTime;
-    const progress = Math.min(elapsedMs / params.durationMs, 1);
+  const stop = () => {
+    subscription?.unsubscribe();
+    subscription = null;
+    node.style.removeProperty('--progress');
+  };
 
-    node.style.setProperty('--progress', String(progress));
-
-    if (progress >= 1) {
-      subscription.unsubscribe();
-      params.onDismiss();
+  const start = () => {
+    if (subscription) {
+      return;
     }
-  });
+
+    const startTime = params.now();
+    node.style.setProperty('--progress', '0');
+
+    subscription = interval(time.fps(fps)).subscribe(() => {
+      const elapsedMs = params.now() - startTime;
+      const progress = Math.min(elapsedMs / params.durationMs, 1);
+
+      node.style.setProperty('--progress', String(progress));
+
+      if (progress >= 1) {
+        stop();
+        params.onDismiss();
+      }
+    });
+  };
+
+  const sync = () => (params.persistent ? stop() : start());
+
+  sync();
 
   return {
     update(newParams: AutoDismissProps) {
@@ -35,10 +60,13 @@ export function autoDismiss(
         onDismiss: newParams.onDismiss,
         durationMs: newParams.durationMs ?? params.durationMs,
         now: newParams.now ?? params.now,
+        persistent: newParams.persistent ?? params.persistent,
       };
+
+      sync();
     },
     destroy() {
-      subscription.unsubscribe();
+      stop();
     },
   };
 }

--- a/projects/client/src/routes/_design_system/snackbar/+page.svelte
+++ b/projects/client/src/routes/_design_system/snackbar/+page.svelte
@@ -7,15 +7,24 @@
 
   let defaultOpen = $state(false);
   let titledOpen = $state(false);
+  let contentOpen = $state(false);
 
   const showDefault = () => {
     defaultOpen = true;
     titledOpen = false;
+    contentOpen = false;
   };
 
   const showTitled = () => {
     defaultOpen = false;
     titledOpen = true;
+    contentOpen = false;
+  };
+
+  const showContent = () => {
+    defaultOpen = false;
+    titledOpen = false;
+    contentOpen = true;
   };
 
   const closeDefault = () => {
@@ -24,6 +33,10 @@
 
   const closeTitled = () => {
     titledOpen = false;
+  };
+
+  const closeContent = () => {
+    contentOpen = false;
   };
 
   onMount(showDefault);
@@ -78,6 +91,37 @@
           onAction: closeTitled,
         }}
       />
+    </section>
+
+    <section>
+      <div class="section-heading">
+        <h2>Custom content</h2>
+      </div>
+
+      <div class="anchor-demo">
+        <Button
+          color="blue"
+          label="Show snackbar with custom content"
+          onclick={showContent}
+        >
+          Show snackbar with custom content
+        </Button>
+      </div>
+
+      <Snackbar
+        open={contentOpen}
+        onDismiss={closeContent}
+        title="Exporting your data"
+        dismissDurationMs={demoDismissDurationMs}
+        action={{
+          label: "Stop exporting",
+          text: "Stop",
+          onAction: closeContent,
+        }}
+      >
+        <p>Exporting… (12/48 · 3)</p>
+        <p class="small secondary">Fetching collection-shows…</p>
+      </Snackbar>
     </section>
   </div>
 </main>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Clearing data, cleaning up duplicate plays and deleting your account now offer a raw export first. The switch is on by default, and the destructive work only runs once the export has landed.
- A partial export asks again before continuing, so a section that failed to export can't silently turn into a wipe.
- Progress reports through a snackbar rather than inline. Inlining it shifted the page around, and the export has a 2h budget so a modal was no place for it either.
  - Stop is the only action while it runs, so a running export can't be hidden with no way left to abort it.
- Raw export is gone from Advanced and keeps its own entry on the Data tab. Both surfaces now report through the same snackbar, including the page counter for sections that span a lot of pages.
- `runRawExport` takes an AbortSignal now, and awaits its zip so the promise resolves after the download instead of before it. An abort is no longer recorded or logged as a failed section.
- Confirmations gained a generic `preflight` switch (label, hint, default) whose value reaches `onConfirm`.
  - This surfaced two call sites passing `onConfirm: markAsWatched`, whose first parameter is an optional `watchedAt`, so the new argument would have landed there. Both call it explicitly now.
- Snackbar gained `persistent` and `dismissible`. `autoDismiss` always ran a 10s timer with no way to opt out, which closed the toast mid-export and then reopened it on the next status tick.

## 👀 Examples 👀

https://github.com/user-attachments/assets/56ea0835-078d-4df8-9862-b9655a2f340e

https://github.com/user-attachments/assets/238bc729-5feb-41a8-9bb3-10657e58035d

https://github.com/user-attachments/assets/e19faf7e-010d-43f4-9f07-ccf6d424ae52

<img width="544" height="356" alt="Screenshot 2026-08-24 at 10 33 12" src="https://github.com/user-attachments/assets/48b493a9-634b-4835-821d-99ac0e985639" />
