### PR TITLE
fix(sentry): collection of production error fixes

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -38,7 +38,7 @@
         globalThis.addEventListener('load', () => {
           navigator.serviceWorker.register('/service-worker.js', {
             type: 'module',
-          });
+          }).catch(() => {});
         });
       }
     </script>

--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -53,6 +53,7 @@ Sentry.init({
     // identifies the same Sentry issue across browser error formats.
     'DA4BED8B-B90C-4112-BEB0-5293448AB67E',
     'Invalid call to runtime.sendMessage',
+    'btn-watch-now',
     'WKWebView API client did not respond',
     'Error invoking postEvent',
   ],

--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -82,6 +82,7 @@ Sentry.init({
     // Browser extension / userscript / native bridge noise — not our code.
     'WebViewJavascriptBridge',
     'userScripts is not defined',
+    "Identifier 'nativeIframe' has already been declared",
     // Greasemonkey internal handle — the UUID is unique to GM and
     // identifies the same Sentry issue across browser error formats.
     'DA4BED8B-B90C-4112-BEB0-5293448AB67E',

--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -8,12 +8,44 @@ import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';
 import * as Sentry from '@sentry/sveltekit';
 import { handleErrorWithSentry } from '@sentry/sveltekit';
+import type { ErrorEvent as SentryErrorEvent } from '@sentry/sveltekit';
 
 // Must run before Sentry.init and before SvelteKit reads `location`: strips the
 // WebView params (slurm VIP token, standalone flag) from the URL and latches
 // them to sessionStorage, so page.url, Sentry tracing and analytics never see
 // the token.
 captureWebviewSession();
+
+const SAMPLED_ERROR_PATTERNS = [
+  /^Failed to fetch( \((app|media)\.trakt\.tv\))?$/,
+  /^Load failed( \((app|media)\.trakt\.tv\))?$/,
+  /^NetworkError when attempting to fetch resource\.( \((app|media)\.trakt\.tv\))?$/,
+  /^network error$/,
+  /^Internal error$/,
+  /^Non-Error promise rejection captured with value: undefined$/,
+];
+
+const SAMPLED_ERROR_RATE = 0.01;
+
+function isServiceWorkerRejection(event: SentryErrorEvent): boolean {
+  return event.exception?.values?.some(({ type, value, stacktrace }) => {
+    const isRejected = type === 'Rejected' || value === 'Rejected';
+    const isServiceWorker = stacktrace?.frames?.some(
+      (frame) =>
+        frame.filename?.includes('service-worker') ||
+        frame.function?.includes('navigator.serviceWorker.register') ||
+        frame.function?.includes('ServiceWorkerContainer.register'),
+    );
+
+    return isRejected && isServiceWorker;
+  }) ?? false;
+}
+
+function isSampledError(event: SentryErrorEvent): boolean {
+  return event.exception?.values?.some(({ value }) =>
+    SAMPLED_ERROR_PATTERNS.some((pattern) => pattern.test(value ?? ''))
+  ) ?? false;
+}
 
 Sentry.init({
   dsn: SENTRY_DSN,
@@ -39,6 +71,7 @@ Sentry.init({
     'error loading dynamically imported module',
     'Importing a module script failed',
     'Unable to preload CSS for',
+    /^Module load timeout: m_\d+$/,
     // Cross-origin frames we cannot reach into: embedded players, plus frames
     // injected by ad-blockers / privacy extensions.
     'Blocked a frame with origin',
@@ -58,21 +91,18 @@ Sentry.init({
     'Error invoking postEvent',
   ],
   beforeSend(event) {
-    const isWellKnownRejection = event.exception?.values?.some(
-      ({ type, value, stacktrace }) => {
-        const isRejected = type === 'Rejected' || value === 'Rejected';
-        const isServiceWorker = stacktrace?.frames?.some(
-          (frame) =>
-            frame.filename?.includes('service-worker') ||
-            frame.function?.includes('navigator.serviceWorker.register') ||
-            frame.function?.includes('ServiceWorkerContainer.register'),
-        );
+    if (isServiceWorkerRejection(event)) {
+      return null;
+    }
 
-        return isRejected && isServiceWorker;
-      },
-    );
+    if (
+      isSampledError(event) &&
+      Math.random() >= SAMPLED_ERROR_RATE
+    ) {
+      return null;
+    }
 
-    return isWellKnownRejection ? null : event;
+    return event;
   },
 });
 

--- a/projects/client/src/lib/components/episode/getEpisodeStatus.ts
+++ b/projects/client/src/lib/components/episode/getEpisodeStatus.ts
@@ -12,16 +12,10 @@ type GetEpisodeStatusOptions = {
   releaseDate?: Date;
 };
 
-const MID_SEASON_TYPES: ReadonlySet<EpisodeType> = new Set([
-  EpisodeFinaleType.mid_season_finale,
-  EpisodePremiereType.mid_season_premiere,
-]);
-
-const NEW_EPISODE_WINDOW_MS = time.days(7);
-
 function isEpisodeNew(releaseDate: Date): boolean {
+  const newEpisodeWindowMs = time.days(7);
   const elapsed = Date.now() - releaseDate.getTime();
-  return elapsed >= 0 && elapsed <= NEW_EPISODE_WINDOW_MS;
+  return elapsed >= 0 && elapsed <= newEpisodeWindowMs;
 }
 
 export function getEpisodeStatus(
@@ -43,7 +37,8 @@ export function getEpisodeStatus(
     return;
   }
 
-  const isMidSeason = MID_SEASON_TYPES.has(type);
+  const isMidSeason = type === EpisodeFinaleType.mid_season_finale ||
+    type === EpisodePremiereType.mid_season_premiere;
   if (isMidSeason && options.isLatestAired === false) {
     return;
   }

--- a/projects/client/src/lib/features/offline/_internal/createOfflineActionsStorage.ts
+++ b/projects/client/src/lib/features/offline/_internal/createOfflineActionsStorage.ts
@@ -18,18 +18,25 @@ export function createOfflineActionsStorage(): OfflineActionsStorage {
   const store = createStore(DB_NAME, STORE_NAME);
 
   return {
-    read: () =>
-      get<unknown[]>(QUEUE_KEY, store)
-        .then((stored) =>
-          (stored ?? [])
-            .map((entry) => OfflineActionSchema.safeParse(entry))
-            .filter((result) => result.success)
-            .map((result) => result.data)
-        )
-        .catch((e) => {
-          handleError(e);
-          return [];
-        }),
-    write: (actions) => set(QUEUE_KEY, actions, store).catch(handleError),
+    read: async () => {
+      try {
+        const stored = await get<unknown[]>(QUEUE_KEY, store);
+
+        return (stored ?? [])
+          .map((entry) => OfflineActionSchema.safeParse(entry))
+          .filter((result) => result.success)
+          .map((result) => result.data);
+      } catch (e) {
+        handleError(e);
+        return [];
+      }
+    },
+    write: async (actions) => {
+      try {
+        await set(QUEUE_KEY, actions, store);
+      } catch (e) {
+        handleError(e);
+      }
+    },
   };
 }

--- a/projects/client/src/lib/utils/formatting/date/toHumanDuration.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDuration.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { toHumanDuration } from './toHumanDuration.ts';
 
 describe('toHumanDuration', () => {
@@ -100,5 +100,41 @@ describe('toHumanDuration', () => {
     expect(toHumanDuration({ minutes: 1530, unitDisplay: 'long' })).toBe(
       '1 day 1 hour 30 minutes',
     );
+  });
+
+  describe('when the unit style is unsupported', () => {
+    const NumberFormat = Intl.NumberFormat;
+
+    beforeEach(() => {
+      vi.spyOn(Intl, 'NumberFormat').mockImplementation(
+        function (locale?: string, options?: Intl.NumberFormatOptions) {
+          if (options?.style === 'unit') {
+            throw new RangeError(
+              'Value unit out of range for Intl.NumberFormat options property style',
+            );
+          }
+
+          return new NumberFormat(locale, options);
+        } as unknown as typeof Intl.NumberFormat,
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should fall back to a plain number with a suffix', () => {
+      expect(toHumanDuration({ minutes: 1530 })).toBe('1d 1h 30m');
+    });
+
+    it('should keep honouring the separator', () => {
+      expect(toHumanDuration({ minutes: 1530, separator: ', ' })).toBe(
+        '1d, 1h, 30m',
+      );
+    });
+
+    it('should keep clamping', () => {
+      expect(toHumanDuration({ minutes: 300, clampAt: 'hour' })).toBe('5h');
+    });
   });
 });

--- a/projects/client/src/lib/utils/formatting/date/toHumanDuration.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDuration.ts
@@ -20,6 +20,37 @@ type ToHumanDurationProps = {
   clampAt?: DurationUnit;
 };
 
+const FALLBACK_UNIT_SUFFIX = {
+  day: 'd',
+  hour: 'h',
+  minute: 'm',
+} as const;
+
+type FormattedUnit = keyof typeof FALLBACK_UNIT_SUFFIX;
+
+type CreateUnitFormatterProps = {
+  locale: string;
+  unit: FormattedUnit;
+  unitDisplay: Intl.NumberFormatOptions['unitDisplay'];
+};
+
+function createUnitFormatter({
+  locale,
+  unit,
+  unitDisplay,
+}: CreateUnitFormatterProps): { format: (value: number) => string } {
+  try {
+    return new Intl.NumberFormat(locale, { style: 'unit', unit, unitDisplay });
+  } catch {
+    const decimal = new Intl.NumberFormat(locale);
+
+    return {
+      format: (value) =>
+        `${decimal.format(value)}${FALLBACK_UNIT_SUFFIX[unit]}`,
+    };
+  }
+}
+
 export function toHumanDuration({
   days = 0,
   hours = 0,
@@ -57,19 +88,16 @@ export function toHumanDuration({
 
   const { days: d, hours: h, minutes: m } = getDuration();
 
+  const intlLocale = getIntlLocale(locale);
   const formatters = {
-    day: new Intl.NumberFormat(getIntlLocale(locale), {
-      style: 'unit',
-      unit: 'day',
-      unitDisplay,
-    }),
-    hour: new Intl.NumberFormat(getIntlLocale(locale), {
-      style: 'unit',
+    day: createUnitFormatter({ locale: intlLocale, unit: 'day', unitDisplay }),
+    hour: createUnitFormatter({
+      locale: intlLocale,
       unit: 'hour',
       unitDisplay,
     }),
-    minute: new Intl.NumberFormat(getIntlLocale(locale), {
-      style: 'unit',
+    minute: createUnitFormatter({
+      locale: intlLocale,
       unit: 'minute',
       unitDisplay,
     }),

--- a/projects/client/src/lib/utils/formatting/intl/_internal/toDisplayName.spec.ts
+++ b/projects/client/src/lib/utils/formatting/intl/_internal/toDisplayName.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { toDisplayName } from './toDisplayName.ts';
 
 describe('toDisplayName', () => {
@@ -62,13 +62,33 @@ describe('toDisplayName', () => {
     expect(displayName).toBe('Netherlands');
   });
 
-  it('will throw when using a non valid code', () => {
-    expect(() => {
-      toDisplayName({
-        code: 'my random value',
+  it('will fall back to the code when it is not a valid code', () => {
+    const displayName = toDisplayName({
+      code: 'my random value',
+      languageTag: 'en',
+      type: 'region',
+    });
+
+    expect(displayName).toBe('my random value');
+  });
+
+  describe('when Intl.DisplayNames is unavailable', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('will fall back to the code', () => {
+      vi.spyOn(Intl, 'DisplayNames').mockImplementation(() => {
+        throw new Error('Missing locale data for ');
+      });
+
+      const displayName = toDisplayName({
+        code: 'nl',
         languageTag: 'en',
         type: 'region',
       });
-    }).toThrowError();
+
+      expect(displayName).toBe('nl');
+    });
   });
 });

--- a/projects/client/src/lib/utils/formatting/intl/_internal/toDisplayName.ts
+++ b/projects/client/src/lib/utils/formatting/intl/_internal/toDisplayName.ts
@@ -13,10 +13,14 @@ export function toDisplayName({
   languageTag,
   type,
 }: ToDisplayNameProps) {
-  const displayNames = new Intl.DisplayNames(languageTag, { type });
-  const displayName = displayNames.of(
-    code.toUpperCase(),
-  );
+  try {
+    const displayNames = new Intl.DisplayNames(languageTag, { type });
+    const displayName = displayNames.of(
+      code.toUpperCase(),
+    );
 
-  return displayName ?? code;
+    return displayName ?? code;
+  } catch {
+    return code;
+  }
 }

--- a/projects/client/src/routes/users/[user]/+page.ts
+++ b/projects/client/src/routes/users/[user]/+page.ts
@@ -8,7 +8,7 @@ import type { PageLoad } from './$types';
 // fires on first load, which aborts it and leaves a blank page.
 // Query params are preserved across the redirect.
 export const load: PageLoad = ({ params, url }) => {
-  const target = UrlBuilder.profile.user(params.user);
+  const target = UrlBuilder.profile.user(encodeURIComponent(params.user));
 
   return redirect(307, `${target}${url.search}`);
 };

--- a/projects/client/src/routes/users/[user]/mir/+page.ts
+++ b/projects/client/src/routes/users/[user]/mir/+page.ts
@@ -8,10 +8,11 @@ import type { PageLoad } from './$types';
 // across the redirect.
 export const load: PageLoad = ({ params, url }) => {
   const previousMonth = subMonths(new Date(), 1);
-  const target = UrlBuilder.users(params.user).monthInReview(
-    previousMonth.getFullYear(),
-    previousMonth.getMonth() + 1,
-  );
+  const target = UrlBuilder.users(encodeURIComponent(params.user))
+    .monthInReview(
+      previousMonth.getFullYear(),
+      previousMonth.getMonth() + 1,
+    );
 
   return redirect(307, `${target}${url.search}`);
 };

--- a/projects/client/src/routes/users/[user]/yir/+page.ts
+++ b/projects/client/src/routes/users/[user]/yir/+page.ts
@@ -11,7 +11,9 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = ({ params, url }) => {
   const year = getYearInReviewYear(new Date());
 
-  const target = UrlBuilder.users(params.user).yearToDate(year);
+  const target = UrlBuilder.users(encodeURIComponent(params.user)).yearToDate(
+    year,
+  );
 
   return redirect(307, `${target}${url.search}`);
 };


### PR DESCRIPTION
## 🎶 Notes 🎶

Batch of fixes for the top Sentry issues of the past week.

- `Intl.NumberFormat` with `style: 'unit'` throws on older browsers (UC Browser, smart TV webviews). Falls back to a plain decimal with a suffix. Fixes TRAKT-WEB-9G1, TRAKT-WEB-9GM
- `Intl.DisplayNames` throws when the environment has no locale data. Falls back to the raw code, so the country filter degrades instead of blanking. Fixes TRAKT-WEB-9G9
  - the spec asserted the throw, updated to the new contract
- `/users/:user`, `/users/:user/yir` and `/users/:user/mir` built a `Location` header straight from the route param, which SvelteKit hands over decoded. A crafted username with CR/LF threw before the redirect went out. Fixes TRAKT-WEB-AYS
  - encoding stays caller-local: `resolveLegacyRedirect` gets `url.pathname`, which is still encoded, so doing it in `UrlBuilder` would double encode
- idb-keyval opens the database lazily inside `get`/`set`, so a `SecurityError` threw synchronously and escaped the promise chain. Awaiting in a try/catch keeps the offline queue degrading to empty. Fixes TRAKT-WEB-ATX
- `getEpisodeStatus` dereferenced the type enums at module scope, which took the whole chunk down on import. Compares at call time now. Fixes TRAKT-WEB-ATY
  - ⚠️ the exact trigger is unconfirmed. The fix removes the module scope dereference either way, so it holds under both theories I could come up with
- `navigator.serviceWorker.register` was unhandled, so every browser that refuses a worker surfaced as an uncaught rejection: Firefox with site data blocked, extensions that block workers, failed installs. Fixes TRAKT-WEB-BQ2, TRAKT-WEB-BQ7, TRAKT-WEB-F9

Sentry config:

- transient network errors are sampled at 1% instead of ignored. Ignoring them outright trades away the only signal that separates a CORS regression from someone's flaky wifi, which is volume. Keeping 1% cuts ~21k events a week and a spike still reads as a spike
- `apiz` and `auth` are deliberately left unsampled. A spike there is a real outage and we cannot see a spike in something we ignore
- patterns are anchored so they cannot swallow our own `Failed to fetch data: query:*`
- hard ignores are only for things that are provably not our code: `btn-watch-now`, `nativeIframe`, `Module load timeout: m_*`

Not tackled:

- BNC `state_unsafe_mutation` needs a proper look at the offline store's subscribe timing
- BP7 / 9A7 `does not provide an export named 't'` looks like a stale chunk. The reload-once path exists but does not match that message. Blind fix until confirmed on prod, so left out
- the duration fallback ignores `unitDisplay` and uses latin suffixes. Only reachable on pre-2020 browsers, and doing it properly needs new pluralised keys across all 28 locales
