### PR TITLE
fix(toast): stop prompting for already rated items

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserRatingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserRatingsQuery.ts
@@ -160,5 +160,6 @@ export const currentUserRatingsQuery = defineQuery({
     ),
   }),
   schema: UserRatingsSchema,
-  ttl: time.hours(12),
+  ttl: time.hours(3),
+  refetchOnWindowFocus: true,
 });

--- a/projects/client/src/lib/sections/toast/_internal/useCurrentUserLastWatched.ts
+++ b/projects/client/src/lib/sections/toast/_internal/useCurrentUserLastWatched.ts
@@ -15,6 +15,7 @@ import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { combineLatest, map } from 'rxjs';
 import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
 import { isShowRatingCandidate } from './isShowRatingCandidate.ts';
+import { useFreshRatings } from './useFreshRatings.ts';
 
 function toLastWatchedMedia(
   activity: MovieActivityHistory | EpisodeActivityHistory,
@@ -33,6 +34,7 @@ function toLastWatchedMedia(
 export function useCurrentUserLastWatched() {
   const { ratings, history, user } = useUser();
   const { wasDismissed } = useDismissals();
+  const { hasCheckedRatingsSince } = useFreshRatings();
 
   const params = {
     slug: 'me',
@@ -91,7 +93,11 @@ export function useCurrentUserLastWatched() {
               }
             });
 
-          return unratedItem ? toLastWatchedMedia(unratedItem) : null;
+          if (!unratedItem || !hasCheckedRatingsSince(unratedItem.watchedAt)) {
+            return null;
+          }
+
+          return toLastWatchedMedia(unratedItem);
         },
       ),
     ),

--- a/projects/client/src/lib/sections/toast/_internal/useFreshRatings.spec.ts
+++ b/projects/client/src/lib/sections/toast/_internal/useFreshRatings.spec.ts
@@ -1,0 +1,102 @@
+import {
+  currentUserRatingsQuery,
+  type UserRatings,
+} from '$lib/features/auth/queries/currentUserRatingsQuery.ts';
+import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { renderStore } from '$test/beds/store/renderStore.ts';
+import { describe, expect, it, vi } from 'vitest';
+import { useFreshRatings } from './useFreshRatings.ts';
+
+const watchedAt = new Date('2026-08-24T12:00:00.000Z');
+const staleSnapshot = new Date(watchedAt.getTime() - time.hours(1));
+
+const emptyRatings: UserRatings = {
+  movies: new Map(),
+  shows: new Map(),
+  seasons: new Map(),
+  episodes: new Map(),
+};
+
+const renderFreshRatings = (snapshotUpdatedAt?: Date) =>
+  renderStore(() => {
+    const client = useQueryClient();
+    const { queryKey } = currentUserRatingsQuery();
+
+    if (snapshotUpdatedAt) {
+      client.setQueryData<UserRatings>(queryKey, emptyRatings, {
+        updatedAt: snapshotUpdatedAt.getTime(),
+      });
+    }
+
+    return {
+      queryKey,
+      invalidateQueries: vi
+        .spyOn(client, 'invalidateQueries')
+        .mockResolvedValue(undefined),
+      ...useFreshRatings(),
+    };
+  });
+
+describe('store: useFreshRatings', () => {
+  it('should not vouch for a watch when no snapshot exists', async () => {
+    const { hasCheckedRatingsSince } = await renderFreshRatings();
+
+    expect(hasCheckedRatingsSince(watchedAt)).toBe(false);
+  });
+
+  it('should vouch for a watch older than the snapshot', async () => {
+    const { hasCheckedRatingsSince, invalidateQueries } =
+      await renderFreshRatings(
+        new Date(watchedAt.getTime() + time.minutes(1)),
+      );
+
+    expect(hasCheckedRatingsSince(watchedAt)).toBe(true);
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('should vouch for a watch as old as the snapshot', async () => {
+    const { hasCheckedRatingsSince } = await renderFreshRatings(watchedAt);
+
+    expect(hasCheckedRatingsSince(watchedAt)).toBe(true);
+  });
+
+  it('should refresh the snapshot instead of vouching for a newer watch', async () => {
+    const { hasCheckedRatingsSince, invalidateQueries, queryKey } =
+      await renderFreshRatings(staleSnapshot);
+
+    expect(hasCheckedRatingsSince(watchedAt)).toBe(false);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey });
+  });
+
+  it('should refresh the snapshot once per watch', async () => {
+    const { hasCheckedRatingsSince, invalidateQueries } =
+      await renderFreshRatings(
+        staleSnapshot,
+      );
+
+    hasCheckedRatingsSince(watchedAt);
+    hasCheckedRatingsSince(watchedAt);
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('should settle for the snapshot once its refresh has run', async () => {
+    const { hasCheckedRatingsSince } = await renderFreshRatings(staleSnapshot);
+
+    expect(hasCheckedRatingsSince(watchedAt)).toBe(false);
+    expect(hasCheckedRatingsSince(watchedAt)).toBe(true);
+  });
+
+  it('should refresh again for a watch newer than the last refresh', async () => {
+    const { hasCheckedRatingsSince, invalidateQueries } =
+      await renderFreshRatings(
+        staleSnapshot,
+      );
+
+    hasCheckedRatingsSince(watchedAt);
+    hasCheckedRatingsSince(new Date(watchedAt.getTime() + time.minutes(1)));
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(2);
+  });
+});

--- a/projects/client/src/lib/sections/toast/_internal/useFreshRatings.ts
+++ b/projects/client/src/lib/sections/toast/_internal/useFreshRatings.ts
@@ -1,0 +1,41 @@
+import { browser } from '$app/environment';
+import { currentUserRatingsQuery } from '$lib/features/auth/queries/currentUserRatingsQuery.ts';
+import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
+
+export function useFreshRatings() {
+  const client = browser ? useQueryClient() : undefined;
+  const { queryKey } = currentUserRatingsQuery();
+
+  let refreshedFor = 0;
+
+  const hasCheckedRatingsSince = (date: Date) => {
+    const state = client?.getQueryState(queryKey);
+
+    if (state == null) {
+      return false;
+    }
+
+    const watchedAt = date.getTime();
+
+    if (state.dataUpdatedAt >= watchedAt) {
+      return true;
+    }
+
+    if (state.fetchStatus !== 'idle') {
+      return false;
+    }
+
+    if (refreshedFor >= watchedAt) {
+      return true;
+    }
+
+    refreshedFor = watchedAt;
+    client?.invalidateQueries({ queryKey });
+
+    return false;
+  };
+
+  return {
+    hasCheckedRatingsSince,
+  };
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Rate now toast was prompting for items users had already rated
- Cause: ratings were cached for 12h while episode activity refreshes hourly. Rate on your phone, web keeps serving a ratings snapshot taken before that rating, the watch shows up within the hour, prompt fires
  - marker invalidation only bumps on local actions, and `refetchOnWindowFocus` is off globally, so nothing pulled fresh ratings in between
- Ratings ttl 12h -> 3h, plus `refetchOnWindowFocus` on that query alone
- New `useFreshRatings` gate: prompt only shows when the ratings snapshot is at least as recent as the watch. If it isn't, refetch and stay quiet for now instead of guessing
  - once a refresh has settled we trust whatever the snapshot says. `dataUpdatedAt` is client time, `watchedAt` is server time, so a lagging clock would otherwise suppress the toast forever
- Left the gate predicate firing the invalidation from inside the `map` for now. Splitting the read from the refresh needs two cache reads plus a `tap` for one decision, didn't seem worth it