### PR TITLE
Streaming: handle new younify return params

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -9599,6 +9599,14 @@
       "default": "You can connect {service} whenever you're ready.",
       "description": "Message shown when the user cancelled connecting a streaming service."
     },
+    "text_connection_status_expired_title": {
+      "default": "Connection timed out",
+      "description": "Title shown in the banner when the streaming service connect session expired before completing."
+    },
+    "text_connection_status_expired_message": {
+      "default": "Your session expired. Try connecting {service} again.",
+      "description": "Message shown when the streaming service connect session expired before completing."
+    },
     "text_streaming_service_fallback": {
       "default": "your streaming service",
       "description": "Generic fallback name used when a streaming service name can't be resolved."

--- a/projects/client/src/lib/models/StreamingConnectionStatusKind.ts
+++ b/projects/client/src/lib/models/StreamingConnectionStatusKind.ts
@@ -1,0 +1,5 @@
+export type StreamingConnectionStatusKind =
+  | 'connected'
+  | 'error'
+  | 'cancelled'
+  | 'expired';

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/ConnectionResultHandler.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/ConnectionResultHandler.svelte
@@ -10,29 +10,25 @@
   import { firstValueFrom } from "rxjs";
   import { onMount } from "svelte";
   import { toFavoritesWithConnection } from "./toFavoritesWithConnection.ts";
-  import {
-    type StreamingConnectionStatusKind,
-    streamingConnectionStatus,
-  } from "./streamingConnectionStatus.ts";
+  import type { StreamingConnectionStatusKind } from "$lib/models/StreamingConnectionStatusKind.ts";
+  import { streamingConnectionStatus } from "./streamingConnectionStatus.ts";
 
   // Clean result params the connect callback route redirects here with.
   const CONNECTION_PARAM = "connection";
   const SERVICE_PARAM = "service";
 
-  const RESULT_KINDS = new Set<StreamingConnectionStatusKind>([
+  const RESULT_KINDS: readonly StreamingConnectionStatusKind[] = [
     "connected",
     "cancelled",
     "error",
-  ]);
+    "expired",
+  ];
 
   const { invalidate } = useInvalidator();
   const { favorites, country } = useStreamingPreferences();
 
-  function toKind(value: string | null): StreamingConnectionStatusKind | null {
-    if (value && RESULT_KINDS.has(value as StreamingConnectionStatusKind)) {
-      return value as StreamingConnectionStatusKind;
-    }
-    return null;
+  function toKind(value: string | null) {
+    return RESULT_KINDS.find((kind) => kind === value) ?? null;
   }
 
   // Mark the connected service as a watch-now favorite, mapping the younify id

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingConnectionStatusSnackbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingConnectionStatusSnackbar.svelte
@@ -41,6 +41,13 @@
             service: serviceName,
           }),
         };
+      case "expired":
+        return {
+          title: `⌛ ${m.text_connection_status_expired_title()}`,
+          message: m.text_connection_status_expired_message({
+            service: serviceName,
+          }),
+        };
     }
   });
 

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/streamingConnectionStatus.ts
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/streamingConnectionStatus.ts
@@ -1,6 +1,5 @@
+import type { StreamingConnectionStatusKind } from '$lib/models/StreamingConnectionStatusKind.ts';
 import { writable } from '$lib/utils/store/WritableSubject.ts';
-
-export type StreamingConnectionStatusKind = 'connected' | 'error' | 'cancelled';
 
 export type StreamingConnectionStatus = {
   kind: StreamingConnectionStatusKind;

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingServicesActions.ts
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingServicesActions.ts
@@ -14,9 +14,8 @@ export function useStreamingServicesActions() {
   const { invalidate } = useInvalidator();
   const { confirm } = useConfirm();
 
-  // Younify returns to the dedicated callback route with `yc_status` /
-  // `yc_serviceId` appended; that route applies the result, then redirects
-  // back to the settings page.
+  // Younify returns to the dedicated callback route, which normalises its
+  // result params before redirecting back to the settings page.
   const buildReturnUrl = () =>
     new URL(UrlBuilder.settings.streamingServicesCallback(), page.url.origin)
       .toString();

--- a/projects/client/src/routes/callback/streaming/+page.ts
+++ b/projects/client/src/routes/callback/streaming/+page.ts
@@ -2,21 +2,32 @@ import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from '$types/callback/streaming/$types.d.ts';
 
-// Params younify appends to the return url in single-provider mode.
+// Younify appends these to the return url in single-provider mode. The beta and
+// release apps name both the service param and the statuses differently, so
+// accept either until the beta app is retired.
 const YC_STATUS_PARAM = 'yc_status';
-const YC_SERVICE_PARAM = 'yc_serviceId';
+const YC_SERVICE_PARAMS = ['yc_service_id', 'yc_serviceId'];
+
+const YC_CONNECTIONS: Record<string, string> = {
+  succeeded: 'connected',
+  connected: 'connected',
+  success: 'connected',
+  canceled: 'cancelled',
+  cancelled: 'cancelled',
+};
 
 function toConnection(status: string | null): string | undefined {
-  if (status === 'connected' || status === 'success') {
-    return 'connected';
+  if (!status) {
+    return undefined;
   }
-  if (status === 'cancelled') {
-    return 'cancelled';
-  }
-  if (status) {
-    return 'error';
-  }
-  return undefined;
+
+  return YC_CONNECTIONS[status] ?? 'error';
+}
+
+function toService(url: URL): string | null {
+  return YC_SERVICE_PARAMS
+    .map((param) => url.searchParams.get(param))
+    .find((value) => value != null) ?? null;
 }
 
 /**
@@ -27,9 +38,7 @@ function toConnection(status: string | null): string | undefined {
  */
 export const load: PageLoad = ({ url }) => {
   const connection = toConnection(url.searchParams.get(YC_STATUS_PARAM));
-  const service = connection
-    ? url.searchParams.get(YC_SERVICE_PARAM)
-    : undefined;
+  const service = connection ? toService(url) : undefined;
 
   redirect(303, UrlBuilder.settings.streamingServices({ connection, service }));
 };

--- a/projects/client/src/routes/callback/streaming/+page.ts
+++ b/projects/client/src/routes/callback/streaming/+page.ts
@@ -1,3 +1,4 @@
+import type { StreamingConnectionStatusKind } from '$lib/models/StreamingConnectionStatusKind.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from '$types/callback/streaming/$types.d.ts';
@@ -8,15 +9,18 @@ import type { PageLoad } from '$types/callback/streaming/$types.d.ts';
 const YC_STATUS_PARAM = 'yc_status';
 const YC_SERVICE_PARAMS = ['yc_service_id', 'yc_serviceId'];
 
-const YC_CONNECTIONS: Record<string, string> = {
+const YC_CONNECTIONS: Record<string, StreamingConnectionStatusKind> = {
   succeeded: 'connected',
   connected: 'connected',
   success: 'connected',
   canceled: 'cancelled',
   cancelled: 'cancelled',
+  expired: 'expired',
 };
 
-function toConnection(status: string | null): string | undefined {
+function toConnection(
+  status: string | null,
+): StreamingConnectionStatusKind | undefined {
   if (!status) {
     return undefined;
   }


### PR DESCRIPTION
# Summary

Younify is updating its web-app communication interface as it comes out of beta, and the query params it appends to our return url are changing. This updates the `/callback/streaming` route to understand the new interface while remaining fully backwards compatible with the current one, so both app versions work during the transition.

# What changed

The release version of the younify app returns different params than the beta:

- The service param is renamed from `yc_serviceId` to `yc_service_id`.
- The `yc_status` vocabulary changes from `connected|success|cancelled|error` to `succeeded|canceled|failed|expired`.

The callback route now reads `yc_service_id` first and falls back to `yc_serviceId`, and `toConnection` accepts both status vocabularies: `succeeded` joins the connected statuses, `canceled` joins cancelled, and `failed` (plus any unknown value) maps to the existing error result. The old params can be dropped once the transition window closes.

The launch side already sends `return_url` in the connect request body, so the newly mandatory return url field required no changes.

# New expired status

The new `expired` status gets first-class handling instead of collapsing into the generic error banner, since it means the connect session timed out rather than something going wrong:

- Added `expired` to `StreamingConnectionStatusKind` and to the result kinds the settings page accepts.
- The snackbar shows dedicated copy ("Connection timed out" / "Your session expired. Try connecting {service} again.") with informational styling rather than the error variant.
- Two new i18n keys added to `i18n/meta/en.json`.
