### PR TITLE
fix(auth): collection of improvements

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -10755,6 +10755,22 @@
     "preview_feature_description_action_confirmations": {
       "default": "Show a confirmation toast with a quick undo when you add, remove, rate, or mark something as watched.",
       "description": "Description for the action-confirmations preview feature toggle in settings."
+    },
+    "text_login_failed_title": {
+      "default": "Couldn't start sign in",
+      "description": "Snackbar title when the sign-in redirect fails before it leaves the app."
+    },
+    "text_login_failed_message": {
+      "default": "Check your connection and try again.",
+      "description": "Snackbar message when the sign-in redirect fails for an unknown reason."
+    },
+    "text_login_rate_limited_title": {
+      "default": "Too many sign in attempts",
+      "description": "Snackbar title when sign in is refused because the viewer is rate limited."
+    },
+    "text_login_rate_limited_message": {
+      "default": "Please wait a moment and try again.",
+      "description": "Snackbar message when sign in is refused because the viewer is rate limited."
     }
   }
 }

--- a/projects/client/src/lib/features/auth/_internal/loginErrorStore.ts
+++ b/projects/client/src/lib/features/auth/_internal/loginErrorStore.ts
@@ -1,0 +1,14 @@
+import { BehaviorSubject, type Observable } from 'rxjs';
+import type { LoginErrorType } from '../models/LoginErrorType.ts';
+
+const errorSubject = new BehaviorSubject<LoginErrorType | null>(null);
+
+export const loginErrorStore: {
+  error$: Observable<LoginErrorType | null>;
+  set: (error: LoginErrorType) => void;
+  clear: () => void;
+} = {
+  error$: errorSubject.asObservable(),
+  set: (error: LoginErrorType) => errorSubject.next(error),
+  clear: () => errorSubject.next(null),
+};

--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -23,15 +23,21 @@
   // document was rendered for whoever populated the entry. Storage is truth.
   const clientAuth = iffy(resolveBrowserAuthState);
 
-  // Optimistic: an expired session still seeds authorized, since the silent
-  // renew `initializeUserManager` fires on init almost always lands before it
-  // matters.
-  const isAuthorized = iffy(() => clientAuth?.hasSession ?? isAuthorizedOidc);
+  // A lapsed access token is not a session that can be spent. Seeding it
+  // authorizes the `useUser` fan-out to leave with a dead bearer, and the 401
+  // that comes back tears the session down before the renewal lands.
+  const hasLiveSession = iffy(
+    () => clientAuth?.hasSession === true && !clientAuth.isExpired,
+  );
+
+  const isAuthorized = iffy(() =>
+    clientAuth == null ? isAuthorizedOidc : hasLiveSession,
+  );
 
   // `useUser` subscribes authorized queries during this first render, before
   // `initializeUserManager` mounts; without a token they 401 and sign out.
   iffy(() => {
-    if (clientAuth?.token.value == null) {
+    if (!hasLiveSession || clientAuth?.token.value == null) {
       return;
     }
 
@@ -41,7 +47,7 @@
   const ctx = iffy(() =>
     createAuthContext({
       isAuthorized,
-      token: clientAuth?.token ?? null,
+      token: hasLiveSession ? (clientAuth?.token ?? null) : null,
     }),
   );
 
@@ -50,11 +56,12 @@
       ctx,
       tokenFromServer: accessToken,
       hasServerSession,
-      // Only skip the gate for a session we actually found. Ungating an
-      // unauthorized tree renders children in this same cycle, and their
-      // `onMount` runs before ours - so `/callback` would reach for
-      // `getUserManager()` before `setUserManager` has been called.
-      isResolved: clientAuth?.hasSession === true,
+      // Only skip the gate for a session that can be spent right now: a lapsed
+      // one waits behind its renewal instead. Ungating an unauthorized tree
+      // renders children in this same cycle, and their `onMount` runs before
+      // ours - so `/callback` would reach for `getUserManager()` before
+      // `setUserManager` has been called.
+      isResolved: hasLiveSession,
     }),
   );
   const { user } = useUser();

--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -23,8 +23,9 @@
   // document was rendered for whoever populated the entry. Storage is truth.
   const clientAuth = iffy(resolveBrowserAuthState);
 
-  // Optimistic: an expired session still seeds authorized, since
-  // `automaticSilentRenew` almost always renews it before it matters.
+  // Optimistic: an expired session still seeds authorized, since the silent
+  // renew `initializeUserManager` fires on init almost always lands before it
+  // matters.
   const isAuthorized = iffy(() => clientAuth?.hasSession ?? isAuthorizedOidc);
 
   // `useUser` subscribes authorized queries during this first render, before

--- a/projects/client/src/lib/features/auth/components/LoginErrorSnackbar.svelte
+++ b/projects/client/src/lib/features/auth/components/LoginErrorSnackbar.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import Snackbar from "$lib/components/snackbar/Snackbar.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { loginErrorStore } from "../_internal/loginErrorStore.ts";
+  import { LoginErrorType } from "../models/LoginErrorType.ts";
+
+  const error$ = loginErrorStore.error$;
+
+  const content = $derived.by(() => {
+    switch ($error$) {
+      case LoginErrorType.RateLimited:
+        return {
+          title: m.text_login_rate_limited_title(),
+          message: m.text_login_rate_limited_message(),
+        };
+      case LoginErrorType.Unreachable:
+        return {
+          title: m.text_login_failed_title(),
+          message: m.text_login_failed_message(),
+        };
+      default:
+        return null;
+    }
+  });
+</script>
+
+{#if content}
+  <Snackbar
+    open
+    title={content.title}
+    message={content.message}
+    variant="error"
+    onDismiss={() => loginErrorStore.clear()}
+  />
+{/if}

--- a/projects/client/src/lib/features/auth/createSilentRenewGuard.spec.ts
+++ b/projects/client/src/lib/features/auth/createSilentRenewGuard.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSilentRenewGuard } from './createSilentRenewGuard.ts';
+
+const cooldown = 30_000;
+const maxFailures = 3;
+const failureReset = 300_000;
+
+function makeGuard(clock: { value: number }) {
+  return createSilentRenewGuard({
+    now: () => clock.value,
+    cooldownMs: cooldown,
+    maxConsecutiveFailures: maxFailures,
+    failureResetMs: failureReset,
+  });
+}
+
+describe('createSilentRenewGuard', () => {
+  it('should run the first attempt', async () => {
+    const clock = { value: 0 };
+    const attempt = vi.fn().mockResolvedValue(undefined);
+
+    await makeGuard(clock).renew(attempt);
+
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip a second attempt within the cooldown', async () => {
+    const clock = { value: 0 };
+    const attempt = vi.fn().mockResolvedValue(undefined);
+    const guard = makeGuard(clock);
+
+    await guard.renew(attempt);
+    clock.value = cooldown - 1;
+    await guard.renew(attempt);
+
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow an attempt once the cooldown lapses', async () => {
+    const clock = { value: 0 };
+    const attempt = vi.fn().mockResolvedValue(undefined);
+    const guard = makeGuard(clock);
+
+    await guard.renew(attempt);
+    clock.value = cooldown;
+    await guard.renew(attempt);
+
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not run a second attempt while one is in flight', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+
+    const attempt = vi.fn().mockImplementation(() =>
+      new Promise((resolve) => setTimeout(resolve, 0))
+    );
+
+    const first = guard.renew(attempt);
+    clock.value = cooldown;
+    await guard.renew(attempt);
+    await first;
+
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('should rethrow so the caller can handle the failure', async () => {
+    const clock = { value: 0 };
+    const error = new Error('nope');
+
+    await expect(makeGuard(clock).renew(() => Promise.reject(error)))
+      .rejects.toThrow(error);
+  });
+
+  it('should stop attempting after consecutive failures', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockRejectedValue(new Error('nope'));
+
+    for (let i = 0; i <= maxFailures; i++) {
+      clock.value = i * cooldown;
+      await guard.renew(attempt).catch(() => null);
+    }
+
+    expect(attempt).toHaveBeenCalledTimes(maxFailures);
+  });
+
+  it('should forget stale failures once the reset window lapses', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockRejectedValue(new Error('nope'));
+
+    for (let i = 0; i < maxFailures; i++) {
+      clock.value = i * cooldown;
+      await guard.renew(attempt).catch(() => null);
+    }
+
+    clock.value = (maxFailures - 1) * cooldown + failureReset;
+    await guard.renew(attempt).catch(() => null);
+
+    expect(attempt).toHaveBeenCalledTimes(maxFailures + 1);
+  });
+
+  it('should reset the failure count after a success', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const failing = vi.fn().mockRejectedValue(new Error('nope'));
+    const passing = vi.fn().mockResolvedValue(undefined);
+
+    await guard.renew(failing).catch(() => null);
+    clock.value = cooldown;
+    await guard.renew(passing);
+
+    clock.value = cooldown * 2;
+    await guard.renew(failing).catch(() => null);
+    clock.value = cooldown * 3;
+    await guard.renew(failing).catch(() => null);
+    clock.value = cooldown * 4;
+    await guard.renew(failing).catch(() => null);
+
+    expect(failing).toHaveBeenCalledTimes(maxFailures + 1);
+  });
+  it('should report whether the attempt actually ran', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockResolvedValue('fresh');
+
+    const attempted = await guard.renew(attempt);
+    const blocked = await guard.renew(attempt);
+
+    expect(attempted).toEqual({ outcome: 'attempted', value: 'fresh' });
+    expect(blocked).toEqual({ outcome: 'blocked', value: null });
+  });
+
+  it('should hand a deferred caller what the in-flight attempt minted', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+
+    let settle: (value: string) => void = () => {};
+    const owner = guard.renew(() =>
+      new Promise<string>((resolve) => {
+        settle = resolve;
+      })
+    );
+
+    const deferred = guard.renew(() => Promise.resolve('second'));
+    settle('first');
+
+    expect(await deferred).toEqual({ outcome: 'deferred', value: 'first' });
+    expect(await owner).toEqual({ outcome: 'attempted', value: 'first' });
+  });
+
+  it('should not report back for a deferred caller when the shared attempt fails', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+
+    let reject: (reason: unknown) => void = () => {};
+    const owner = guard.renew(() =>
+      new Promise<string>((_, fail) => {
+        reject = fail;
+      })
+    );
+    const deferred = guard.renew(() => Promise.resolve('second'));
+
+    reject(new Error('nope'));
+
+    await expect(owner).rejects.toThrow('nope');
+    expect(await deferred).toEqual({ outcome: 'deferred', value: null });
+  });
+});

--- a/projects/client/src/lib/features/auth/createSilentRenewGuard.spec.ts
+++ b/projects/client/src/lib/features/auth/createSilentRenewGuard.spec.ts
@@ -101,6 +101,26 @@ describe('createSilentRenewGuard', () => {
     expect(attempt).toHaveBeenCalledTimes(maxFailures + 1);
   });
 
+  it('should ignore a reset that follows another within the cooldown', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockRejectedValue(new Error('nope'));
+
+    for (let i = 0; i < maxFailures; i++) {
+      clock.value += cooldown;
+      await guard.renew(attempt).catch(() => null);
+    }
+
+    guard.reset();
+    await guard.renew(attempt).catch(() => null);
+    clock.value += cooldown - 1;
+    guard.reset();
+    const blocked = await guard.renew(attempt);
+
+    expect(attempt).toHaveBeenCalledTimes(maxFailures + 1);
+    expect(blocked.outcome).toBe('blocked');
+  });
+
   it('should reset the failure count after a success', async () => {
     const clock = { value: 0 };
     const guard = makeGuard(clock);
@@ -166,5 +186,77 @@ describe('createSilentRenewGuard', () => {
 
     await expect(owner).rejects.toThrow('nope');
     expect(await deferred).toEqual({ outcome: 'deferred', value: null });
+  });
+  it('should let a reconnect outrun the cooldown', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockResolvedValue(undefined);
+
+    await guard.renew(attempt);
+    guard.reset();
+    await guard.renew(attempt);
+
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reopen the breaker on reset', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockRejectedValue(new Error('nope'));
+
+    for (let i = 0; i < maxFailures; i++) {
+      clock.value += cooldown;
+      await guard.renew(attempt).catch(() => null);
+    }
+
+    expect((await guard.renew(attempt)).outcome).toBe('blocked');
+
+    clock.value += cooldown;
+    guard.reset();
+    await guard.renew(attempt).catch(() => null);
+
+    expect(attempt).toHaveBeenCalledTimes(maxFailures + 1);
+  });
+
+  it('should let a caller override the cooldown it waits behind', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockResolvedValue(undefined);
+
+    await guard.renew(attempt);
+    clock.value = 5_000;
+    await guard.renew(attempt, { cooldownMs: 1_000 });
+
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('should still block an overriding caller inside its own cooldown', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockResolvedValue(undefined);
+
+    await guard.renew(attempt);
+    clock.value = 500;
+    const blocked = await guard.renew(attempt, { cooldownMs: 1_000 });
+
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(blocked.outcome).toBe('blocked');
+  });
+
+  it('should hold an overriding caller behind the shared breaker', async () => {
+    const clock = { value: 0 };
+    const guard = makeGuard(clock);
+    const attempt = vi.fn().mockRejectedValue(new Error('nope'));
+
+    for (let i = 0; i < maxFailures; i++) {
+      clock.value = i * cooldown;
+      await guard.renew(attempt).catch(() => null);
+    }
+
+    clock.value = maxFailures * cooldown;
+    const blocked = await guard.renew(attempt, { cooldownMs: 0 });
+
+    expect(attempt).toHaveBeenCalledTimes(maxFailures);
+    expect(blocked.outcome).toBe('blocked');
   });
 });

--- a/projects/client/src/lib/features/auth/createSilentRenewGuard.ts
+++ b/projects/client/src/lib/features/auth/createSilentRenewGuard.ts
@@ -1,0 +1,61 @@
+type CreateSilentRenewGuardParams = {
+  now: () => number;
+  cooldownMs: number;
+  maxConsecutiveFailures: number;
+  failureResetMs: number;
+};
+
+type RenewOutcome = 'attempted' | 'deferred' | 'blocked';
+
+type RenewResult<T> = {
+  outcome: RenewOutcome;
+  value: T | null;
+};
+
+export function createSilentRenewGuard<T>({
+  now,
+  cooldownMs,
+  maxConsecutiveFailures,
+  failureResetMs,
+}: CreateSilentRenewGuardParams) {
+  let inflight: Promise<T> | null = null;
+  let lastAttemptAt: number | null = null;
+  let consecutiveFailures = 0;
+
+  const sinceLastAttempt = () =>
+    lastAttemptAt == null ? Infinity : now() - lastAttemptAt;
+
+  return {
+    async renew(attempt: () => Promise<T>): Promise<RenewResult<T>> {
+      if (inflight) {
+        return { outcome: 'deferred', value: await inflight.catch(() => null) };
+      }
+
+      if (sinceLastAttempt() >= failureResetMs) {
+        consecutiveFailures = 0;
+      }
+
+      if (consecutiveFailures >= maxConsecutiveFailures) {
+        return { outcome: 'blocked', value: null };
+      }
+
+      if (sinceLastAttempt() < cooldownMs) {
+        return { outcome: 'blocked', value: null };
+      }
+
+      lastAttemptAt = now();
+
+      try {
+        inflight = attempt();
+        const value = await inflight;
+        consecutiveFailures = 0;
+        return { outcome: 'attempted', value };
+      } catch (error) {
+        consecutiveFailures = consecutiveFailures + 1;
+        throw error;
+      } finally {
+        inflight = null;
+      }
+    },
+  };
+}

--- a/projects/client/src/lib/features/auth/createSilentRenewGuard.ts
+++ b/projects/client/src/lib/features/auth/createSilentRenewGuard.ts
@@ -12,6 +12,10 @@ type RenewResult<T> = {
   value: T | null;
 };
 
+type RenewParams = {
+  cooldownMs: number;
+};
+
 export function createSilentRenewGuard<T>({
   now,
   cooldownMs,
@@ -20,18 +24,34 @@ export function createSilentRenewGuard<T>({
 }: CreateSilentRenewGuardParams) {
   let inflight: Promise<T> | null = null;
   let lastAttemptAt: number | null = null;
+  let lastFailureAt: number | null = null;
+  let lastResetAt: number | null = null;
   let consecutiveFailures = 0;
 
-  const sinceLastAttempt = () =>
-    lastAttemptAt == null ? Infinity : now() - lastAttemptAt;
+  const elapsedSince = (at: number | null) =>
+    at == null ? Infinity : now() - at;
 
   return {
-    async renew(attempt: () => Promise<T>): Promise<RenewResult<T>> {
+    reset() {
+      if (elapsedSince(lastResetAt) < cooldownMs) {
+        return;
+      }
+
+      lastResetAt = now();
+      lastAttemptAt = null;
+      lastFailureAt = null;
+      consecutiveFailures = 0;
+    },
+
+    async renew(
+      attempt: () => Promise<T>,
+      { cooldownMs: attemptCooldownMs = cooldownMs }: Partial<RenewParams> = {},
+    ): Promise<RenewResult<T>> {
       if (inflight) {
         return { outcome: 'deferred', value: await inflight.catch(() => null) };
       }
 
-      if (sinceLastAttempt() >= failureResetMs) {
+      if (elapsedSince(lastFailureAt) >= failureResetMs) {
         consecutiveFailures = 0;
       }
 
@@ -39,7 +59,7 @@ export function createSilentRenewGuard<T>({
         return { outcome: 'blocked', value: null };
       }
 
-      if (sinceLastAttempt() < cooldownMs) {
+      if (elapsedSince(lastAttemptAt) < attemptCooldownMs) {
         return { outcome: 'blocked', value: null };
       }
 
@@ -49,9 +69,11 @@ export function createSilentRenewGuard<T>({
         inflight = attempt();
         const value = await inflight;
         consecutiveFailures = 0;
+        lastFailureAt = null;
         return { outcome: 'attempted', value };
       } catch (error) {
         consecutiveFailures = consecutiveFailures + 1;
+        lastFailureAt = now();
         throw error;
       } finally {
         inflight = null;

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -3,6 +3,12 @@ import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
 import { resolveOidcAuthority } from './resolveOidcAuthority.ts';
 
+// The renewal POST rotates the refresh token the moment it lands, so aborting
+// it early strands the one it minted. oidc-client-ts defaults to 10s there,
+// and to no timeout at all for the discovery fetch.
+const RENEW_TIMEOUT_SECONDS = 30;
+const DISCOVERY_TIMEOUT_SECONDS = 15;
+
 export function getOidcConfig(): UserManagerSettings {
   const referrer = getReferrer();
 
@@ -14,6 +20,8 @@ export function getOidcConfig(): UserManagerSettings {
     response_type: 'code',
     scope: 'public openid profile email',
     automaticSilentRenew: false,
+    silentRequestTimeoutInSeconds: RENEW_TIMEOUT_SECONDS,
+    requestTimeoutInSeconds: DISCOVERY_TIMEOUT_SECONDS,
     userStore: new WebStorageStateStore({
       store: safeLocalStorage,
     }),

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -13,7 +13,7 @@ export function getOidcConfig(): UserManagerSettings {
     silent_redirect_uri: `${referrer}/silent-redirect`,
     response_type: 'code',
     scope: 'public openid profile email',
-    automaticSilentRenew: true,
+    automaticSilentRenew: false,
     userStore: new WebStorageStateStore({
       store: safeLocalStorage,
     }),

--- a/projects/client/src/lib/features/auth/isFatalRenewError.spec.ts
+++ b/projects/client/src/lib/features/auth/isFatalRenewError.spec.ts
@@ -1,0 +1,33 @@
+import { ErrorResponse } from 'oidc-client-ts';
+import { describe, expect, it } from 'vitest';
+import { isFatalRenewError } from './isFatalRenewError.ts';
+
+describe('isFatalRenewError', () => {
+  it('should treat a rejected refresh token as fatal', () => {
+    expect(isFatalRenewError(new ErrorResponse({ error: 'invalid_grant' })))
+      .toBe(true);
+  });
+
+  it('should treat a lapsed provider session as fatal', () => {
+    expect(isFatalRenewError(new ErrorResponse({ error: 'login_required' })))
+      .toBe(true);
+  });
+
+  it('should treat a provider outage as transient', () => {
+    expect(isFatalRenewError(new ErrorResponse({ error: 'server_error' })))
+      .toBe(false);
+  });
+
+  it('should treat a network failure as transient', () => {
+    expect(isFatalRenewError(new TypeError('Failed to fetch'))).toBe(false);
+  });
+
+  it('should treat a status-only failure as transient', () => {
+    expect(isFatalRenewError(new Error('Too Many Requests (429): {}')))
+      .toBe(false);
+  });
+
+  it('should treat a thrown non-error as transient', () => {
+    expect(isFatalRenewError('invalid_grant')).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/auth/isFatalRenewError.ts
+++ b/projects/client/src/lib/features/auth/isFatalRenewError.ts
@@ -1,0 +1,20 @@
+import { ErrorResponse } from 'oidc-client-ts';
+
+const fatalErrorCodes = [
+  'invalid_grant',
+  'invalid_client',
+  'unauthorized_client',
+  'invalid_scope',
+  'access_denied',
+  'login_required',
+  'consent_required',
+  'interaction_required',
+];
+
+export function isFatalRenewError(error: unknown): boolean {
+  if (!(error instanceof ErrorResponse)) {
+    return false;
+  }
+
+  return fatalErrorCodes.includes(error.error ?? '');
+}

--- a/projects/client/src/lib/features/auth/isRateLimitError.spec.ts
+++ b/projects/client/src/lib/features/auth/isRateLimitError.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isRateLimitError } from './isRateLimitError.ts';
+
+describe('isRateLimitError', () => {
+  it('should match a status carried in the message', () => {
+    expect(isRateLimitError(new Error('Too Many Requests (429): {}')))
+      .toBe(true);
+  });
+
+  it('should not match a longer number containing the status', () => {
+    expect(isRateLimitError(new Error('failed after 4291ms'))).toBe(false);
+  });
+
+  it('should not match an unrelated status', () => {
+    expect(isRateLimitError(new Error('Bad Gateway (502)'))).toBe(false);
+  });
+
+  it('should not match a thrown non-error', () => {
+    expect(isRateLimitError('429')).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/auth/isRateLimitError.ts
+++ b/projects/client/src/lib/features/auth/isRateLimitError.ts
@@ -1,0 +1,5 @@
+const rateLimitPattern = /\b429\b/;
+
+export function isRateLimitError(error: unknown): boolean {
+  return error instanceof Error && rateLimitPattern.test(error.message);
+}

--- a/projects/client/src/lib/features/auth/mapToLoginError.spec.ts
+++ b/projects/client/src/lib/features/auth/mapToLoginError.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { mapToLoginError } from './mapToLoginError.ts';
+import { LoginErrorType } from './models/LoginErrorType.ts';
+
+describe('mapToLoginError', () => {
+  it('should report a rate limit when the status is readable', () => {
+    expect(mapToLoginError(new Error('Rate limited (429)')))
+      .toBe(LoginErrorType.RateLimited);
+  });
+
+  it('should not read a status out of an unrelated number', () => {
+    expect(mapToLoginError(new Error('failed after 4291ms')))
+      .toBe(LoginErrorType.Unreachable);
+  });
+
+  it('should fall back when CORS hides the status', () => {
+    expect(mapToLoginError(new TypeError('Failed to fetch')))
+      .toBe(LoginErrorType.Unreachable);
+  });
+
+  it('should fall back for a thrown non-error', () => {
+    expect(mapToLoginError('429')).toBe(LoginErrorType.Unreachable);
+  });
+});

--- a/projects/client/src/lib/features/auth/mapToLoginError.ts
+++ b/projects/client/src/lib/features/auth/mapToLoginError.ts
@@ -1,0 +1,8 @@
+import { isRateLimitError } from './isRateLimitError.ts';
+import { LoginErrorType } from './models/LoginErrorType.ts';
+
+export function mapToLoginError(error: unknown): LoginErrorType {
+  return isRateLimitError(error)
+    ? LoginErrorType.RateLimited
+    : LoginErrorType.Unreachable;
+}

--- a/projects/client/src/lib/features/auth/models/LoginErrorType.ts
+++ b/projects/client/src/lib/features/auth/models/LoginErrorType.ts
@@ -1,0 +1,4 @@
+export enum LoginErrorType {
+  RateLimited = 'RateLimited',
+  Unreachable = 'Unreachable',
+}

--- a/projects/client/src/lib/features/auth/renewAccessToken.spec.ts
+++ b/projects/client/src/lib/features/auth/renewAccessToken.spec.ts
@@ -15,16 +15,19 @@ function makeUser(expiresInSeconds: number): User {
 
 function makeManager(current: User | null, renewed: User | null = null) {
   const signinSilent = vi.fn().mockResolvedValue(renewed);
+  const load = vi.fn().mockResolvedValue(undefined);
 
   return {
     manager: {
       getUser: vi.fn().mockResolvedValue(current),
       signinSilent,
+      events: { load },
       settings: {
         accessTokenExpiringNotificationTimeInSeconds: notificationTimeSeconds,
       },
     } as unknown as UserManager,
     signinSilent,
+    load,
   };
 }
 
@@ -47,7 +50,7 @@ describe('renewAccessToken', () => {
     const result = await renewAccessToken(manager);
 
     expect(signinSilent).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ user: renewed, didAdopt: false });
+    expect(result).toBe(renewed);
   });
 
   it('should renew when there is no stored token', async () => {
@@ -57,7 +60,7 @@ describe('renewAccessToken', () => {
     const result = await renewAccessToken(manager);
 
     expect(signinSilent).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ user: renewed, didAdopt: false });
+    expect(result).toBe(renewed);
   });
 
   it('should adopt a token another holder just minted', async () => {
@@ -67,7 +70,37 @@ describe('renewAccessToken', () => {
     const result = await renewAccessToken(manager);
 
     expect(signinSilent).not.toHaveBeenCalled();
-    expect(result).toEqual({ user: current, didAdopt: true });
+    expect(result).toBe(current);
+  });
+
+  it('should renew a fresh token the server just rejected', async () => {
+    const current = makeUser(3600);
+    const renewed = makeUser(7200);
+    const { manager, signinSilent } = makeManager(current, renewed);
+
+    const result = await renewAccessToken(manager, current.access_token);
+
+    expect(signinSilent).toHaveBeenCalledTimes(1);
+    expect(result).toBe(renewed);
+  });
+
+  it('should adopt a fresh token when another holder minted it', async () => {
+    const current = makeUser(3600);
+    const { manager, signinSilent } = makeManager(current);
+
+    const result = await renewAccessToken(manager, 'a-token-since-replaced');
+
+    expect(signinSilent).not.toHaveBeenCalled();
+    expect(result).toBe(current);
+  });
+
+  it('should announce an adopted token so every holder writes it', async () => {
+    const current = makeUser(3600);
+    const { manager, load } = makeManager(current);
+
+    await renewAccessToken(manager);
+
+    expect(load).toHaveBeenCalledWith(current);
   });
 
   it('should renew a token already inside its expiring window', async () => {

--- a/projects/client/src/lib/features/auth/renewAccessToken.spec.ts
+++ b/projects/client/src/lib/features/auth/renewAccessToken.spec.ts
@@ -1,0 +1,107 @@
+import { time } from '$lib/utils/timing/time.ts';
+import type { User, UserManager } from 'oidc-client-ts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renewAccessToken } from './renewAccessToken.ts';
+
+const notificationTimeSeconds = 60;
+
+function makeUser(expiresInSeconds: number): User {
+  return {
+    access_token: `token-${expiresInSeconds}`,
+    expires_at: (Date.now() + time.seconds(expiresInSeconds)) / 1000,
+    expired: expiresInSeconds <= 0,
+  } as User;
+}
+
+function makeManager(current: User | null, renewed: User | null = null) {
+  const signinSilent = vi.fn().mockResolvedValue(renewed);
+
+  return {
+    manager: {
+      getUser: vi.fn().mockResolvedValue(current),
+      signinSilent,
+      settings: {
+        accessTokenExpiringNotificationTimeInSeconds: notificationTimeSeconds,
+      },
+    } as unknown as UserManager,
+    signinSilent,
+  };
+}
+
+function stubLocks(request: (name: string, task: () => unknown) => unknown) {
+  Object.defineProperty(globalThis.navigator, 'locks', {
+    configurable: true,
+    value: { request },
+  });
+}
+
+describe('renewAccessToken', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis.navigator, 'locks');
+  });
+
+  it('should renew when the stored token has lapsed', async () => {
+    const renewed = makeUser(3600);
+    const { manager, signinSilent } = makeManager(makeUser(-1), renewed);
+
+    const result = await renewAccessToken(manager);
+
+    expect(signinSilent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ user: renewed, didAdopt: false });
+  });
+
+  it('should renew when there is no stored token', async () => {
+    const renewed = makeUser(3600);
+    const { manager, signinSilent } = makeManager(null, renewed);
+
+    const result = await renewAccessToken(manager);
+
+    expect(signinSilent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ user: renewed, didAdopt: false });
+  });
+
+  it('should adopt a token another holder just minted', async () => {
+    const current = makeUser(3600);
+    const { manager, signinSilent } = makeManager(current);
+
+    const result = await renewAccessToken(manager);
+
+    expect(signinSilent).not.toHaveBeenCalled();
+    expect(result).toEqual({ user: current, didAdopt: true });
+  });
+
+  it('should renew a token already inside its expiring window', async () => {
+    const renewed = makeUser(3600);
+    const { manager, signinSilent } = makeManager(
+      makeUser(notificationTimeSeconds - 1),
+      renewed,
+    );
+
+    await renewAccessToken(manager);
+
+    expect(signinSilent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should hold the renew lock for the whole attempt', async () => {
+    const request = vi.fn((_name: string, task: () => unknown) => task());
+    stubLocks(request);
+    const { manager } = makeManager(makeUser(-1), makeUser(3600));
+
+    await renewAccessToken(manager);
+
+    expect(request).toHaveBeenCalledWith(
+      'trakt-auth-renew',
+      expect.any(
+        Function,
+      ),
+    );
+  });
+
+  it('should renew without a lock manager', async () => {
+    const { manager, signinSilent } = makeManager(makeUser(-1), makeUser(3600));
+
+    await renewAccessToken(manager);
+
+    expect(signinSilent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/projects/client/src/lib/features/auth/renewAccessToken.ts
+++ b/projects/client/src/lib/features/auth/renewAccessToken.ts
@@ -3,15 +3,6 @@ import type { User, UserManager } from 'oidc-client-ts';
 
 const RENEW_LOCK_NAME = 'trakt-auth-renew';
 
-export type RenewedSession = {
-  user: User | null;
-  /**
-   * True when another holder had already renewed, so `signinSilent` was skipped
-   * and no `userLoaded` event was raised for this user.
-   */
-  didAdopt: boolean;
-};
-
 function withRenewLock<T>(task: () => Promise<T>): Promise<T> {
   if (!navigator.locks) {
     return task();
@@ -25,7 +16,13 @@ function withRenewLock<T>(task: () => Promise<T>): Promise<T> {
 // origin - the rest adopt what it minted instead of spending theirs again.
 export function renewAccessToken(
   manager: UserManager,
-): Promise<RenewedSession> {
+  /**
+   * The access token a 401 just refused, when the renewal is reactive. Storage
+   * still holding it means nobody has renewed and its expiry cannot be
+   * trusted, so the freshness check below must not adopt it.
+   */
+  rejectedToken?: string | null,
+): Promise<User | null> {
   return withRenewLock(async () => {
     const current = await manager.getUser();
 
@@ -33,12 +30,16 @@ export function renewAccessToken(
       manager.settings.accessTokenExpiringNotificationTimeInSeconds,
     );
     const didAnotherHolderRenew = current != null && !current.expired &&
+      current.access_token !== rejectedToken &&
       time.seconds(current.expires_at ?? 0) > expiringAt;
 
     if (didAnotherHolderRenew) {
-      return { user: current, didAdopt: true };
+      // `signinSilent` raises `userLoaded` itself; adopting has to, or only
+      // the minting holder ends up writing the token.
+      await manager.events.load(current);
+      return current;
     }
 
-    return { user: await manager.signinSilent(), didAdopt: false };
+    return await manager.signinSilent();
   });
 }

--- a/projects/client/src/lib/features/auth/renewAccessToken.ts
+++ b/projects/client/src/lib/features/auth/renewAccessToken.ts
@@ -1,0 +1,44 @@
+import { time } from '$lib/utils/timing/time.ts';
+import type { User, UserManager } from 'oidc-client-ts';
+
+const RENEW_LOCK_NAME = 'trakt-auth-renew';
+
+export type RenewedSession = {
+  user: User | null;
+  /**
+   * True when another holder had already renewed, so `signinSilent` was skipped
+   * and no `userLoaded` event was raised for this user.
+   */
+  didAdopt: boolean;
+};
+
+function withRenewLock<T>(task: () => Promise<T>): Promise<T> {
+  if (!navigator.locks) {
+    return task();
+  }
+
+  return navigator.locks.request(RENEW_LOCK_NAME, task);
+}
+
+// Refresh tokens rotate on use, so a second concurrent renewal presents a
+// consumed token and the server reads it as a replay. One holder at a time per
+// origin - the rest adopt what it minted instead of spending theirs again.
+export function renewAccessToken(
+  manager: UserManager,
+): Promise<RenewedSession> {
+  return withRenewLock(async () => {
+    const current = await manager.getUser();
+
+    const expiringAt = Date.now() + time.seconds(
+      manager.settings.accessTokenExpiringNotificationTimeInSeconds,
+    );
+    const didAnotherHolderRenew = current != null && !current.expired &&
+      time.seconds(current.expires_at ?? 0) > expiringAt;
+
+    if (didAnotherHolderRenew) {
+      return { user: current, didAdopt: true };
+    }
+
+    return { user: await manager.signinSilent(), didAdopt: false };
+  });
+}

--- a/projects/client/src/lib/features/auth/renewAccessToken.ts
+++ b/projects/client/src/lib/features/auth/renewAccessToken.ts
@@ -8,7 +8,13 @@ function withRenewLock<T>(task: () => Promise<T>): Promise<T> {
     return task();
   }
 
-  return navigator.locks.request(RENEW_LOCK_NAME, task);
+  // lib.dom's LockGrantedCallback types the callback's return as a bare `T`
+  // rather than `T | PromiseLike<T>`, even though the spec awaits it - so TS
+  // can't infer through the promise `task` returns. The runtime does flatten
+  // it, hence the cast.
+  return navigator.locks.request(RENEW_LOCK_NAME, task) as unknown as Promise<
+    T
+  >;
 }
 
 // Refresh tokens rotate on use, so a second concurrent renewal presents a

--- a/projects/client/src/lib/features/auth/silentRenewPolicy.ts
+++ b/projects/client/src/lib/features/auth/silentRenewPolicy.ts
@@ -1,0 +1,11 @@
+import { time } from '$lib/utils/timing/time.ts';
+
+export const silentRenewPolicy: {
+  cooldownMs: number;
+  maxConsecutiveFailures: number;
+  failureResetMs: number;
+} = {
+  cooldownMs: time.seconds(30),
+  maxConsecutiveFailures: 3,
+  failureResetMs: time.minutes(5),
+};

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject } from 'rxjs';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { ErrorResponse, type User, UserManager } from 'oidc-client-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { silentRenewPolicy } from '../silentRenewPolicy.ts';
 import { getToken, type Token } from '../token/index.ts';
 import type { AuthContextType } from './createAuthContext.ts';
 import { getAuthContext } from './getAuthContext.ts';
@@ -28,6 +29,19 @@ function stubServiceWorker() {
 }
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const { cooldownMs, failureResetMs, maxConsecutiveFailures } =
+  silentRenewPolicy;
+
+const openBreaker = async (
+  stub: { signinSilent: ReturnType<typeof vi.fn> },
+) => {
+  await vi.advanceTimersByTimeAsync(cooldownMs * (maxConsecutiveFailures - 1));
+  expect(stub.signinSilent).toHaveBeenCalledTimes(maxConsecutiveFailures);
+
+  await vi.advanceTimersByTimeAsync(cooldownMs);
+  expect(stub.signinSilent).toHaveBeenCalledTimes(maxConsecutiveFailures);
+};
 
 function makeLapsedUser(): User {
   return {
@@ -171,6 +185,7 @@ describe('initializeUserManager', () => {
   });
   describe('renewal', () => {
     afterEach(() => {
+      vi.useRealTimers();
       vi.mocked(UserManager).mockReset();
     });
 
@@ -206,6 +221,79 @@ describe('initializeUserManager', () => {
 
       expect(stub.removeUser).toHaveBeenCalledTimes(1);
       expect(isInitializing()).toBe(false);
+    });
+
+    it('should keep a session whose refresh token survived a transient failure', async () => {
+      const { stub } = stubUserManager(() =>
+        Promise.reject(new TypeError('Failed to fetch'))
+      );
+
+      await renderGate();
+
+      expect(stub.removeUser).not.toHaveBeenCalled();
+    });
+
+    it('should retry once the cooldown lapses', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { stub } = stubUserManager(() =>
+        Promise.reject(new TypeError('Failed to fetch'))
+      );
+
+      await renderGate();
+
+      expect(stub.signinSilent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(cooldownMs);
+
+      expect(stub.signinSilent).toHaveBeenCalledTimes(2);
+    });
+
+    it('should let a reconnect renew without waiting out the cooldown', async () => {
+      const { stub } = stubUserManager(() =>
+        Promise.reject(new TypeError('Failed to fetch'))
+      );
+
+      await renderGate();
+
+      expect(stub.signinSilent).toHaveBeenCalledTimes(1);
+
+      globalThis.window.dispatchEvent(new Event('online'));
+      await flush();
+
+      expect(stub.signinSilent).toHaveBeenCalledTimes(2);
+    });
+
+    it('should let a reconnect renew past an open breaker', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { stub } = stubUserManager(() =>
+        Promise.reject(new TypeError('Failed to fetch'))
+      );
+
+      await renderGate();
+      await openBreaker(stub);
+
+      globalThis.window.dispatchEvent(new Event('online'));
+      await flush();
+
+      expect(stub.signinSilent).toHaveBeenCalledTimes(
+        maxConsecutiveFailures + 1,
+      );
+    });
+
+    it('should keep retrying until an open breaker resets', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { stub } = stubUserManager(() =>
+        Promise.reject(new TypeError('Failed to fetch'))
+      );
+
+      await renderGate();
+      await openBreaker(stub);
+
+      await vi.advanceTimersByTimeAsync(failureResetMs);
+
+      expect(stub.signinSilent.mock.calls.length).toBeGreaterThan(
+        maxConsecutiveFailures,
+      );
     });
   });
 });

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
@@ -1,9 +1,14 @@
 import { time } from '$lib/utils/timing/time.ts';
 import { OidcUserMock } from '$mocks/data/auth/OidcUserMock.ts';
+import UserManagerTestBed from '$test/beds/auth/UserManagerTestBed.svelte';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { render } from '@testing-library/svelte';
+import { BehaviorSubject } from 'rxjs';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
+import { type User, UserManager } from 'oidc-client-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getToken } from '../token/index.ts';
+import { getToken, type Token } from '../token/index.ts';
+import type { AuthContextType } from './createAuthContext.ts';
 import { getAuthContext } from './getAuthContext.ts';
 import { initializeUserManager } from './initializeUserManager.ts';
 import { useAuth } from './useAuth.ts';
@@ -23,6 +28,80 @@ function stubServiceWorker() {
 }
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makeLapsedUser(): User {
+  return {
+    access_token: 'lapsed-token',
+    refresh_token: 'refresh-token',
+    expires_at: (Date.now() - time.hours(1)) / 1000,
+    expired: true,
+  } as User;
+}
+
+function makeFreshUser(): User {
+  return {
+    access_token: 'fresh-token',
+    refresh_token: 'refresh-token',
+    expires_at: (Date.now() + time.hours(1)) / 1000,
+    expired: false,
+  } as User;
+}
+
+function stubUserManager(
+  signinSilent: () => Promise<User | null>,
+  user: User | null = makeLapsedUser(),
+) {
+  const handlers = new Map<string, () => void>();
+
+  const stub = {
+    getUser: vi.fn(() => Promise.resolve(user)),
+    signinSilent: vi.fn(signinSilent),
+    removeUser: vi.fn().mockResolvedValue(undefined),
+    settings: { accessTokenExpiringNotificationTimeInSeconds: 60 },
+    events: {
+      addAccessTokenExpiring: vi.fn(() => () => {}),
+      addAccessTokenExpired: vi.fn((cb: () => void) => {
+        handlers.set('expired', cb);
+        return () => handlers.delete('expired');
+      }),
+      addUserLoaded: vi.fn(() => () => {}),
+      addUserUnloaded: vi.fn(() => () => {}),
+      load: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+
+  vi.mocked(UserManager).mockImplementation(function () {
+    return stub as unknown as UserManager;
+  });
+
+  return {
+    stub,
+    raiseAccessTokenExpired: () => handlers.get('expired')?.(),
+  };
+}
+
+function renderUserManager() {
+  const ctx: AuthContextType = {
+    isAuthorized: new BehaviorSubject(false),
+    token: new BehaviorSubject<Token | null>(null),
+  };
+
+  return new Promise<ReturnType<typeof initializeUserManager>>((resolve) =>
+    render(UserManagerTestBed, {
+      props: { params: { ctx, isResolved: false }, output: resolve },
+    })
+  );
+}
+
+async function renderGate() {
+  const { isInitializing } = await renderUserManager();
+
+  const emissions: boolean[] = [];
+  isInitializing.subscribe((value) => emissions.push(value));
+  await flush();
+
+  return () => emissions.at(-1);
+}
 
 const bustedNavigationCache = () =>
   postMessage.mock.calls.some(([message]) =>
@@ -89,5 +168,33 @@ describe('initializeUserManager', () => {
     await flush();
 
     expect(bustedNavigationCache()).toBe(true);
+  });
+  describe('renewal', () => {
+    afterEach(() => {
+      vi.mocked(UserManager).mockReset();
+    });
+
+    it('should hold the gate while a renewal another holder started is in flight', async () => {
+      let settle: (value: User | null) => void = () => {};
+      const { raiseAccessTokenExpired } = stubUserManager(() =>
+        new Promise<User | null>((resolve) => {
+          settle = resolve;
+        })
+      );
+
+      const isInitializing = await renderGate();
+
+      expect(isInitializing()).toBe(true);
+
+      raiseAccessTokenExpired();
+      await flush();
+
+      expect(isInitializing()).toBe(true);
+
+      settle(makeFreshUser());
+      await flush();
+
+      expect(isInitializing()).toBe(false);
+    });
   });
 });

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
@@ -5,7 +5,7 @@ import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { render } from '@testing-library/svelte';
 import { BehaviorSubject } from 'rxjs';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
-import { type User, UserManager } from 'oidc-client-ts';
+import { ErrorResponse, type User, UserManager } from 'oidc-client-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getToken, type Token } from '../token/index.ts';
 import type { AuthContextType } from './createAuthContext.ts';
@@ -194,6 +194,17 @@ describe('initializeUserManager', () => {
       settle(makeFreshUser());
       await flush();
 
+      expect(isInitializing()).toBe(false);
+    });
+
+    it('should clear a refused grant out of storage', async () => {
+      const { stub } = stubUserManager(() =>
+        Promise.reject(new ErrorResponse({ error: 'invalid_grant' }))
+      );
+
+      const isInitializing = await renderGate();
+
+      expect(stub.removeUser).toHaveBeenCalledTimes(1);
       expect(isInitializing()).toBe(false);
     });
   });

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -16,15 +16,13 @@ import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
 import { postToken } from '../postToken.ts';
 import { renewAccessToken } from '../renewAccessToken.ts';
 import { resolveOidcAuthority } from '../resolveOidcAuthority.ts';
+import { NOOP_FN } from '$lib/utils/constants.ts';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
-import { time } from '$lib/utils/timing/time.ts';
+import { silentRenewPolicy } from '../silentRenewPolicy.ts';
 import { setToken, type Token } from '../token/index.ts';
 import type { AuthContextType } from './createAuthContext.ts';
+import { setSilentRenewGuard } from './silentRenewGuard.ts';
 import { setUserManager } from './userManager.ts';
-
-const renewCooldown = time.seconds(30);
-const maxRenewFailures = 3;
-const renewFailureReset = time.minutes(5);
 
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
@@ -65,11 +63,11 @@ export function initializeUserManager(
       getOidcConfig(),
     );
 
-    const renewGuard = createSilentRenewGuard({
+    let retryHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const renewGuard = createSilentRenewGuard<User | null>({
       now: () => Date.now(),
-      cooldownMs: renewCooldown,
-      maxConsecutiveFailures: maxRenewFailures,
-      failureResetMs: renewFailureReset,
+      ...silentRenewPolicy,
     });
 
     const syncToken = (user: User | null) => {
@@ -122,13 +120,24 @@ export function initializeUserManager(
       );
     };
 
+    const scheduleRenewRetry = () => {
+      if (retryHandle != null) {
+        return;
+      }
+
+      retryHandle = setTimeout(() => {
+        retryHandle = null;
+        renewIfLapsed();
+      }, silentRenewPolicy.cooldownMs);
+    };
+
     const handleSilentRenewFailure = async (error: unknown) => {
       if (isRateLimitError(error) && isInitializing.value) {
         dispatchRateLimitError();
       }
 
       if (isFatalRenewError(error)) {
-        await manager.removeUser().catch(() => {});
+        await manager.removeUser().catch(NOOP_FN);
         handleUserEvent(null);
         return;
       }
@@ -140,12 +149,20 @@ export function initializeUserManager(
       const current = await manager.getUser().catch(() => null);
       if (current?.refresh_token == null) {
         handleUserEvent(null);
+        return;
       }
+
+      scheduleRenewRetry();
     };
 
     const renewSilently = () => {
       renewGuard
         .renew(() => renewAccessToken(manager))
+        .then(({ outcome }) => {
+          if (outcome === 'blocked') {
+            scheduleRenewRetry();
+          }
+        })
         .catch(handleSilentRenewFailure)
         // The guard resolves without attempting once its breaker is open, and
         // a gated tree that never hears back renders nothing at all.
@@ -175,13 +192,31 @@ export function initializeUserManager(
       syncToken(user);
     };
 
-    const checkTokenOnFocus = async () => {
-      const user = await manager.getUser();
-      if (!user?.expired) {
+    // A tab that opens already focused never fires `focus`, so a failed
+    // renewal would sit lapsed until a manual reload.
+    function renewIfLapsed() {
+      manager.getUser()
+        .then((user) => {
+          if (!user?.expired) {
+            return;
+          }
+
+          renewSilently();
+        })
+        .catch(NOOP_FN);
+    }
+
+    const renewOnReconnect = () => {
+      renewGuard.reset();
+      renewIfLapsed();
+    };
+
+    const renewIfVisible = () => {
+      if (globalThis.document.visibilityState !== 'visible') {
         return;
       }
 
-      renewSilently();
+      renewIfLapsed();
     };
 
     const disposeExpiring = manager.events.addAccessTokenExpiring(
@@ -197,16 +232,30 @@ export function initializeUserManager(
 
     manager.getUser().then(initializeUser);
 
-    globalThis.window.addEventListener('focus', checkTokenOnFocus);
+    globalThis.window.addEventListener('focus', renewIfLapsed);
+    globalThis.window.addEventListener('online', renewOnReconnect);
+    globalThis.document.addEventListener('visibilitychange', renewIfVisible);
 
+    setSilentRenewGuard(renewGuard);
     setUserManager(manager);
 
     return () => {
+      if (retryHandle != null) {
+        clearTimeout(retryHandle);
+        retryHandle = null;
+      }
+
       disposeExpiring();
       disposeExpired();
       disposeUserLoaded();
       disposeUserUnloaded();
-      globalThis.window.removeEventListener('focus', checkTokenOnFocus);
+      globalThis.window.removeEventListener('focus', renewIfLapsed);
+      globalThis.window.removeEventListener('online', renewOnReconnect);
+      globalThis.document.removeEventListener(
+        'visibilitychange',
+        renewIfVisible,
+      );
+      setSilentRenewGuard(null);
       setUserManager(null);
     };
   });

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -24,6 +24,16 @@ import { setUserManager } from './userManager.ts';
 const renewCooldown = time.seconds(30);
 const maxRenewFailures = 3;
 const renewFailureReset = time.minutes(5);
+const renewLockName = 'trakt-auth-renew';
+
+async function withRenewLock(task: () => Promise<void>) {
+  if (!navigator.locks) {
+    await task();
+    return;
+  }
+
+  await navigator.locks.request(renewLockName, task);
+}
 
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
@@ -141,9 +151,28 @@ export function initializeUserManager(
       isInitializing.next(false);
     };
 
+    const renewUnderLock = async () => {
+      await withRenewLock(async () => {
+        const current = await manager.getUser();
+
+        const expiringAt = Date.now() + time.seconds(
+          manager.settings.accessTokenExpiringNotificationTimeInSeconds,
+        );
+        const didAnotherTabRenew = current != null && !current.expired &&
+          time.seconds(current.expires_at ?? 0) > expiringAt;
+
+        if (didAnotherTabRenew) {
+          handleUserEvent(current);
+          return;
+        }
+
+        await manager.signinSilent();
+      });
+    };
+
     const renewSilently = () => {
       renewGuard
-        .renew(() => manager.signinSilent())
+        .renew(renewUnderLock)
         .catch(handleSilentRenewFailure);
     };
 
@@ -179,15 +208,28 @@ export function initializeUserManager(
       renewSilently();
     };
 
+    const disposeExpiring = manager.events.addAccessTokenExpiring(
+      renewSilently,
+    );
+    const disposeExpired = manager.events.addAccessTokenExpired(
+      renewSilently,
+    );
+    const disposeUserLoaded = manager.events.addUserLoaded(handleUserEvent);
+    const disposeUserUnloaded = manager.events.addUserUnloaded(
+      () => handleUserEvent(null),
+    );
+
     manager.getUser().then(initializeUser);
-    manager.events.addUserLoaded(handleUserEvent);
-    manager.events.addUserUnloaded(() => handleUserEvent(null));
 
     globalThis.window.addEventListener('focus', checkTokenOnFocus);
 
     setUserManager(manager);
 
     return () => {
+      disposeExpiring();
+      disposeExpired();
+      disposeUserLoaded();
+      disposeUserUnloaded();
       globalThis.window.removeEventListener('focus', checkTokenOnFocus);
       setUserManager(null);
     };

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -6,6 +6,7 @@ import { type User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, of } from 'rxjs';
 import { onMount } from 'svelte';
 import { writeAuthMarker } from '../authMarker.ts';
+import { createSilentRenewGuard } from '../createSilentRenewGuard.ts';
 import { deriveStandardAuthority } from '../deriveStandardAuthority.ts';
 import { getOidcConfig } from '../getOidcConfig.ts';
 import { mapToToken } from '../mapToToken.ts';
@@ -13,9 +14,14 @@ import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
 import { postToken } from '../postToken.ts';
 import { resolveOidcAuthority } from '../resolveOidcAuthority.ts';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { setToken, type Token } from '../token/index.ts';
 import type { AuthContextType } from './createAuthContext.ts';
 import { setUserManager } from './userManager.ts';
+
+const renewCooldown = time.seconds(30);
+const maxRenewFailures = 3;
+const renewFailureReset = time.minutes(5);
 
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
@@ -55,6 +61,13 @@ export function initializeUserManager(
     const manager = new UserManager(
       getOidcConfig(),
     );
+
+    const renewGuard = createSilentRenewGuard({
+      now: () => Date.now(),
+      cooldownMs: renewCooldown,
+      maxConsecutiveFailures: maxRenewFailures,
+      failureResetMs: renewFailureReset,
+    });
 
     const syncToken = (user: User | null) => {
       if (!user) return;
@@ -113,9 +126,15 @@ export function initializeUserManager(
       handleUserEvent(null);
     };
 
+    const renewSilently = () => {
+      renewGuard
+        .renew(() => manager.signinSilent())
+        .catch(handleSilentRenewFailure);
+    };
+
     const initializeUser = (user: User | null) => {
       if (user?.expired) {
-        manager.signinSilent().catch(handleSilentRenewFailure);
+        renewSilently();
         return;
       }
 
@@ -142,7 +161,7 @@ export function initializeUserManager(
         return;
       }
 
-      manager.signinSilent().catch(handleSilentRenewFailure);
+      renewSilently();
     };
 
     manager.getUser().then(initializeUser);

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -9,6 +9,7 @@ import { writeAuthMarker } from '../authMarker.ts';
 import { createSilentRenewGuard } from '../createSilentRenewGuard.ts';
 import { deriveStandardAuthority } from '../deriveStandardAuthority.ts';
 import { getOidcConfig } from '../getOidcConfig.ts';
+import { isRateLimitError } from '../isRateLimitError.ts';
 import { mapToToken } from '../mapToToken.ts';
 import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
 import { postToken } from '../postToken.ts';
@@ -120,7 +121,7 @@ export function initializeUserManager(
     };
 
     const handleSilentRenewFailure = (error: unknown) => {
-      if (error instanceof Error && error.message.includes('429')) {
+      if (isRateLimitError(error)) {
         dispatchRateLimitError();
       }
       handleUserEvent(null);

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -14,6 +14,7 @@ import { isRateLimitError } from '../isRateLimitError.ts';
 import { mapToToken } from '../mapToToken.ts';
 import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
 import { postToken } from '../postToken.ts';
+import { renewAccessToken } from '../renewAccessToken.ts';
 import { resolveOidcAuthority } from '../resolveOidcAuthority.ts';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { time } from '$lib/utils/timing/time.ts';
@@ -24,16 +25,6 @@ import { setUserManager } from './userManager.ts';
 const renewCooldown = time.seconds(30);
 const maxRenewFailures = 3;
 const renewFailureReset = time.minutes(5);
-const renewLockName = 'trakt-auth-renew';
-
-async function withRenewLock(task: () => Promise<void>) {
-  if (!navigator.locks) {
-    await task();
-    return;
-  }
-
-  await navigator.locks.request(renewLockName, task);
-}
 
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
@@ -142,38 +133,32 @@ export function initializeUserManager(
         return;
       }
 
+      // A surviving refresh token means the session is still spendable and
+      // only the attempt failed. Gating on the access token instead tore the
+      // session down for every renewal that ran past its expiry - which is
+      // every renewal, since that expiry is what triggers them.
       const current = await manager.getUser().catch(() => null);
-      if (current?.expired ?? true) {
+      if (current?.refresh_token == null) {
         handleUserEvent(null);
-        return;
       }
-
-      isInitializing.next(false);
     };
 
     const renewUnderLock = async () => {
-      await withRenewLock(async () => {
-        const current = await manager.getUser();
+      const { user, didAdopt } = await renewAccessToken(manager);
 
-        const expiringAt = Date.now() + time.seconds(
-          manager.settings.accessTokenExpiringNotificationTimeInSeconds,
-        );
-        const didAnotherTabRenew = current != null && !current.expired &&
-          time.seconds(current.expires_at ?? 0) > expiringAt;
-
-        if (didAnotherTabRenew) {
-          handleUserEvent(current);
-          return;
-        }
-
-        await manager.signinSilent();
-      });
+      // `signinSilent` raises `userLoaded`; an adopted token does not.
+      if (didAdopt) {
+        handleUserEvent(user);
+      }
     };
 
     const renewSilently = () => {
       renewGuard
         .renew(renewUnderLock)
-        .catch(handleSilentRenewFailure);
+        .catch(handleSilentRenewFailure)
+        // The guard resolves without attempting once its breaker is open, and
+        // a gated tree that never hears back renders nothing at all.
+        .finally(() => isInitializing.next(false));
     };
 
     const initializeUser = (user: User | null) => {

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -143,18 +143,9 @@ export function initializeUserManager(
       }
     };
 
-    const renewUnderLock = async () => {
-      const { user, didAdopt } = await renewAccessToken(manager);
-
-      // `signinSilent` raises `userLoaded`; an adopted token does not.
-      if (didAdopt) {
-        handleUserEvent(user);
-      }
-    };
-
     const renewSilently = () => {
       renewGuard
-        .renew(renewUnderLock)
+        .renew(() => renewAccessToken(manager))
         .catch(handleSilentRenewFailure)
         // The guard resolves without attempting once its breaker is open, and
         // a gated tree that never hears back renders nothing at all.

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -9,6 +9,7 @@ import { writeAuthMarker } from '../authMarker.ts';
 import { createSilentRenewGuard } from '../createSilentRenewGuard.ts';
 import { deriveStandardAuthority } from '../deriveStandardAuthority.ts';
 import { getOidcConfig } from '../getOidcConfig.ts';
+import { isFatalRenewError } from '../isFatalRenewError.ts';
 import { isRateLimitError } from '../isRateLimitError.ts';
 import { mapToToken } from '../mapToToken.ts';
 import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
@@ -120,11 +121,24 @@ export function initializeUserManager(
       );
     };
 
-    const handleSilentRenewFailure = (error: unknown) => {
-      if (isRateLimitError(error)) {
+    const handleSilentRenewFailure = async (error: unknown) => {
+      if (isRateLimitError(error) && isInitializing.value) {
         dispatchRateLimitError();
       }
-      handleUserEvent(null);
+
+      if (isFatalRenewError(error)) {
+        await manager.removeUser().catch(() => {});
+        handleUserEvent(null);
+        return;
+      }
+
+      const current = await manager.getUser().catch(() => null);
+      if (current?.expired ?? true) {
+        handleUserEvent(null);
+        return;
+      }
+
+      isInitializing.next(false);
     };
 
     const renewSilently = () => {
@@ -168,7 +182,6 @@ export function initializeUserManager(
     manager.getUser().then(initializeUser);
     manager.events.addUserLoaded(handleUserEvent);
     manager.events.addUserUnloaded(() => handleUserEvent(null));
-    manager.events.addSilentRenewError(() => handleUserEvent(null));
 
     globalThis.window.addEventListener('focus', checkTokenOnFocus);
 

--- a/projects/client/src/lib/features/auth/stores/silentRenewGuard.ts
+++ b/projects/client/src/lib/features/auth/stores/silentRenewGuard.ts
@@ -1,0 +1,15 @@
+import type { User } from 'oidc-client-ts';
+import { BehaviorSubject } from 'rxjs';
+import type { createSilentRenewGuard } from '../createSilentRenewGuard.ts';
+
+type SilentRenewGuard = ReturnType<typeof createSilentRenewGuard<User | null>>;
+
+const silentRenewGuard = new BehaviorSubject<SilentRenewGuard | null>(null);
+
+export function getSilentRenewGuard() {
+  return silentRenewGuard.value;
+}
+
+export function setSilentRenewGuard(guard: SilentRenewGuard | null) {
+  silentRenewGuard.next(guard);
+}

--- a/projects/client/src/lib/features/auth/stores/useAuth.ts
+++ b/projects/client/src/lib/features/auth/stores/useAuth.ts
@@ -1,9 +1,13 @@
 import { getLocale } from '$lib/features/i18n/index.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { error as printError } from '$lib/utils/console/print.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { workerRequest } from '$worker/workerRequest.ts';
+import { loginErrorStore } from '../_internal/loginErrorStore.ts';
 import { writeAuthMarker } from '../authMarker.ts';
+import { mapToLoginError } from '../mapToLoginError.ts';
+import { LoginErrorType } from '../models/LoginErrorType.ts';
 import { setToken } from '../token/index.ts';
 import { getAuthContext } from './getAuthContext.ts';
 import { getUserManager } from './userManager.ts';
@@ -36,15 +40,29 @@ export function useAuth() {
 
   const login = async () => {
     const manager = getUserManager();
+
+    loginErrorStore.clear();
+
+    if (!manager) {
+      printError('Failed to start sign-in: no user manager');
+      loginErrorStore.set(LoginErrorType.Unreachable);
+      return;
+    }
+
     const [language, region] = getLocale().split('-');
     const lang = region ? `${language}-${region.toUpperCase()}` : language;
 
-    await manager?.signinRedirect({
-      extraQueryParams: {
-        hide_email_form: 'true',
-        lang,
-      },
-    });
+    try {
+      await manager.signinRedirect({
+        extraQueryParams: {
+          hide_email_form: 'true',
+          lang,
+        },
+      });
+    } catch (error) {
+      printError('Failed to start sign-in:', error);
+      loginErrorStore.set(mapToLoginError(error));
+    }
   };
 
   return {

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.spec.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.spec.ts
@@ -34,8 +34,8 @@ function stubUserManager(
   return { removeUser };
 }
 
-function bearerOf(call: [unknown, RequestInit | undefined] | undefined) {
-  return new Headers(call?.at(1)?.headers).get('Authorization');
+function bearerOf(call: Parameters<typeof fetch> | undefined) {
+  return new Headers(call?.[1]?.headers).get('Authorization');
 }
 
 describe('createAuthenticatedFetch', () => {
@@ -49,7 +49,9 @@ describe('createAuthenticatedFetch', () => {
   });
 
   it('should attach the current bearer', async () => {
-    const baseFetch = vi.fn().mockResolvedValue(new Response(null));
+    const baseFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null),
+    );
 
     await createAuthenticatedFetch(baseFetch as unknown as typeof fetch)('/x');
 
@@ -58,7 +60,7 @@ describe('createAuthenticatedFetch', () => {
 
   it('should retry a 401 with the renewed bearer', async () => {
     stubUserManager(() => Promise.resolve(makeRenewedUser()));
-    const baseFetch = vi.fn()
+    const baseFetch = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockResolvedValueOnce(new Response(null, { status: 200 }));
 

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.spec.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.spec.ts
@@ -1,3 +1,8 @@
+import { createSilentRenewGuard } from '$lib/features/auth/createSilentRenewGuard.ts';
+import {
+  getSilentRenewGuard,
+  setSilentRenewGuard,
+} from '$lib/features/auth/stores/silentRenewGuard.ts';
 import { setToken } from '$lib/features/auth/token/index.ts';
 import { setUserManager } from '$lib/features/auth/stores/userManager.ts';
 import { time } from '$lib/utils/timing/time.ts';
@@ -34,6 +39,24 @@ function stubUserManager(
   return { removeUser };
 }
 
+const BACKGROUND_COOLDOWN = time.seconds(30);
+const clock = { value: 0 };
+
+function stubRenewGuard(
+  { maxConsecutiveFailures = 3 }: { maxConsecutiveFailures?: number } = {},
+) {
+  clock.value = 0;
+
+  setSilentRenewGuard(
+    createSilentRenewGuard<User | null>({
+      now: () => clock.value,
+      cooldownMs: BACKGROUND_COOLDOWN,
+      maxConsecutiveFailures,
+      failureResetMs: time.minutes(5),
+    }),
+  );
+}
+
 function bearerOf(call: Parameters<typeof fetch> | undefined) {
   return new Headers(call?.[1]?.headers).get('Authorization');
 }
@@ -41,10 +64,12 @@ function bearerOf(call: Parameters<typeof fetch> | undefined) {
 describe('createAuthenticatedFetch', () => {
   beforeEach(() => {
     setToken({ value: LAPSED_TOKEN, expiresAt: Date.now() });
+    stubRenewGuard();
   });
 
   afterEach(() => {
     setUserManager(null);
+    setSilentRenewGuard(null);
     setToken(null);
   });
 
@@ -145,5 +170,82 @@ describe('createAuthenticatedFetch', () => {
 
     expect(renewals).toBe(1);
     expect(responses.every((response) => response.status === 200)).toBe(true);
+  });
+  it('should stop renewing once the breaker has opened', async () => {
+    stubRenewGuard({ maxConsecutiveFailures: 1 });
+    let renewals = 0;
+    stubUserManager(() => {
+      renewals = renewals + 1;
+      return Promise.reject(new TypeError('Failed to fetch'));
+    });
+    const baseFetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    const authenticatedFetch = createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    );
+
+    await authenticatedFetch('/x');
+    clock.value = BACKGROUND_COOLDOWN;
+    await authenticatedFetch('/x');
+
+    expect(renewals).toBe(1);
+  });
+
+  it('should renew a 401 the background cooldown would have silenced', async () => {
+    stubUserManager(() => Promise.resolve(makeRenewedUser()));
+    await getSilentRenewGuard()?.renew(() => Promise.resolve(null));
+
+    clock.value = time.seconds(6);
+    const baseFetch = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const response = await createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    )('/x');
+
+    expect(response.status).toBe(200);
+    expect(bearerOf(baseFetch.mock.calls.at(1))).toBe(
+      `Bearer ${RENEWED_TOKEN}`,
+    );
+  });
+
+  it('should not renew again for a 401 that trails a fresh token', async () => {
+    let renewals = 0;
+    stubUserManager(() => {
+      renewals = renewals + 1;
+      return Promise.resolve(makeRenewedUser());
+    });
+    const baseFetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    const authenticatedFetch = createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    );
+
+    await authenticatedFetch('/x');
+    clock.value = time.seconds(1);
+    await authenticatedFetch('/x');
+
+    expect(renewals).toBe(1);
+  });
+
+  it('should return the 401 untouched when no guard is mounted', async () => {
+    setSilentRenewGuard(null);
+    const { removeUser } = stubUserManager(() =>
+      Promise.resolve(makeRenewedUser())
+    );
+    const baseFetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+
+    const response = await createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    )('/x');
+
+    expect(response.status).toBe(401);
+    expect(removeUser).not.toHaveBeenCalled();
+    expect(baseFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.spec.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.spec.ts
@@ -1,0 +1,147 @@
+import { setToken } from '$lib/features/auth/token/index.ts';
+import { setUserManager } from '$lib/features/auth/stores/userManager.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { ErrorResponse, type User, type UserManager } from 'oidc-client-ts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAuthenticatedFetch } from './createAuthenticatedFetch.ts';
+
+const LAPSED_TOKEN = 'lapsed-token';
+const RENEWED_TOKEN = 'renewed-token';
+
+function makeRenewedUser(): User {
+  return {
+    access_token: RENEWED_TOKEN,
+    expires_at: (Date.now() + time.hours(1)) / 1000,
+    expired: false,
+  } as User;
+}
+
+function stubUserManager(
+  signinSilent: () => Promise<User | null>,
+) {
+  const removeUser = vi.fn().mockResolvedValue(undefined);
+
+  setUserManager(
+    {
+      // Lapsed, so `renewAccessToken` never short-circuits into adopting it.
+      getUser: vi.fn().mockResolvedValue(null),
+      signinSilent: vi.fn(signinSilent),
+      removeUser,
+      settings: { accessTokenExpiringNotificationTimeInSeconds: 60 },
+    } as unknown as UserManager,
+  );
+
+  return { removeUser };
+}
+
+function bearerOf(call: [unknown, RequestInit | undefined] | undefined) {
+  return new Headers(call?.at(1)?.headers).get('Authorization');
+}
+
+describe('createAuthenticatedFetch', () => {
+  beforeEach(() => {
+    setToken({ value: LAPSED_TOKEN, expiresAt: Date.now() });
+  });
+
+  afterEach(() => {
+    setUserManager(null);
+    setToken(null);
+  });
+
+  it('should attach the current bearer', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(new Response(null));
+
+    await createAuthenticatedFetch(baseFetch as unknown as typeof fetch)('/x');
+
+    expect(bearerOf(baseFetch.mock.calls.at(0))).toBe(`Bearer ${LAPSED_TOKEN}`);
+  });
+
+  it('should retry a 401 with the renewed bearer', async () => {
+    stubUserManager(() => Promise.resolve(makeRenewedUser()));
+    const baseFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const response = await createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    )('/x');
+
+    expect(response.status).toBe(200);
+    expect(bearerOf(baseFetch.mock.calls.at(1))).toBe(
+      `Bearer ${RENEWED_TOKEN}`,
+    );
+  });
+
+  it('should keep the session when a renewal fails transiently', async () => {
+    const { removeUser } = stubUserManager(() =>
+      Promise.reject(new TypeError('Failed to fetch'))
+    );
+    const baseFetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+
+    const response = await createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    )('/x');
+
+    expect(response.status).toBe(401);
+    expect(removeUser).not.toHaveBeenCalled();
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear the session when the grant is refused', async () => {
+    const { removeUser } = stubUserManager(() =>
+      Promise.reject(new ErrorResponse({ error: 'invalid_grant' }))
+    );
+    const baseFetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+
+    await createAuthenticatedFetch(baseFetch as unknown as typeof fetch)('/x');
+
+    expect(removeUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not renew for a request that carried no bearer', async () => {
+    setToken(null);
+    const { removeUser } = stubUserManager(() =>
+      Promise.reject(new ErrorResponse({ error: 'invalid_grant' }))
+    );
+    const baseFetch = vi.fn().mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+
+    await createAuthenticatedFetch(baseFetch as unknown as typeof fetch)('/x');
+
+    expect(removeUser).not.toHaveBeenCalled();
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should share one renewal across a burst of 401s', async () => {
+    let renewals = 0;
+    stubUserManager(() => {
+      renewals = renewals + 1;
+      return Promise.resolve(makeRenewedUser());
+    });
+    const baseFetch = vi.fn().mockImplementation((_input, init) =>
+      Promise.resolve(
+        new Response(null, {
+          status: new Headers(init?.headers).get('Authorization') ===
+              `Bearer ${RENEWED_TOKEN}`
+            ? 200
+            : 401,
+        }),
+      )
+    );
+
+    const authenticatedFetch = createAuthenticatedFetch(
+      baseFetch as unknown as typeof fetch,
+    );
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () => authenticatedFetch('/x')),
+    );
+
+    expect(renewals).toBe(1);
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+  });
+});

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -24,7 +24,9 @@ function renewSession(rejectedToken: string): Promise<string | null> {
       // and rate limits leave the refresh token spendable, so the 401 goes back
       // to the caller with the session intact.
       if (isFatalRenewError(reason)) {
-        void manager.removeUser();
+        // Best-effort: storage can be unavailable (private mode, blocked),
+        // and a failed clear here shouldn't surface as an unhandled rejection.
+        manager.removeUser().catch(() => {});
       }
 
       error('Failed to renew the session:', reason);

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -1,20 +1,41 @@
 import { getToken } from '$lib/features/auth/token/index.ts';
 
 import { error } from '$lib/utils/console/print.ts';
+import { isFatalRenewError } from '$lib/features/auth/isFatalRenewError.ts';
+import { renewAccessToken } from '$lib/features/auth/renewAccessToken.ts';
 import { getUserManager } from '../../features/auth/stores/userManager.ts';
 import { IS_DEV } from '../../utils/env/index.ts';
-import { safeSessionStorage } from '../../utils/storage/safeStorage.ts';
 
-const SESSION_STORAGE_REFRESH_KEY = 'trakt:is_refreshing';
+// `useUser` fans out ~15 authorized queries at once, so a lapsed token 401s
+// every one of them. Share one attempt across the burst.
+let inflightRenewal: Promise<string | null> | null = null;
 
-const hasRequestedRefresh = () =>
-  Boolean(safeSessionStorage.getItem(SESSION_STORAGE_REFRESH_KEY));
+function renewSession(rejectedToken: string): Promise<string | null> {
+  const manager = getUserManager();
 
-const setRefreshKey = () =>
-  safeSessionStorage.setItem(SESSION_STORAGE_REFRESH_KEY, 'true');
+  if (!manager) {
+    return Promise.resolve(null);
+  }
 
-const clearRefreshKey = () =>
-  safeSessionStorage.removeItem(SESSION_STORAGE_REFRESH_KEY);
+  inflightRenewal ??= renewAccessToken(manager, rejectedToken)
+    .then((user) => user?.access_token ?? null)
+    .catch((reason) => {
+      // Only a refused grant means the session is gone. Offline, timeout, 5xx
+      // and rate limits leave the refresh token spendable, so the 401 goes back
+      // to the caller with the session intact.
+      if (isFatalRenewError(reason)) {
+        void manager.removeUser();
+      }
+
+      error('Failed to renew the session:', reason);
+      return null;
+    })
+    .finally(() => {
+      inflightRenewal = null;
+    });
+
+  return inflightRenewal;
+}
 
 export function createAuthenticatedFetch<
   T extends typeof fetch,
@@ -23,10 +44,8 @@ export function createAuthenticatedFetch<
     input: Parameters<T>[0],
     init?: Parameters<T>[1],
   ): Promise<Response> {
-    const headers = new Headers(init?.headers || {});
-
-    try {
-      const { value: token } = getToken();
+    const send = (token: string | Nil) => {
+      const headers = new Headers(init?.headers || {});
 
       if (token) {
         headers.set('Authorization', `Bearer ${token}`);
@@ -38,23 +57,24 @@ export function createAuthenticatedFetch<
           ...init,
           headers,
         } as Parameters<T>[1],
-      ).then((response) => {
+      );
+    };
+
+    try {
+      const { value: token } = getToken();
+
+      return send(token).then((response) => {
         /**
          * FIXME: @seferturan these should return 403 not 401
          * talk to @rudf0rd about this
          */
-        if (!IS_DEV && response.status === 401 && !hasRequestedRefresh()) {
-          setRefreshKey();
-          getUserManager()?.removeUser().then(() =>
-            globalThis.window.location.reload()
-          );
+        if (IS_DEV || response.status !== 401 || !token) {
+          return response;
         }
 
-        if (response.status !== 401) {
-          clearRefreshKey();
-        }
-
-        return response;
+        return renewSession(token).then((renewed) =>
+          renewed == null || renewed === token ? response : send(renewed)
+        );
       });
     } catch (e) {
       error('Fetch interceptor error:', e);

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -1,42 +1,47 @@
 import { getToken } from '$lib/features/auth/token/index.ts';
+import { NOOP_FN } from '$lib/utils/constants.ts';
 
 import { error } from '$lib/utils/console/print.ts';
 import { isFatalRenewError } from '$lib/features/auth/isFatalRenewError.ts';
 import { renewAccessToken } from '$lib/features/auth/renewAccessToken.ts';
+import { getSilentRenewGuard } from '$lib/features/auth/stores/silentRenewGuard.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { getUserManager } from '../../features/auth/stores/userManager.ts';
 import { IS_DEV } from '../../utils/env/index.ts';
 
-// `useUser` fans out ~15 authorized queries at once, so a lapsed token 401s
-// every one of them. Share one attempt across the burst.
-let inflightRenewal: Promise<string | null> | null = null;
+// A 401 is evidence the token is spent, so it cannot sit behind the
+// speculative cooldown the timer-driven renewals share. This window only
+// collapses the stragglers that 401 just after a renewal already landed.
+const RENEW_ON_401_COOLDOWN = time.seconds(5);
 
-function renewSession(rejectedToken: string): Promise<string | null> {
+async function renewSession(rejectedToken: string): Promise<string | null> {
   const manager = getUserManager();
+  const guard = getSilentRenewGuard();
 
-  if (!manager) {
-    return Promise.resolve(null);
+  if (!manager || !guard) {
+    return null;
   }
 
-  inflightRenewal ??= renewAccessToken(manager, rejectedToken)
-    .then((user) => user?.access_token ?? null)
-    .catch((reason) => {
-      // Only a refused grant means the session is gone. Offline, timeout, 5xx
-      // and rate limits leave the refresh token spendable, so the 401 goes back
-      // to the caller with the session intact.
-      if (isFatalRenewError(reason)) {
-        // Best-effort: storage can be unavailable (private mode, blocked),
-        // and a failed clear here shouldn't surface as an unhandled rejection.
-        manager.removeUser().catch(() => {});
-      }
+  try {
+    const { value } = await guard.renew(
+      () => renewAccessToken(manager, rejectedToken),
+      { cooldownMs: RENEW_ON_401_COOLDOWN },
+    );
 
-      error('Failed to renew the session:', reason);
-      return null;
-    })
-    .finally(() => {
-      inflightRenewal = null;
-    });
+    return value?.access_token ?? null;
+  } catch (reason) {
+    // Only a refused grant means the session is gone. Offline, timeout, 5xx
+    // and rate limits leave the refresh token spendable, so the 401 goes back
+    // to the caller with the session intact.
+    if (isFatalRenewError(reason)) {
+      // Best-effort: storage can be unavailable (private mode, blocked),
+      // and a failed clear here shouldn't surface as an unhandled rejection.
+      manager.removeUser().catch(NOOP_FN);
+    }
 
-  return inflightRenewal;
+    error('Failed to renew the session:', reason);
+    return null;
+  }
 }
 
 export function createAuthenticatedFetch<

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
   import AnalyticsProvider from "$lib/features/analytics/AnalyticsProvider.svelte";
   import PageView from "$lib/features/analytics/PageView.svelte";
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
+  import LoginErrorSnackbar from "$lib/features/auth/components/LoginErrorSnackbar.svelte";
   import BotProvider from "$lib/features/bot-verification/BotProvider.svelte";
   import ConfirmationProvider from "$lib/features/confirmation/ConfirmationProvider.svelte";
   import { DeploymentEndpoint } from "$lib/features/deployment/DeploymentEndpoint.js";
@@ -140,6 +141,8 @@
                                         <RenderFor audience="authenticated">
                                           <OfflineSync />
                                         </RenderFor>
+
+                                        <LoginErrorSnackbar />
                                         <QueryDevtools
                                           client={data.queryClient}
                                           buttonPosition="bottom-right"

--- a/projects/client/src/routes/callback/+page.svelte
+++ b/projects/client/src/routes/callback/+page.svelte
@@ -6,6 +6,7 @@
   import { error as printError } from "$lib/utils/console/print.ts";
   import { setCacheBuster } from "$lib/utils/url/setCacheBuster";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { claimSigninCallback } from "./_internal/claimSigninCallback.ts";
   import type { User } from "oidc-client-ts";
   import { onMount } from "svelte";
 
@@ -26,8 +27,14 @@
   };
 
   onMount(() => {
-    getUserManager()
-      ?.signinCallback()
+    const manager = getUserManager();
+
+    if (!manager || !claimSigninCallback()) {
+      return;
+    }
+
+    manager
+      .signinCallback()
       .then(storeSession)
       .then(navigateToHome)
       .catch((error) => {

--- a/projects/client/src/routes/callback/_internal/claimSigninCallback.spec.ts
+++ b/projects/client/src/routes/callback/_internal/claimSigninCallback.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function importClaim() {
+  const module = await import('./claimSigninCallback.ts');
+  return module.claimSigninCallback;
+}
+
+describe('claimSigninCallback', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('should grant the first claim', async () => {
+    const claimSigninCallback = await importClaim();
+
+    expect(claimSigninCallback()).toBe(true);
+  });
+
+  it('should refuse a second claim', async () => {
+    const claimSigninCallback = await importClaim();
+
+    expect(claimSigninCallback()).toBe(true);
+    expect(claimSigninCallback()).toBe(false);
+  });
+
+  it('should refuse every claim after the first', async () => {
+    const claimSigninCallback = await importClaim();
+
+    claimSigninCallback();
+
+    expect([claimSigninCallback(), claimSigninCallback()]).toEqual([
+      false,
+      false,
+    ]);
+  });
+});

--- a/projects/client/src/routes/callback/_internal/claimSigninCallback.ts
+++ b/projects/client/src/routes/callback/_internal/claimSigninCallback.ts
@@ -1,0 +1,12 @@
+// FIXME: stop AuthProvider's gate remounting its children when `$user` flaps on
+// the CacheBust login triggers, then drop this latch.
+let hasClaimed = false;
+
+export function claimSigninCallback(): boolean {
+  if (hasClaimed) {
+    return false;
+  }
+
+  hasClaimed = true;
+  return true;
+}

--- a/projects/client/test/beds/auth/UserManagerTestBed.svelte
+++ b/projects/client/test/beds/auth/UserManagerTestBed.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { initializeUserManager } from "$lib/features/auth/stores/initializeUserManager.ts";
+  import { untrack } from "svelte";
+
+  const { params, output }: {
+    params: Parameters<typeof initializeUserManager>[0];
+    output: (value: ReturnType<typeof initializeUserManager>) => void;
+  } = $props();
+
+  untrack(() => output(initializeUserManager(params)));
+</script>

--- a/projects/client/test/mocks/oidc-client-ts.mock.ts
+++ b/projects/client/test/mocks/oidc-client-ts.mock.ts
@@ -17,9 +17,10 @@ const mockUserManager = vi.fn(function () {
     events: {
       addAccessTokenExpiring: vi.fn().mockReturnValue(() => {}),
       addAccessTokenExpired: vi.fn().mockReturnValue(() => {}),
-      addUserLoaded: vi.fn().mockResolvedValue(OidcUserMock),
-      addUserUnloaded: vi.fn(),
+      addUserLoaded: vi.fn().mockReturnValue(() => {}),
+      addUserUnloaded: vi.fn().mockReturnValue(() => {}),
       addSilentRenewError: vi.fn(),
+      load: vi.fn().mockResolvedValue(undefined),
     },
   };
 });

--- a/projects/client/test/mocks/oidc-client-ts.mock.ts
+++ b/projects/client/test/mocks/oidc-client-ts.mock.ts
@@ -15,6 +15,8 @@ const mockUserManager = vi.fn(function () {
     signinRedirect: vi.fn().mockResolvedValue(undefined),
     signinRedirectCallback: vi.fn().mockResolvedValue(undefined),
     events: {
+      addAccessTokenExpiring: vi.fn().mockReturnValue(() => {}),
+      addAccessTokenExpired: vi.fn().mockReturnValue(() => {}),
       addUserLoaded: vi.fn().mockResolvedValue(OidcUserMock),
       addUserUnloaded: vi.fn(),
       addSilentRenewError: vi.fn(),


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #3062
- Guards the silent renew fired on window focus (cooldown + failure breaker)
  - A stale tab could self-sustain a renew loop: the renew iframe hands focus back to the top window, which refires the focus handler
  - Failures decay after 5 min, so a long lived tab doesn't get stuck after a few blips
- Only clears the session on a terminal OAuth error
  - Offline / timeout / 5xx / rate limit used to log you out too, even with a perfectly good refresh token still in storage
- Serializes renewal across tabs with a web lock
  - Refresh tokens rotate on use, so two tabs renewing at once means the second one presents a consumed token. Server reads that as a replay and invalidates the whole refresh family, on every device
  - `automaticSilentRenew` is off on purpose: it calls `signinSilent` straight off the manager, so it can't be routed through the lock. The expiry timer still comes from oidc-client-ts, we just own the subscription now
- Shows a snackbar when a login can't start
  - Was an uncaught rejection and a button that visibly did nothing
  - Only says "too many sign in attempts" when the status is actually readable. A rate limit at the edge strips the CORS headers off its own 429, so the browser reports a bare "Failed to fetch" with no status
- ⚠️ The weekly logout reports should be covered by the renewal changes, but that's inferred from the code, not reproduced. Will verify on prod

## 👀 Example 👀
Example when rate limited:
<img width="1175" height="895" alt="Screenshot 2026-08-24 at 14 23 28" src="https://github.com/user-attachments/assets/c0bf3a45-b005-4006-b91f-c5fccb30a0f4" />
