### PR TITLE
fix(pwa): stop the service worker failing every intercepted request

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -7,6 +7,8 @@ import { captureWebviewSession } from '$lib/features/webview/captureWebviewSessi
 import { SentryEndpoint } from '$lib/features/sentry/SentryEndpoint.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';
+import { delay } from '$lib/utils/timing/delay.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import * as Sentry from '@sentry/sveltekit';
 import { handleErrorWithSentry } from '@sentry/sveltekit';
 import type { ErrorEvent as SentryErrorEvent } from '@sentry/sveltekit';
@@ -164,24 +166,33 @@ function getRejectionUrl(reason: unknown): string | undefined {
   return String((reason as { url?: unknown }).url ?? '');
 }
 
-function shouldReloadForRejection(event: PromiseRejectionEvent): boolean {
-  if (isDynamicImportError(event.reason)) return true;
-  return hasChunkPath(getRejectionUrl(event.reason));
+type RecoveryAction = 'purge-and-reload' | 'reload';
+
+function getRecoveryForRejection(
+  event: PromiseRejectionEvent,
+): RecoveryAction | undefined {
+  if (isDynamicImportError(event.reason)) return 'purge-and-reload';
+  if (hasChunkPath(getRejectionUrl(event.reason))) return 'purge-and-reload';
+  return undefined;
 }
 
-function shouldReloadForError(event: ErrorEvent): boolean {
-  if (isDynamicImportError(event.error ?? event.message)) return true;
-  if (event.target instanceof HTMLScriptElement) {
-    return hasChunkPath(event.target.src);
+function getRecoveryForError(event: ErrorEvent): RecoveryAction | undefined {
+  if (isDynamicImportError(event.error ?? event.message)) {
+    return 'purge-and-reload';
   }
-  return hasChunkPath(event.filename);
+
+  if (event.target instanceof HTMLScriptElement) {
+    return hasChunkPath(event.target.src) ? 'purge-and-reload' : undefined;
+  }
+
+  return hasChunkPath(event.filename) ? 'reload' : undefined;
 }
 
-function shouldReloadForClientEvent(
+function getRecoveryForClientEvent(
   event: ErrorEvent | PromiseRejectionEvent,
-): boolean {
-  if ('reason' in event) return shouldReloadForRejection(event);
-  return shouldReloadForError(event);
+): RecoveryAction | undefined {
+  if ('reason' in event) return getRecoveryForRejection(event);
+  return getRecoveryForError(event);
 }
 
 function buildReloadUrl() {
@@ -190,27 +201,62 @@ function buildReloadUrl() {
   return url.toString();
 }
 
-function triggerReloadOnce(): void {
+async function purgeCaches(): Promise<void> {
+  if (!('caches' in window)) return;
+
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => caches.delete(key)));
+}
+
+async function unregisterServiceWorkers(): Promise<void> {
+  if (!('serviceWorker' in navigator)) return;
+
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(
+    registrations.map((registration) => registration.unregister()),
+  );
+}
+
+const RECOVERY_CLEANUP_TIMEOUT_MS = time.seconds(3);
+
+function triggerReloadOnce(action: RecoveryAction): void {
+  if (!navigator.onLine) return;
   if (safeSessionStorage.getItem(DYNAMIC_IMPORT_RELOAD_KEY)) return;
 
   safeSessionStorage.setItem(DYNAMIC_IMPORT_RELOAD_KEY, '1');
-  window.location.replace(buildReloadUrl());
+
+  // `_cb` asks the worker to drop the navigation cache. The purge path
+  // unregisters it first, so that reload is uncontrolled: nothing would honour
+  // the param, and nothing would strip it back out of the URL.
+  if (action === 'reload') {
+    window.location.replace(buildReloadUrl());
+    return;
+  }
+
+  Promise.race([
+    Promise.allSettled([purgeCaches(), unregisterServiceWorkers()]),
+    delay(RECOVERY_CLEANUP_TIMEOUT_MS),
+  ]).then(() => window.location.reload());
 }
 
 function reloadOnceForStaleDeploy(error: unknown): void {
   if (!isDynamicImportError(error)) return;
-  triggerReloadOnce();
+  triggerReloadOnce('purge-and-reload');
 }
 
 function reloadOnceFromClientEvent(
   event: ErrorEvent | PromiseRejectionEvent,
 ): void {
-  if (!shouldReloadForClientEvent(event)) return;
-  triggerReloadOnce();
+  const action = getRecoveryForClientEvent(event);
+  if (action === undefined) return;
+  triggerReloadOnce(action);
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('error', reloadOnceFromClientEvent);
+  // Resource load errors do not bubble.
+  window.addEventListener('error', reloadOnceFromClientEvent, {
+    capture: true,
+  });
   window.addEventListener('unhandledrejection', reloadOnceFromClientEvent);
 }
 

--- a/projects/client/src/lib/utils/timing/delay.ts
+++ b/projects/client/src/lib/utils/timing/delay.ts
@@ -1,0 +1,3 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -82,8 +82,16 @@ const expiration = (maxAgeMs: number, maxEntries?: number) =>
     ...(maxEntries === undefined ? {} : { maxEntries }),
   });
 
+async function deleteCache(key: string) {
+  try {
+    return await caches.delete(key);
+  } catch {
+    return false;
+  }
+}
+
 function removeNavigationCache() {
-  return caches.delete(CacheKey.navigation);
+  return deleteCache(CacheKey.navigation);
 }
 
 // Force immediate activation for new service worker
@@ -92,12 +100,16 @@ self.addEventListener('install', () => {
 });
 
 // Claim clients and purge the navigation cache so stale locale-specific HTML
-// (e.g. a poisoned ru-RU document) is evicted on update.
+// (e.g. a poisoned ru-RU document) is evicted on update. A rejected
+// `waitUntil` fails activation, leaving a redundant worker that still controls
+// its clients and fails every request it intercepts.
 self.addEventListener('activate', (event) => {
-  event.waitUntil(Promise.all([
-    removeNavigationCache(),
-    self.clients.claim(),
-  ]));
+  event.waitUntil(
+    Promise.all([
+      removeNavigationCache(),
+      self.clients.claim(),
+    ]).catch(() => undefined),
+  );
 });
 
 self.addEventListener('message', (event) => {
@@ -160,7 +172,6 @@ registerRoute(
     const hasCacheParam = url.searchParams.has('_cb');
 
     if (hasCacheParam) {
-      // Delete the entire navigation cache
       await removeNavigationCache();
 
       // Remove _cb param and redirect
@@ -185,16 +196,35 @@ registerRoute(
   }),
 );
 
+function isSameOriginAsset(url: URL) {
+  // Skip caching for localhost
+  if (url.hostname === 'localhost') {
+    return false;
+  }
+  // Only cache same-origin assets to avoid intercepting third-party scripts,
+  // tracking pixels, etc. which fail CORS in strict browsers (e.g. Firefox).
+  return url.origin === self.location.origin;
+}
+
+// One build emits ~850 cacheable files, so a cap below that evicts forever,
+// and one under ~3400 evicts a build that is still in a user's tabs.
+const IMMUTABLE_CACHE_ENTRIES = 3500;
+
+registerRoute(
+  ({ url }) =>
+    isSameOriginAsset(url) &&
+    AssetPattern.immutable.test(url.pathname) &&
+    AssetPattern.static.test(url.pathname),
+  new CacheFirst({
+    cacheName: CacheKey.immutable,
+    plugins: [expiration(time.days(30), IMMUTABLE_CACHE_ENTRIES)],
+  }),
+);
+
 // Same-origin static assets, media and documents (CacheFirst)
 registerRoute(
   ({ url }) => {
-    // Skip caching for localhost
-    if (url.hostname === 'localhost') {
-      return false;
-    }
-    // Only cache same-origin assets to avoid intercepting third-party scripts,
-    // tracking pixels, etc. which fail CORS in strict browsers (e.g. Firefox).
-    if (url.origin !== self.location.origin) {
+    if (!isSameOriginAsset(url)) {
       return false;
     }
     return AssetPattern.static.test(url.pathname) ||

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -1,7 +1,7 @@
 import { AssetPattern } from '$worker/AssetPattern.ts';
 import { Domain } from '$worker/Domain.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
-import { ExpirationPlugin } from 'workbox-expiration';
+import { CacheExpiration, ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute } from 'workbox-precaching';
 import {
   NavigationRoute,
@@ -15,6 +15,7 @@ import {
 } from 'workbox-strategies';
 import { readAuthMarker } from './lib/features/auth/authMarker.ts';
 import { LOCALE_COOKIE_NAME } from './lib/features/i18n/constants.ts';
+import { delay } from './lib/utils/timing/delay.ts';
 import { time } from './lib/utils/timing/time.ts';
 import { CacheKey } from './worker/CacheKey.ts';
 
@@ -83,6 +84,12 @@ const expiration = (maxAgeMs: number, maxEntries?: number) =>
   });
 
 async function deleteCache(key: string) {
+  // `caches.delete` leaves the expiration plugin's IndexedDB rows behind, and
+  // the sha in the cache name means a dead name every deploy.
+  await new CacheExpiration(key, { maxAgeSeconds: 1 })
+    .delete()
+    .catch(() => undefined);
+
   try {
     return await caches.delete(key);
   } catch {
@@ -90,8 +97,29 @@ async function deleteCache(key: string) {
   }
 }
 
+const navigationCacheName = `${CacheKey.navigation}-${TRAKT_GIT_SHA}`;
+
+const CLEANUP_TIMEOUT_MS = time.seconds(3);
+
+async function deleteNavigationCaches() {
+  const keys = await caches.keys().catch(() => []);
+
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith(CacheKey.navigation))
+      .map((key) => deleteCache(key)),
+  );
+}
+
+// The cache name is keyed to the build, so this is garbage collection, not
+// correctness. Broken storage can hang instead of rejecting, and every caller
+// sits on something a user is waiting for: activation, a `_cb` navigation, or
+// a CacheBust round trip.
 function removeNavigationCache() {
-  return deleteCache(CacheKey.navigation);
+  return Promise.race([
+    deleteNavigationCaches(),
+    delay(CLEANUP_TIMEOUT_MS),
+  ]);
 }
 
 // Force immediate activation for new service worker
@@ -99,15 +127,14 @@ self.addEventListener('install', () => {
   self.skipWaiting();
 });
 
-// Claim clients and purge the navigation cache so stale locale-specific HTML
-// (e.g. a poisoned ru-RU document) is evicted on update. A rejected
-// `waitUntil` fails activation, leaving a redundant worker that still controls
-// its clients and fails every request it intercepts.
+// Claim clients and evict old navigation caches. A `waitUntil` that rejects
+// fails activation, and one that never settles parks the worker in
+// `activating` while the spec queues every fetch behind it.
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     Promise.all([
-      removeNavigationCache(),
       self.clients.claim(),
+      removeNavigationCache(),
     ]).catch(() => undefined),
   );
 });
@@ -150,7 +177,7 @@ const skipRedirectedDocuments = {
 };
 
 const navigationOptions = {
-  cacheName: CacheKey.navigation,
+  cacheName: navigationCacheName,
   plugins: [
     documentCacheKey,
     skipRedirectedDocuments,

--- a/projects/client/src/worker/AssetPattern.ts
+++ b/projects/client/src/worker/AssetPattern.ts
@@ -1,5 +1,6 @@
 export const AssetPattern = {
-  static: /\.(css|js|json|map)$/i,
+  static: /\.(css|js)$/i,
   media: /\.(png|jpg|jpeg|gif|svg|webp|ico|woff2?|ttf|eot)$/i,
   documents: /\.(html|htm)$/i,
+  immutable: /^\/_app\/immutable\//,
 };

--- a/projects/client/src/worker/CacheKey.ts
+++ b/projects/client/src/worker/CacheKey.ts
@@ -7,6 +7,7 @@ function buildCacheKey(key: string) {
 export const CacheKey = {
   manifest: buildCacheKey('manifest'),
   static: buildCacheKey('static-assets'),
+  immutable: buildCacheKey('immutable-assets'),
   navigation: buildCacheKey('navigation'),
   external: buildCacheKey('external-resources'),
   images: buildCacheKey('images'),


### PR DESCRIPTION
## 🎶 Notes 🎶

- A Firefox user hit `NS_ERROR_INTERCEPTION_FAILED` on every `_app/immutable` chunk: the service worker intercepts each request but can never respond.
- Cause: `activate` awaited an unguarded `caches.delete`. On profiles where storage throws (ETP strict, clear-on-close, quota eviction) the rejected `waitUntil` fails activation, and because we `skipWaiting` + `claim`, the now-redundant worker still controls the page and fails every request. State-dependent, which is why it only shows on some profiles.
- Fix: the navigation cache is keyed to the build, so our `activate` cleanup is garbage collection rather than correctness. It no longer gates activation, and it is time-bounded so a hanging quota manager can't park the worker in `activating` either (the spec queues every fetch behind activation, same symptom with a timeout instead of an error).
  - Not airtight: workbox-precaching registers its own `activate` `waitUntil` and that one is unguarded, so the same storage profile can still fail activation there. Exposure is ~13 precache entries, and the client-side recovery below is the real backstop.
- Recovery for users already stuck: the chunk-failure listener never actually fired (resource errors don't bubble, needs capture). It now wipes caches + unregisters the worker client-side before reloading, instead of asking the broken worker to clean up via `_cb`.
  - Skipped entirely while offline, so a transient blip on mobile data doesn't cost the caches.
- Side fixes while in there:
  - `version.json` sat in CacheFirst for 30 days, killing SvelteKit's update polling.
  - static cache capped at 500 entries while one build emits ~850 files, so it evicted forever; content-hashed chunks get their own cache.
- ⚠️ Can't repro locally (needs a broken-storage profile), so partly a blind fix. The recovery path also covers unknown causes, will monitor after deploy.
