### PR TITLE
fix: escapes user submitted markdown and json-ld

### DIFF
--- a/projects/client/eslint.config.js
+++ b/projects/client/eslint.config.js
@@ -43,4 +43,24 @@ export default ts.config(
       ],
     },
   },
+  {
+    files: ['src/**'],
+    ignores: ['src/lib/utils/markdown/**'],
+
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          'paths': [
+            {
+              'name': 'marked',
+              'importNames': ['Marked', 'marked', 'parse', 'parseInline'],
+              'message':
+                'Raw marked output is not XSS safe. Use createSafeMarked from $lib/utils/markdown/createSafeMarked.ts instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -8,6 +8,7 @@
   import type { ExtendedMediaType } from "$lib/requests/models/ExtendedMediaType";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre";
+  import { escapeJsonForScriptTag } from "$lib/utils/json/escapeJsonForScriptTag.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import Redirect from "../../components/router/Redirect.svelte";
   import Footer from "../footer/Footer.svelte";
@@ -263,6 +264,10 @@
     return null;
   });
 
+  const escapedJsonLd = $derived(
+    jsonLd == null ? null : escapeJsonForScriptTag(jsonLd),
+  );
+
   const dynamicContentProps = $derived(
     hasDynamicContent
       ? {
@@ -305,8 +310,8 @@
   <meta name="twitter:image" content={image} />
   <meta name="twitter:creator" content={twitterHandle} />
 
-  {#if jsonLd != null}
-    {@html `<script type="application/ld+json">${jsonLd}</script>`}
+  {#if escapedJsonLd != null}
+    {@html `<script type="application/ld+json">${escapedJsonLd}</script>`}
   {/if}
 </svelte:head>
 

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
@@ -4,7 +4,7 @@
   import { spoilMeAnyway } from "$lib/features/spoilers/components/spoilMeAnyway";
   import type { MediaComment } from "$lib/requests/models/MediaComment";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
-  import { Marked } from "marked";
+  import { createSafeMarked } from "$lib/utils/markdown/createSafeMarked.ts";
   import { createHeadingRenderer } from "./marked/createHeadingRenderer";
   import { createParagraphRenderer } from "./marked/createParagraphRenderer";
   import { spoilerExtension } from "./marked/spoilerExtension";
@@ -21,7 +21,7 @@
   const { comment, media, type, onClick }: CommentBodyProps = $props();
 
   const marked = $derived(
-    new Marked({
+    createSafeMarked({
       extensions: [spoilerExtension()],
       renderer: {
         paragraph: createParagraphRenderer(comment.isSpoiler),

--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
@@ -2,7 +2,7 @@
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaTrivia } from "$lib/requests/models/MediaTrivia";
-  import { Marked } from "marked";
+  import { createSafeMarked } from "$lib/utils/markdown/createSafeMarked.ts";
   import InfoCard from "../../_internal/InfoCard.svelte";
 
   const {
@@ -13,7 +13,7 @@
     media: MediaEntry;
   } = $props();
 
-  const marked = new Marked();
+  const marked = createSafeMarked();
 </script>
 
 {#snippet parsedContent()}

--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaSummaryCard.svelte
@@ -8,7 +8,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import { SummaryDrawers } from "$lib/sections/summary/SummaryDrawers.ts";
   import { summaryDrawerNavigation } from "$lib/sections/summary/summaryDrawerNavigation.ts";
-  import { Marked } from "marked";
+  import { createSafeMarked } from "$lib/utils/markdown/createSafeMarked.ts";
 
   const {
     summary,
@@ -16,7 +16,7 @@
     summary: ReadonlyArray<string>;
   } = $props();
 
-  const marked = new Marked();
+  const marked = createSafeMarked();
   const { buildDrawerLink } = summaryDrawerNavigation();
   const { track } = useTrack(AnalyticsEvent.Drilldown);
 </script>

--- a/projects/client/src/lib/sections/yir/_internal/yirTooltipHTML.ts
+++ b/projects/client/src/lib/sections/yir/_internal/yirTooltipHTML.ts
@@ -1,3 +1,4 @@
+import { escapeHtml } from '$lib/utils/string/escapeHtml.ts';
 // Imported for the CSS side effect — YirTooltip's :global styles are reused
 // here when rendering the tooltip via Carbon's customHTML callback.
 import './YirTooltip.svelte';
@@ -7,14 +8,6 @@ export type YirTooltipContent = {
   sub?: string;
   extra?: string;
 };
-
-const escapeHtml = (text: string): string =>
-  text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 
 const line = (className: string, text: string | undefined): string =>
   text ? `<div class="${className}">${escapeHtml(text)}</div>` : '';

--- a/projects/client/src/lib/utils/json/escapeJsonForScriptTag.spec.ts
+++ b/projects/client/src/lib/utils/json/escapeJsonForScriptTag.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { escapeJsonForScriptTag } from './escapeJsonForScriptTag.ts';
+
+describe('escapeJsonForScriptTag', () => {
+  it('should escape a closing script tag', () => {
+    const json = JSON.stringify({ name: 'Heretic</script><img src=x>' });
+
+    const result = escapeJsonForScriptTag(json);
+
+    expect(result).not.toContain('</script>');
+    expect(result).not.toContain('<img');
+    expect(result).toContain('\\u003c/script\\u003e');
+  });
+
+  it('should escape angle brackets', () => {
+    expect(escapeJsonForScriptTag('{"a":"<b>"}')).toBe(
+      '{"a":"\\u003cb\\u003e"}',
+    );
+  });
+
+  it('should escape a line separator', () => {
+    const json = JSON.stringify({ a: String.fromCharCode(0x2028) });
+
+    expect(escapeJsonForScriptTag(json)).toBe('{"a":"\\u2028"}');
+  });
+
+  it('should escape a paragraph separator', () => {
+    const json = JSON.stringify({ a: String.fromCharCode(0x2029) });
+
+    expect(escapeJsonForScriptTag(json)).toBe('{"a":"\\u2029"}');
+  });
+
+  it('should stay valid json', () => {
+    const original = { name: 'a</script>b', overview: '1 < 2 > 0' };
+
+    const result = escapeJsonForScriptTag(JSON.stringify(original));
+
+    expect(JSON.parse(result)).toEqual(original);
+  });
+
+  it('should leave json without special characters untouched', () => {
+    const json = JSON.stringify({ name: 'Heretic' });
+
+    expect(escapeJsonForScriptTag(json)).toBe(json);
+  });
+});

--- a/projects/client/src/lib/utils/json/escapeJsonForScriptTag.ts
+++ b/projects/client/src/lib/utils/json/escapeJsonForScriptTag.ts
@@ -1,0 +1,7 @@
+export function escapeJsonForScriptTag(json: string): string {
+  return json
+    .replace(/</gu, '\\u003c')
+    .replace(/>/gu, '\\u003e')
+    .replace(/\u2028/gu, '\\u2028')
+    .replace(/\u2029/gu, '\\u2029');
+}

--- a/projects/client/src/lib/utils/markdown/_internal/safeMarkdownExtension.ts
+++ b/projects/client/src/lib/utils/markdown/_internal/safeMarkdownExtension.ts
@@ -1,0 +1,53 @@
+import { escapeHtml } from '$lib/utils/string/escapeHtml.ts';
+import { hasSafeUrlProtocol } from '$lib/utils/url/hasSafeUrlProtocol.ts';
+import type { MarkedExtension, RendererThis, Tokens } from 'marked';
+
+const DOUBLE_ENCODED_PERCENT = /%25/gu;
+
+const toAttributeUrl = (url: string) => {
+  if (!hasSafeUrlProtocol(url)) return null;
+
+  try {
+    return escapeHtml(encodeURI(url).replace(DOUBLE_ENCODED_PERCENT, '%'));
+  } catch {
+    return null;
+  }
+};
+
+const toTitleAttribute = (title: string | Nil) =>
+  title ? ` title="${escapeHtml(title)}"` : '';
+
+export function safeMarkdownExtension(): MarkedExtension {
+  return {
+    renderer: {
+      html({ text }: Tokens.HTML | Tokens.Tag) {
+        return escapeHtml(text);
+      },
+      link(this: RendererThis, token: Tokens.Link) {
+        const content = this.parser.parseInline(token.tokens);
+        const href = toAttributeUrl(token.href);
+
+        if (!href) return content;
+
+        return `<a href="${href}"${
+          toTitleAttribute(token.title)
+        }>${content}</a>`;
+      },
+      image(token: Tokens.Image) {
+        const alt = escapeHtml(token.text);
+        const src = toAttributeUrl(token.href);
+
+        if (!src) return alt;
+
+        return `<img src="${src}" alt="${alt}"${
+          toTitleAttribute(token.title)
+        }>`;
+      },
+      text(token: Tokens.Text | Tokens.Escape) {
+        if ('escaped' in token && token.escaped) return escapeHtml(token.text);
+
+        return false;
+      },
+    },
+  };
+}

--- a/projects/client/src/lib/utils/markdown/createSafeMarked.spec.ts
+++ b/projects/client/src/lib/utils/markdown/createSafeMarked.spec.ts
@@ -1,0 +1,276 @@
+import { createHeadingRenderer } from '$lib/sections/summary/components/comments/_internal/marked/createHeadingRenderer.ts';
+import { createParagraphRenderer } from '$lib/sections/summary/components/comments/_internal/marked/createParagraphRenderer.ts';
+import { spoilerExtension } from '$lib/sections/summary/components/comments/_internal/marked/spoilerExtension.ts';
+import { describe, expect, it } from 'vitest';
+import { createSafeMarked } from './createSafeMarked.ts';
+
+const commentOptions = { gfm: true, breaks: true, async: false } as const;
+
+const DANGEROUS_ELEMENTS =
+  'script, img, iframe, svg, style, object, embed, link, base, form';
+
+const renderComment = (source: string) =>
+  createSafeMarked().parse(source, commentOptions);
+
+const toDom = (html: string) => {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return container;
+};
+
+const eventHandlerAttributesOf = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('*'))
+    .flatMap((element) => Array.from(element.attributes))
+    .map((attribute) => attribute.name)
+    .filter((name) => name.startsWith('on'));
+
+describe('createSafeMarked', () => {
+  describe('raw html', () => {
+    const payloads = [
+      '<img src=x onerror=alert(1)>',
+      '<script>alert(1)</script>',
+      '<div onmouseover="alert(1)">hover</div>',
+      '<svg/onload=alert(1)>',
+      '<iframe src="javascript:alert(1)"></iframe>',
+      '<a href="javascript:alert(1)">click</a>',
+      '<style>body{display:none}</style>',
+      '<object data="javascript:alert(1)"></object>',
+      '<base href="https://evil.example/">',
+    ];
+
+    payloads.forEach((payload) => {
+      it(
+        `should build no dangerous element for ${JSON.stringify(payload)}`,
+        () => {
+          const container = toDom(renderComment(payload));
+
+          expect(container.querySelector(DANGEROUS_ELEMENTS)).toBeNull();
+        },
+      );
+
+      it(`should build no event handler for ${JSON.stringify(payload)}`, () => {
+        const container = toDom(renderComment(payload));
+
+        expect(eventHandlerAttributesOf(container)).toEqual([]);
+      });
+    });
+
+    it('should keep raw html readable as text', () => {
+      expect(renderComment('<img src=x onerror=alert(1)>')).toContain(
+        '&lt;img src=x onerror=alert(1)&gt;',
+      );
+    });
+
+    it('should not lose the content of a block level tag', () => {
+      expect(toDom(renderComment('<div>my entire review</div>')).textContent)
+        .toContain('my entire review');
+    });
+
+    it('should not leave a raw html comment in the output', () => {
+      expect(renderComment('<!-- <img src=x onerror=alert(1)> -->'))
+        .not.toContain('<!--');
+    });
+  });
+
+  describe('unsafe link protocols', () => {
+    const payloads = [
+      '[click](javascript:alert(1))',
+      '[click](JaVaScRiPt:alert(1))',
+      '[click](&#106;avascript:alert(1))',
+      '[click](javascript&colon;alert(1))',
+      '[click](javascript&#58;alert(1))',
+      '[click](javascript&#x3a;alert(1))',
+      '[click](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)',
+      '[click](vbscript:msgbox(1))',
+    ];
+
+    payloads.forEach((payload) => {
+      it(`should build no anchor for ${JSON.stringify(payload)}`, () => {
+        const container = toDom(renderComment(payload));
+
+        expect(container.querySelector('a')).toBeNull();
+        expect(container.textContent).toContain('click');
+      });
+
+      it(
+        `should resolve no unsafe protocol for ${JSON.stringify(payload)}`,
+        () => {
+          const container = toDom(renderComment(payload));
+          const anchors = Array.from(container.querySelectorAll('a'));
+
+          expect(anchors.map((anchor) => anchor.protocol)).toEqual([]);
+        },
+      );
+    });
+
+    it('should build no image for an unsafe source', () => {
+      const container = toDom(
+        renderComment('![alt text](javascript:alert(1))'),
+      );
+
+      expect(container.querySelector('img')).toBeNull();
+      expect(container.textContent).toContain('alt text');
+    });
+
+    it('should build no image for an entity encoded source', () => {
+      const container = toDom(
+        renderComment('![alt text](javascript&colon;alert(1))'),
+      );
+
+      expect(container.querySelector('img')).toBeNull();
+      expect(container.textContent).toContain('alt text');
+    });
+  });
+
+  describe('attribute encoding', () => {
+    it('should escape an ampersand in a href', () => {
+      expect(renderComment('[ok](/movies?a=1&b=2)')).toContain(
+        'href="/movies?a=1&amp;b=2"',
+      );
+    });
+
+    it('should resolve a href to the value that was validated', () => {
+      const source = '/movies?a=1&b=2';
+      const anchor = toDom(renderComment(`[ok](${source})`)).querySelector('a');
+
+      expect(anchor).toHaveAttribute('href', source);
+    });
+
+    it('should escape an ampersand in an image source', () => {
+      const image = toDom(renderComment('![alt](/i.png?a=1&b=2)'))
+        .querySelector('img');
+
+      expect(image).toHaveAttribute('src', '/i.png?a=1&b=2');
+    });
+
+    it('should escape a link title', () => {
+      const anchor = toDom(renderComment('[ok](/a "b&c")')).querySelector('a');
+
+      expect(anchor).toHaveAttribute('title', 'b&c');
+    });
+
+    it('should escape an image alt text', () => {
+      const image = toDom(renderComment('![a&b](/i.png)')).querySelector('img');
+
+      expect(image).toHaveAttribute('alt', 'a&b');
+    });
+
+    it('should build no title attribute when there is none', () => {
+      const anchor = toDom(renderComment('[ok](/a)')).querySelector('a');
+
+      expect(anchor).not.toHaveAttribute('title');
+    });
+  });
+
+  describe('safe markdown', () => {
+    it('should render bold text', () => {
+      expect(renderComment('**bold**')).toContain('<strong>bold</strong>');
+    });
+
+    it('should render emphasis', () => {
+      expect(renderComment('*em*')).toContain('<em>em</em>');
+    });
+
+    it('should render an https link', () => {
+      expect(toDom(renderComment('[ok](https://trakt.tv)')).querySelector('a'))
+        .toHaveAttribute('href', 'https://trakt.tv');
+    });
+
+    it('should render a relative link', () => {
+      expect(
+        toDom(renderComment('[ok](/movies/heretic-2024)')).querySelector('a'),
+      ).toHaveAttribute('href', '/movies/heretic-2024');
+    });
+
+    it('should render a fragment link', () => {
+      expect(toDom(renderComment('[ok](#section)')).querySelector('a'))
+        .toHaveAttribute('href', '#section');
+    });
+
+    it('should render a mailto link', () => {
+      expect(
+        toDom(renderComment('[ok](mailto:support@trakt.tv)')).querySelector(
+          'a',
+        ),
+      ).toHaveAttribute('href', 'mailto:support@trakt.tv');
+    });
+
+    it('should render an autolink', () => {
+      expect(toDom(renderComment('<https://trakt.tv>')).querySelector('a'))
+        .toHaveAttribute('href', 'https://trakt.tv');
+    });
+
+    it('should preserve query parameters', () => {
+      expect(
+        toDom(renderComment('[ok](https://trakt.tv/a?b=1&c=2)')).querySelector(
+          'a',
+        ),
+      ).toHaveAttribute('href', 'https://trakt.tv/a?b=1&c=2');
+    });
+
+    it('should render a codespan containing a tag', () => {
+      expect(renderComment('`<script>`')).toContain(
+        '<code>&lt;script&gt;</code>',
+      );
+    });
+
+    it('should render a fenced code block', () => {
+      expect(renderComment('```\nconst a = 1;\n```')).toContain('<pre>');
+    });
+
+    it('should render a list', () => {
+      expect(renderComment('- one\n- two')).toContain('<li>');
+    });
+
+    it('should render a blockquote', () => {
+      expect(renderComment('> quoted')).toContain('<blockquote>');
+    });
+  });
+
+  describe('composed with the comment renderers', () => {
+    const renderWithCommentExtensions = (
+      source: string,
+      isCommentSpoiler = false,
+    ) =>
+      createSafeMarked({
+        extensions: [spoilerExtension()],
+        renderer: {
+          paragraph: createParagraphRenderer(isCommentSpoiler),
+          heading: createHeadingRenderer(),
+        },
+      }).parse(source, commentOptions);
+
+    it('should neutralise a payload inside a spoiler tag', () => {
+      const container = toDom(
+        renderWithCommentExtensions(
+          '[spoiler]<img src=x onerror=alert(1)>[/spoiler]',
+        ),
+      );
+
+      expect(container.querySelector(DANGEROUS_ELEMENTS)).toBeNull();
+      expect(eventHandlerAttributesOf(container)).toEqual([]);
+    });
+
+    it('should still render a spoiler tag', () => {
+      const result = renderWithCommentExtensions('[spoiler]hidden[/spoiler]');
+
+      expect(result).toContain('class="trakt-spoiler"');
+      expect(result).toContain('<span>hidden</span>');
+    });
+
+    it('should still render a heading', () => {
+      expect(renderWithCommentExtensions('# title')).toContain(
+        'class="bold trakt-comment-heading"',
+      );
+    });
+
+    it('should neutralise a payload inside a heading', () => {
+      const container = toDom(
+        renderWithCommentExtensions('# <img src=x onerror=alert(1)>'),
+      );
+
+      expect(container.querySelector(DANGEROUS_ELEMENTS)).toBeNull();
+      expect(eventHandlerAttributesOf(container)).toEqual([]);
+    });
+  });
+});

--- a/projects/client/src/lib/utils/markdown/createSafeMarked.ts
+++ b/projects/client/src/lib/utils/markdown/createSafeMarked.ts
@@ -1,0 +1,8 @@
+import { Marked, type MarkedExtension } from 'marked';
+import { safeMarkdownExtension } from './_internal/safeMarkdownExtension.ts';
+
+export function createSafeMarked(
+  ...extensions: ReadonlyArray<MarkedExtension>
+): Marked {
+  return new Marked(...extensions, safeMarkdownExtension());
+}

--- a/projects/client/src/lib/utils/string/escapeHtml.spec.ts
+++ b/projects/client/src/lib/utils/string/escapeHtml.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from './escapeHtml.ts';
+
+describe('escapeHtml', () => {
+  it('should escape ampersands', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b');
+  });
+
+  it('should escape angle brackets', () => {
+    expect(escapeHtml('<b>')).toBe('&lt;b&gt;');
+  });
+
+  it('should escape double quotes', () => {
+    expect(escapeHtml('say "hi"')).toBe('say &quot;hi&quot;');
+  });
+
+  it('should escape single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#39;s');
+  });
+
+  it('should escape a script tag payload', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+  });
+
+  it('should escape an attribute injection payload', () => {
+    expect(escapeHtml('<img src=x onerror="alert(1)">')).toBe(
+      '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;',
+    );
+  });
+
+  it('should leave text without special characters untouched', () => {
+    expect(escapeHtml('plain text')).toBe('plain text');
+  });
+
+  it('should return an empty string unchanged', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('should escape the ampersand of an existing entity', () => {
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+  });
+});

--- a/projects/client/src/lib/utils/string/escapeHtml.ts
+++ b/projects/client/src/lib/utils/string/escapeHtml.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;')
+    .replace(/'/gu, '&#39;');
+}

--- a/projects/client/src/lib/utils/url/hasSafeUrlProtocol.spec.ts
+++ b/projects/client/src/lib/utils/url/hasSafeUrlProtocol.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { hasSafeUrlProtocol } from './hasSafeUrlProtocol.ts';
+
+const TAB = 9;
+const LINE_FEED = 10;
+const CARRIAGE_RETURN = 13;
+const NULL_CHARACTER = 0;
+const SPACE = 32;
+
+const itRejects = (urls: ReadonlyArray<string>) =>
+  urls.forEach((url) => {
+    it(`should reject ${JSON.stringify(url)}`, () => {
+      expect(hasSafeUrlProtocol(url)).toBe(false);
+    });
+  });
+
+const itAllows = (urls: ReadonlyArray<string>) =>
+  urls.forEach((url) => {
+    it(`should allow ${JSON.stringify(url)}`, () => {
+      expect(hasSafeUrlProtocol(url)).toBe(true);
+    });
+  });
+
+describe('hasSafeUrlProtocol', () => {
+  describe('unsafe protocols', () => {
+    const unsafe = [
+      'javascript:alert(1)', // skipcq: JS-0087
+      'JaVaScRiPt:alert(1)', // skipcq: JS-0087
+      'JAVASCRIPT:alert(1)', // skipcq: JS-0087
+      'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'blob:https://trakt.tv/abc',
+      'ftp://trakt.tv/x',
+    ];
+
+    itRejects(unsafe);
+  });
+
+  describe('control character obfuscation', () => {
+    const codes = [TAB, LINE_FEED, CARRIAGE_RETURN, NULL_CHARACTER, SPACE];
+
+    codes.forEach((code) => {
+      it(`should reject a scheme split by char code ${code}`, () => {
+        const url = `java${String.fromCharCode(code)}script:alert(1)`;
+        expect(hasSafeUrlProtocol(url)).toBe(false);
+      });
+
+      it(`should reject a scheme prefixed by char code ${code}`, () => {
+        const url = `${String.fromCharCode(code)}javascript:alert(1)`;
+        expect(hasSafeUrlProtocol(url)).toBe(false);
+      });
+    });
+  });
+
+  describe('html entity encoded protocols', () => {
+    const encoded = [
+      '&#106;avascript:alert(1)',
+      '&#x6a;avascript:alert(1)',
+      '&#0000106avascript:alert(1)',
+      '&#106;avascript:alert(1)#fragment',
+    ];
+
+    itRejects(encoded);
+  });
+
+  describe('html entity encoded colons', () => {
+    const encoded = [
+      'javascript&colon;alert(1)',
+      'JaVaScRiPt&colon;alert(1)',
+      'javascript&#58;alert(1)',
+      'javascript&#x3a;alert(1)',
+      'javascript&#X3A;alert(1)',
+      'javascript&#0000058;alert(1)',
+      'data&colon;text/html,<script>alert(1)</script>',
+      'vbscript&colon;msgbox(1)',
+    ];
+
+    itRejects(encoded);
+  });
+
+  describe('safe protocols', () => {
+    const safe = [
+      'https://trakt.tv/movies/heretic-2024',
+      'http://trakt.tv/movies/heretic-2024',
+      'HTTPS://trakt.tv/x',
+      'mailto:support@trakt.tv',
+      'https://trakt.tv/a?b=1&c=2',
+      'https://trakt.tv/a&b',
+      'mailto:support@trakt.tv?subject=a&body=b',
+    ];
+
+    itAllows(safe);
+  });
+
+  describe('relative urls', () => {
+    const relative = [
+      '/movies/heretic-2024',
+      '../shows/silo',
+      '#section',
+      '',
+      '//trakt.tv/movies',
+      'foo/bar:baz',
+      '?q=a:b',
+      '/movies?a=1&b=2',
+      '?a=1&b=2',
+      '/movies/heretic-2024#a&b',
+    ];
+
+    itAllows(relative);
+  });
+});

--- a/projects/client/src/lib/utils/url/hasSafeUrlProtocol.ts
+++ b/projects/client/src/lib/utils/url/hasSafeUrlProtocol.ts
@@ -1,0 +1,33 @@
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+const LAST_CONTROL_CHARACTER_CODE = 0x20;
+const PATH_SEPARATORS = /[/?]/u;
+const AUTHORITY_SEPARATORS = /[/?#]/u;
+const CHARACTER_REFERENCE_START = '&';
+
+const stripControlCharacters = (url: string) =>
+  Array.from(url)
+    .filter((character) =>
+      character.charCodeAt(0) > LAST_CONTROL_CHARACTER_CODE
+    )
+    .join('');
+
+const hasEncodedScheme = (url: string) => {
+  const authorityEnd = url.search(AUTHORITY_SEPARATORS);
+  const authority = authorityEnd === -1 ? url : url.slice(0, authorityEnd);
+
+  return authority.includes(CHARACTER_REFERENCE_START);
+};
+
+export function hasSafeUrlProtocol(url: string): boolean {
+  const normalized = stripControlCharacters(url);
+
+  if (normalized.startsWith('#')) return true;
+
+  const colonIndex = normalized.indexOf(':');
+  if (colonIndex === -1) return !hasEncodedScheme(normalized);
+
+  const prefix = normalized.slice(0, colonIndex);
+  if (PATH_SEPARATORS.test(prefix)) return true;
+
+  return SAFE_PROTOCOLS.has(`${prefix.toLowerCase()}:`);
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Comments, reviews and trivia render user markdown through `{@html}`. marked ships zero sanitization by design, so `<script>` and `javascript:` links went straight to the DOM.
- All markdown now goes through `createSafeMarked`. Raw html tokens are escaped to visible text, link and image hrefs must pass `hasSafeUrlProtocol`.
  - Escaped rather than stripped: on a block token `text` is the whole chunk, so stripping would render `<div>my entire review</div>` as nothing.
- The link and image renderers build their own attributes, so the href we validate is the exact string the browser resolves.
  - Without that, an entity encoded colon (`javascript&colon;alert(1)`) slips past the protocol check and the html parser decodes it back to `javascript:` in the attribute.
- eslint rule bans raw `marked` imports outside the factory, so the unsafe path is unreachable. Catches named and namespace imports.
- The json-ld block is assembled as a raw script tag and `JSON.stringify` doesn't escape `<`, so an api title containing `</script>` broke out of the element. Escaped at the sink rather than in each of the four builders.
- No dompurify: it needs a DOM and we ssr on workers, so it would mean pulling `isomorphic-dompurify` + jsdom into the worker bundle. Escaping at token level works the same on both sides, and we allow zero user html anyway, which is stricter than dompurify's allowlist.
- `escapeHtml` was living in the yir tooltip, moved to a shared util.
