### PR TITLE
fix(filter): only put the discover mode in the url when it is not the default

### DIFF
--- a/projects/client/src/lib/components/toggles/useToggler.ts
+++ b/projects/client/src/lib/components/toggles/useToggler.ts
@@ -43,6 +43,7 @@ export function useToggler<T extends TogglerId, K = TogglerValueMap[T]>(id: T) {
 
   return {
     options: toggler.options,
+    default: toggler.default as K,
     current: current.pipe(
       map(($current) => {
         const option = toggler.options.find((o) => o.value === $current) ??

--- a/projects/client/src/lib/features/filters/FilterProvider.spec.ts
+++ b/projects/client/src/lib/features/filters/FilterProvider.spec.ts
@@ -1,7 +1,7 @@
 import { goto } from '$app/navigation';
+import { resetGlobalStore } from '$lib/components/toggles/useToggler.ts';
 import { renderComponent } from '$test/beds/component/renderComponent.ts';
-import { waitFor } from '@testing-library/svelte';
-import { createRawSnippet } from 'svelte';
+import { createRawSnippet, tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import FilterProvider from './FilterProvider.svelte';
 import { DISCOVER_MODE_PARAM } from './_internal/constants.ts';
@@ -12,61 +12,114 @@ const children = createRawSnippet(() => ({
   render: () => '<span>child</span>',
 }));
 
+const DISCOVER_TOGGLER_KEY = 'trakt_toggler_discover';
+
 describe('FilterProvider', () => {
-  const renderProvider = () =>
+  const renderProvider = async () => {
     renderComponent(FilterProvider, { props: { children } });
+    await tick();
+    await tick();
+  };
+
+  const storeFilters = (filters: Record<string, string>) =>
+    localStorage.setItem(STORED_FILTERS_KEY, JSON.stringify(filters));
+
+  const storeMode = (mode: string) =>
+    localStorage.setItem(DISCOVER_TOGGLER_KEY, JSON.stringify(mode));
+
+  const targetUrl = () =>
+    new URL(vi.mocked(goto).mock.calls.at(0)?.[0] ?? '', 'http://localhost');
 
   beforeEach(() => {
     localStorage.clear();
+    resetGlobalStore();
     window.history.replaceState({}, '', '/movies');
   });
 
   it('should restore stored filters into the URL on mount', async () => {
-    localStorage.setItem(
-      STORED_FILTERS_KEY,
-      JSON.stringify({ [FilterKey.Genres]: 'action' }),
-    );
+    storeFilters({ [FilterKey.Genres]: 'action' });
 
-    renderProvider();
+    await renderProvider();
 
-    await waitFor(() => expect(goto).toHaveBeenCalledTimes(1));
-
-    const target = new URL(vi.mocked(goto).mock.calls.at(0)?.[0] ?? '');
-    expect(target.searchParams.get(FilterKey.Genres)).toBe('action');
+    expect(goto).toHaveBeenCalledTimes(1);
+    expect(targetUrl().searchParams.get(FilterKey.Genres)).toBe('action');
   });
 
-  it('should set discover mode when there are no stored filters', async () => {
-    renderProvider();
+  it('should not navigate when there are no stored filters', async () => {
+    await renderProvider();
 
-    await waitFor(() => expect(goto).toHaveBeenCalledTimes(1));
-
-    const target = new URL(vi.mocked(goto).mock.calls.at(0)?.[0] ?? '');
-    expect(target.searchParams.get(DISCOVER_MODE_PARAM)).toBe('media');
+    expect(goto).not.toHaveBeenCalled();
   });
 
-  it('should set discover mode when stored filters are empty', async () => {
-    localStorage.setItem(STORED_FILTERS_KEY, JSON.stringify({}));
+  it('should not navigate when stored filters are empty', async () => {
+    storeFilters({});
 
-    renderProvider();
+    await renderProvider();
 
-    await waitFor(() => expect(goto).toHaveBeenCalledTimes(1));
-
-    const target = new URL(vi.mocked(goto).mock.calls.at(0)?.[0] ?? '');
-    expect(target.searchParams.get(DISCOVER_MODE_PARAM)).toBe('media');
+    expect(goto).not.toHaveBeenCalled();
   });
 
   it('should not override filters already present in the URL', async () => {
     window.history.replaceState({}, '', `/movies?${FilterKey.Genres}=comedy`);
-    localStorage.setItem(
-      STORED_FILTERS_KEY,
-      JSON.stringify({ [FilterKey.Genres]: 'action' }),
-    );
+    storeFilters({ [FilterKey.Genres]: 'action' });
 
-    renderProvider();
+    await renderProvider();
 
-    await waitFor(() => expect(goto).toHaveBeenCalledTimes(1));
+    expect(goto).not.toHaveBeenCalled();
+  });
 
-    const target = new URL(vi.mocked(goto).mock.calls.at(0)?.[0] ?? '');
-    expect(target.searchParams.get(FilterKey.Genres)).toBe('comedy');
+  describe('discover mode', () => {
+    it('should not add the default mode to the URL', async () => {
+      storeFilters({ [FilterKey.Genres]: 'action' });
+      storeMode('media');
+
+      await renderProvider();
+
+      expect(goto).toHaveBeenCalledTimes(1);
+      expect(targetUrl().searchParams.has(DISCOVER_MODE_PARAM)).toBe(false);
+    });
+
+    it('should not navigate for the default mode alone', async () => {
+      storeMode('media');
+
+      await renderProvider();
+
+      expect(goto).not.toHaveBeenCalled();
+    });
+
+    it('should restore a non-default mode into the URL', async () => {
+      storeMode('movie');
+
+      await renderProvider();
+
+      expect(goto).toHaveBeenCalledTimes(1);
+      expect(targetUrl().searchParams.get(DISCOVER_MODE_PARAM)).toBe('movie');
+    });
+
+    it('should restore a non-default mode alongside stored filters', async () => {
+      storeFilters({ [FilterKey.Genres]: 'action' });
+      storeMode('show');
+
+      await renderProvider();
+
+      expect(goto).toHaveBeenCalledTimes(1);
+
+      const params = targetUrl().searchParams;
+      expect(params.get(DISCOVER_MODE_PARAM)).toBe('show');
+      expect(params.get(FilterKey.Genres)).toBe('action');
+    });
+
+    it('should not override a mode already present in the URL', async () => {
+      window.history.replaceState(
+        {},
+        '',
+        `/movies?${DISCOVER_MODE_PARAM}=show`,
+      );
+      storeMode('movie');
+
+      await renderProvider();
+
+      expect(goto).not.toHaveBeenCalled();
+    });
   });
 });

--- a/projects/client/src/lib/features/filters/FilterProvider.svelte
+++ b/projects/client/src/lib/features/filters/FilterProvider.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  import { page } from "$app/state";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { safeLocalStorage } from "$lib/utils/storage/safeStorage";
   import { firstValueFrom } from "rxjs";
   import { onMount } from "svelte";
-  import {
-    DISCOVER_MODE_PARAM,
-    SEASONAL_STORAGE_KEY,
-  } from "./_internal/constants";
+  import { SEASONAL_STORAGE_KEY } from "./_internal/constants";
   import { createDiscoverContext } from "./_internal/createDiscoverContext";
   import { useStoredFilters } from "./useStoredFilters";
 
@@ -18,6 +14,7 @@
   );
 
   const { restoreFilters } = useStoredFilters();
+  const { current, default: defaultMode } = useToggler("discover");
   createDiscoverContext(useSeasonalFilters);
 
   /*
@@ -27,15 +24,8 @@
     future features that rely on search params.
   */
   onMount(async () => {
-    const hasDiscoverParam = page.url.searchParams.has(DISCOVER_MODE_PARAM);
-    if (hasDiscoverParam) {
-      restoreFilters();
-      return;
-    }
-
-    const { current } = useToggler("discover");
-    const { value: initialMode } = await firstValueFrom(current);
-    restoreFilters(initialMode);
+    const { value: mode } = await firstValueFrom(current);
+    restoreFilters(mode === defaultMode ? undefined : mode);
   });
 </script>
 

--- a/projects/client/src/lib/features/filters/useStoredFilters.ts
+++ b/projects/client/src/lib/features/filters/useStoredFilters.ts
@@ -59,21 +59,17 @@ export function useStoredFilters() {
   const { search } = useParameters();
   const { track } = useTrack(AnalyticsEvent.Filters);
 
-  const goToStoredFilters = (
-    filters: StoredFilter,
-    baseUrl: URL,
-  ) => {
-    const url = new URL(baseUrl);
-
+  const applyFilters = (url: URL, filters: StoredFilter) => {
     processFilterParams(
       Object.entries(filters),
       (key, value) => {
         url.searchParams.set(key, String(value));
       },
     );
+  };
 
-    // No-op navigations (e.g. empty stored filters) would otherwise loop
-    // forever under afterNavigate, since the URL never changes.
+  const goToUrl = (url: URL) => {
+    // goto still navigates when the target is identical, so skip it.
     if (url.href === page.url.href) {
       return;
     }
@@ -107,24 +103,16 @@ export function useStoredFilters() {
   const restoreFilters = (mode?: DiscoverMode) => {
     const url = new URL(page.url);
 
-    if (mode) {
+    if (mode && !url.searchParams.has(DISCOVER_MODE_PARAM)) {
       url.searchParams.set(DISCOVER_MODE_PARAM, mode);
     }
 
-    const hasParams = hasFilter(page.url.searchParams);
     const defaultFilters = getDefaultFilters();
-    const shouldRestoreFilters = !hasParams && defaultFilters;
-
-    if (mode && !shouldRestoreFilters) {
-      if (url.href !== page.url.href) {
-        goto(url, { replaceState: true, keepFocus: true, noScroll: true });
-      }
-      return;
+    if (!hasFilter(page.url.searchParams) && defaultFilters) {
+      applyFilters(url, defaultFilters);
     }
 
-    if (shouldRestoreFilters) {
-      goToStoredFilters(defaultFilters, url);
-    }
+    goToUrl(url);
   };
 
   const resetFilters = () => {
@@ -138,7 +126,8 @@ export function useStoredFilters() {
 
     const url = new URL(page.url);
     FILTERS.forEach((filter) => url.searchParams.delete(filter.key));
-    goToStoredFilters(defaultFilters, url);
+    applyFilters(url, defaultFilters);
+    goToUrl(url);
   };
 
   const setActiveMode = (mode: string) => {


### PR DESCRIPTION
## 🎶 Notes 🎶

- We seeded the discover mode into the url on every mount, so pages that never read it ended up with things like `/about?mode=media`. `media` is the default, so the param said nothing
- The mode is now only written when it differs from the toggler default, in the same navigation that restores the stored filters
- An existing `?mode=` is never overwritten, so the url stays the source of truth. A shared link resolves to the same content for everyone, whatever the recipient last picked
- `useToggler` now exposes its `default` so the comparison doesn't have to reach into `TOGGLERS`
- Untangled `restoreFilters` into build one url, one guard, one navigation. `applyFilters` and `goToUrl` are shared with `resetFilters`
- `appendGlobalParameters` is untouched, so once the mode is set it still gets carried exactly like before

- ⚠️ `resetFilters` still throws away the whole query string when there are no stored filters, so it drops the mode with it. Left as is for now, since fixing it also changes what happens to `sort_by` / `sort_how` on a reset. Will be tackled separately
- Stored filters can still reach presentation pages (`/about?genres=action`). Keeping them off would need a hardcoded list of paths, which isn't worth the maintenance. Properly generic would mean each route declaring whether it takes global params, revisit later
