### PR TITLE
Streaming: adjustments for 1 free service

### DIFF
--- a/projects/client/src/lib/requests/models/StreamingConnection.ts
+++ b/projects/client/src/lib/requests/models/StreamingConnection.ts
@@ -4,7 +4,6 @@ export const StreamingConnectionSchema = z.object({
   id: z.string(),
   key: z.string(),
   name: z.string(),
-  isVip: z.boolean(),
   color: z.string().nullish(),
   logoUrl: z.string().nullish(),
   isConnectable: z.boolean(),

--- a/projects/client/src/lib/requests/queries/streaming-sync/_internal/mapToStreamingConnection.ts
+++ b/projects/client/src/lib/requests/queries/streaming-sync/_internal/mapToStreamingConnection.ts
@@ -19,7 +19,6 @@ export function mapToStreamingConnection(
     id: connection.id,
     key: `streaming-connection-${connection.id}`,
     name: connection.name,
-    isVip: connection.vip,
     color: mapToColor(connection.color),
     logoUrl: prependHttps(connection.images?.logo),
     isConnectable: connection.connectable,

--- a/projects/client/src/lib/requests/queries/streaming-sync/streamingConnectionsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/streaming-sync/streamingConnectionsQuery.spec.ts
@@ -22,7 +22,6 @@ describe('streamingConnectionsQuery', () => {
     const prime = connections?.find((connection) => connection.id === 'amazon');
     expect(prime).to.include({
       name: 'Prime Video',
-      isVip: true,
       isConnected: true,
       isActive: true,
       profile: 'Justin',

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServices.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServices.svelte
@@ -4,10 +4,6 @@
   import StreamingServiceTile from "./StreamingServiceTile.svelte";
   import { useStreamingConnections } from "./useStreamingConnections.ts";
 
-  // Actionable services (connected, or connectable on the current plan - e.g.
-  // HBO Max for free users). VIP-gated services live in their own section
-  // (LockedStreamingServices) so the actionable ones are not buried among
-  // upgrade prompts.
   const { available } = useStreamingConnections();
 
   const inactiveNames = $derived(

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingConnections.ts
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingConnections.ts
@@ -2,12 +2,6 @@ import { useQuery } from '$lib/features/query/useQuery.ts';
 import { streamingConnectionsQuery } from '$lib/requests/queries/streaming-sync/streamingConnectionsQuery.ts';
 import { map } from 'rxjs';
 
-/**
- * Splits the user's streaming connections into services they can act on
- * (already connected, or connectable on their current plan - e.g. HBO Max for
- * free users) and VIP-gated services they cannot connect yet. Both views share
- * one cached query so the split stays consistent across sections.
- */
 export function useStreamingConnections() {
   const connections = useQuery(streamingConnectionsQuery()).pipe(
     map((query) => query.data ?? []),

--- a/projects/client/src/mocks/data/streaming-sync/response/StreamingConnectionsResponseMock.ts
+++ b/projects/client/src/mocks/data/streaming-sync/response/StreamingConnectionsResponseMock.ts
@@ -4,12 +4,12 @@ export const StreamingConnectionsResponseMock: YounifyConnection[] = [
   {
     id: 'hbomax',
     name: 'HBO Max',
-    vip: false,
+    vip: true,
     color: '#5822b4',
     images: {
       logo: 'walter-r2.trakt.tv/images/younify/hbomax/logo.png',
     },
-    connectable: true,
+    connectable: false,
     connected: false,
     active: false,
     profile: null,
@@ -18,7 +18,7 @@ export const StreamingConnectionsResponseMock: YounifyConnection[] = [
   {
     id: 'amazon',
     name: 'Prime Video',
-    vip: true,
+    vip: false,
     color: '#00a8e1',
     images: {
       logo: 'walter-r2.trakt.tv/images/younify/amazon/logo.png',
@@ -32,7 +32,7 @@ export const StreamingConnectionsResponseMock: YounifyConnection[] = [
   {
     id: 'appletv',
     name: 'Apple TV',
-    vip: true,
+    vip: false,
     color: '#000000',
     images: {
       logo: 'walter-r2.trakt.tv/images/younify/appletv/logo.png',


### PR DESCRIPTION
# Overview

The backend is moving streaming sync gating from a hardcoded free-service allowlist (HBO Max only) to a connection slot model: free accounts can connect **any single streaming service**, VIP unlocks them all. Those backend changes are already done and enforce everything server-side through the dynamic `connectable` flag on `/younify/connections`.

No functional changes are required here since this client already drives the entire streaming settings UI off `connectable`. Once the backend ships, free users automatically see every service as connectable until their slot is used, at which point the rest flow into the "Available with VIP" section. This PR just cleans up the leftovers from the old model.

# Changes

- Updated comments in `useStreamingConnections.ts` and `StreamingServices.svelte` that described the old model ("e.g. HBO Max for free users") to describe the slot model.
- Reshaped `StreamingConnectionsResponseMock` to the new semantics: the server now derives `vip` per user as the inverse of `connectable`, so no service is inherently VIP anymore. The mock scenario keeps both the available and locked sections rendering in dev.
- Removed the unused `isVip` field from the `StreamingConnection` model and mapper (nothing consumed it). The `vip` field remains on the `@trakt/api` wire type since the server still sends it; the client just no longer maps it.

# Notes

- The new backend also exposes `limits.streaming.connection_count` in `/users/settings` (1 for free, total service count for VIP). This client doesn't consume settings limits today; a "free accounts can sync 1 service" hint could be a follow-up if we want the explanatory upsell.
- The unused `tag_text_vip` i18n key is left in place to avoid locale pruning; it can be removed separately if we're sure no design needs a VIP tag on service tiles.

# Verification

- `deno task check`: 0 errors.
- All streaming-related specs pass (10 files, 36 tests) via `vitest --run streaming`.
