### PR TITLE
feat(errors): tunnel sentry envelopes through our own origin

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -4,6 +4,7 @@ import '$lib/polyfills/randomUUID.ts';
 import '$lib/polyfills/toReversed.ts';
 import '$lib/polyfills/toSorted.ts';
 import { captureWebviewSession } from '$lib/features/webview/captureWebviewSession.ts';
+import { SentryEndpoint } from '$lib/features/sentry/SentryEndpoint.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';
 import * as Sentry from '@sentry/sveltekit';
@@ -49,6 +50,8 @@ function isSampledError(event: SentryErrorEvent): boolean {
 
 Sentry.init({
   dsn: SENTRY_DSN,
+
+  tunnel: SentryEndpoint.Tunnel,
 
   // Matches the server rate. Client navigations are the higher-volume side, so
   // sampling them harder than the server made the asymmetry backwards.

--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -10,6 +10,7 @@ import { handle as handleImage } from '$lib/features/image/handle.ts';
 import { handle as handleLegacyRedirect } from '$lib/features/legacy-redirects/handle.ts';
 import { handle as handleMobileOperatingSystem } from '$lib/features/mobile-os/handle.ts';
 import { handle as handleSearchConfig } from '$lib/features/search/handle.ts';
+import { handle as handleSentryTunnel } from '$lib/features/sentry/handle.ts';
 import { handle as handleTheme } from '$lib/features/theme/handle.ts';
 import { hasAuthSession } from '$lib/features/auth/hasAuthSession.ts';
 import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
@@ -118,6 +119,7 @@ export const handle: Handle = sequence(
     beforeSend: scrubWebviewParams,
     beforeSendTransaction: scrubWebviewParams,
   }),
+  handleSentryTunnel,
   sentryHandle(),
   // Retire legacy trakt.tv paths with a 301 before any routing/auth/i18n work.
   handleLegacyRedirect,

--- a/projects/client/src/lib/features/sentry/SentryEndpoint.ts
+++ b/projects/client/src/lib/features/sentry/SentryEndpoint.ts
@@ -1,0 +1,3 @@
+export enum SentryEndpoint {
+  Tunnel = '/api/client-report',
+}

--- a/projects/client/src/lib/features/sentry/_internal/parseSentryDsn.spec.ts
+++ b/projects/client/src/lib/features/sentry/_internal/parseSentryDsn.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseSentryDsn } from './parseSentryDsn.ts';
+
+describe('util: parseSentryDsn', () => {
+  it('should extract host and project id from a regional DSN', () => {
+    expect(
+      parseSentryDsn(
+        'https://7c03bc5bf58eb8ceb23801702a91954f@o4509870904639488.ingest.de.sentry.io/4509870926463056',
+      ),
+    ).toEqual({
+      host: 'o4509870904639488.ingest.de.sentry.io',
+      projectId: '4509870926463056',
+    });
+  });
+
+  it('should extract host and project id from a non-regional DSN', () => {
+    expect(parseSentryDsn('https://key@o1.ingest.sentry.io/42')).toEqual({
+      host: 'o1.ingest.sentry.io',
+      projectId: '42',
+    });
+  });
+
+  it('should return null when the project id is missing', () => {
+    expect(parseSentryDsn('https://key@o1.ingest.sentry.io')).toBeNull();
+  });
+
+  it('should return null for a malformed url', () => {
+    expect(parseSentryDsn('not-a-dsn')).toBeNull();
+  });
+
+  it('should return null for an empty string', () => {
+    expect(parseSentryDsn('')).toBeNull();
+  });
+});

--- a/projects/client/src/lib/features/sentry/_internal/parseSentryDsn.ts
+++ b/projects/client/src/lib/features/sentry/_internal/parseSentryDsn.ts
@@ -1,0 +1,19 @@
+type SentryDsn = {
+  host: string;
+  projectId: string;
+};
+
+export function parseSentryDsn(dsn: string): SentryDsn | null {
+  try {
+    const { host, pathname } = new URL(dsn);
+    const projectId = pathname.replace(/^\/+/, '');
+
+    if (!host || !projectId) {
+      return null;
+    }
+
+    return { host, projectId };
+  } catch {
+    return null;
+  }
+}

--- a/projects/client/src/lib/features/sentry/handle.spec.ts
+++ b/projects/client/src/lib/features/sentry/handle.spec.ts
@@ -1,0 +1,204 @@
+import { SENTRY_DSN } from '$lib/utils/constants.ts';
+import { server } from '$mocks/server.ts';
+import { mockRequestEvent } from '$test/request/mockRequestEvent.ts';
+import type { Handle } from '@sveltejs/kit';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+import { parseSentryDsn } from './_internal/parseSentryDsn.ts';
+import { handle } from './handle.ts';
+import { SentryEndpoint } from './SentryEndpoint.ts';
+
+const ingest = parseSentryDsn(SENTRY_DSN);
+
+const INGEST_URL = ingest
+  ? `https://${ingest.host}/api/${ingest.projectId}/envelope/`
+  : '';
+
+const TUNNEL_URL = `http://localhost${SentryEndpoint.Tunnel}`;
+
+const MAX_ENVELOPE_BYTES = 4 * 1024 * 1024;
+
+function toEnvelope(header: Record<string, unknown>): string {
+  return [
+    JSON.stringify(header),
+    JSON.stringify({ type: 'event' }),
+    JSON.stringify({ message: 'tunnel spec' }),
+  ].join('\n');
+}
+
+function toRequest(
+  { body, headers, method = 'POST' }: {
+    body?: BodyInit;
+    headers?: HeadersInit;
+    method?: string;
+  },
+): Request {
+  return new Request(TUNNEL_URL, { method, headers, body });
+}
+
+function callHandle(
+  request: Request,
+  url: string = TUNNEL_URL,
+): ReturnType<Handle> {
+  const resolve = vi.fn(() => new Response('page'));
+
+  return handle(
+    {
+      event: mockRequestEvent({ url, request }),
+      resolve,
+    } as unknown as Parameters<Handle>[0],
+  );
+}
+
+function serveIngest(
+  responder: Parameters<typeof http.post>[1],
+): { bodies: string[] } {
+  const bodies: string[] = [];
+
+  server.use(
+    http.post(INGEST_URL, async (context) => {
+      bodies.push(await context.request.text());
+      return responder(context);
+    }),
+  );
+
+  return { bodies };
+}
+
+describe('handle: sentry', () => {
+  it('should pass unrelated paths through to the next handler', async () => {
+    const resolve = vi.fn(() => new Response('page'));
+
+    const response = await handle(
+      {
+        event: mockRequestEvent({
+          url: 'http://localhost/movies/heretic-2024',
+          request: new Request('http://localhost/movies/heretic-2024'),
+        }),
+        resolve,
+      } as unknown as Parameters<Handle>[0],
+    );
+
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(await response.text()).toBe('page');
+  });
+
+  it('should reject a non-POST request with 405', async () => {
+    const response = await callHandle(toRequest({ method: 'GET' }));
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('POST');
+  });
+
+  it('should relay a known envelope and mirror the ingest status', async () => {
+    const { bodies } = serveIngest(() =>
+      HttpResponse.json({ id: 'abc' }, { status: 200 })
+    );
+    const envelope = toEnvelope({ dsn: SENTRY_DSN });
+
+    const response = await callHandle(toRequest({ body: envelope }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: 'abc' });
+    expect(bodies).toEqual([envelope]);
+  });
+
+  it('should forward the rate limit headers back to the client', async () => {
+    serveIngest(() =>
+      new HttpResponse(null, {
+        status: 429,
+        headers: {
+          'retry-after': '60',
+          'x-sentry-rate-limits': '60:error:organization',
+        },
+      })
+    );
+
+    const response = await callHandle(
+      toRequest({ body: toEnvelope({ dsn: SENTRY_DSN }) }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('retry-after')).toBe('60');
+    expect(response.headers.get('x-sentry-rate-limits')).toBe(
+      '60:error:organization',
+    );
+  });
+
+  it('should relay when the request carries no content length', async () => {
+    const request = toRequest({ body: toEnvelope({ dsn: SENTRY_DSN }) });
+
+    expect(request.headers.get('content-length')).toBeNull();
+
+    serveIngest(() => HttpResponse.json({ id: 'abc' }));
+
+    const response = await callHandle(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should reject an envelope addressed to another host', async () => {
+    const response = await callHandle(
+      toRequest({
+        body: toEnvelope({ dsn: 'https://key@evil.example.com/1' }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject an envelope addressed to another project', async () => {
+    const response = await callHandle(
+      toRequest({
+        body: toEnvelope({
+          dsn: `https://key@${ingest?.host ?? ''}/9999999`,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject an envelope without a dsn in its header', async () => {
+    const response = await callHandle(
+      toRequest({ body: toEnvelope({ event_id: 'abc' }) }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject an envelope whose header is not json', async () => {
+    const response = await callHandle(toRequest({ body: 'not-an-envelope' }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should reject a declared content length above the cap', async () => {
+    const response = await callHandle(
+      toRequest({
+        body: toEnvelope({ dsn: SENTRY_DSN }),
+        headers: { 'content-length': `${MAX_ENVELOPE_BYTES + 1}` },
+      }),
+    );
+
+    expect(response.status).toBe(413);
+  });
+
+  it('should reject a body above the cap when no content length is declared', async () => {
+    const response = await callHandle(
+      toRequest({ body: 'x'.repeat(MAX_ENVELOPE_BYTES + 1) }),
+    );
+
+    expect(response.status).toBe(413);
+  });
+
+  it('should return 502 when the ingest relay fails', async () => {
+    serveIngest(() => HttpResponse.error());
+
+    const response = await callHandle(
+      toRequest({ body: toEnvelope({ dsn: SENTRY_DSN }) }),
+    );
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/projects/client/src/lib/features/sentry/handle.ts
+++ b/projects/client/src/lib/features/sentry/handle.ts
@@ -1,0 +1,124 @@
+import { SentryEndpoint } from '$lib/features/sentry/SentryEndpoint.ts';
+import { SENTRY_DSN } from '$lib/utils/constants.ts';
+import { parseSentryDsn } from './_internal/parseSentryDsn.ts';
+import type { Handle } from '@sveltejs/kit';
+import { z } from 'zod';
+
+const ENVELOPE_CONTENT_TYPE = 'application/x-sentry-envelope';
+
+const LINE_FEED = 0x0a;
+
+const MAX_ENVELOPE_BYTES = 4 * 1024 * 1024;
+
+const FORWARDED_RESPONSE_HEADERS: ReadonlyArray<string> = [
+  'content-type',
+  'retry-after',
+  'x-sentry-rate-limits',
+];
+
+const EnvelopeHeaderSchema = z.object({
+  dsn: z.string(),
+});
+
+const INGEST = parseSentryDsn(SENTRY_DSN);
+
+function toEnvelopeDsn(payload: ArrayBuffer): string | null {
+  const bytes = new Uint8Array(payload);
+  const lineFeedIndex = bytes.indexOf(LINE_FEED);
+  const headerBytes = lineFeedIndex === -1
+    ? bytes
+    : bytes.subarray(0, lineFeedIndex);
+
+  try {
+    const header = EnvelopeHeaderSchema.safeParse(
+      JSON.parse(new TextDecoder().decode(headerBytes)),
+    );
+
+    return header.success ? header.data.dsn : null;
+  } catch {
+    return null;
+  }
+}
+
+function isKnownEnvelope(
+  payload: ArrayBuffer,
+  ingest: NonNullable<typeof INGEST>,
+): boolean {
+  const envelopeDsn = toEnvelopeDsn(payload);
+  const parsed = envelopeDsn ? parseSentryDsn(envelopeDsn) : null;
+
+  return parsed?.host === ingest.host &&
+    parsed?.projectId === ingest.projectId;
+}
+
+function isOversizedContentLength(contentLength: string | null): boolean {
+  if (contentLength === null) {
+    return false;
+  }
+
+  const size = Number(contentLength);
+
+  return Number.isFinite(size) && size > MAX_ENVELOPE_BYTES;
+}
+
+function toForwardedHeaders(headers: Headers): Headers {
+  return FORWARDED_RESPONSE_HEADERS.reduce((forwarded, name) => {
+    const value = headers.get(name);
+
+    if (value !== null) {
+      forwarded.set(name, value);
+    }
+
+    return forwarded;
+  }, new Headers());
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+  if (event.url.pathname !== SentryEndpoint.Tunnel) {
+    return resolve(event);
+  }
+
+  if (event.request.method !== 'POST') {
+    return new Response(null, { status: 405, headers: { allow: 'POST' } });
+  }
+
+  if (!INGEST) {
+    return new Response(null, { status: 500 });
+  }
+
+  if (isOversizedContentLength(event.request.headers.get('content-length'))) {
+    return new Response(null, { status: 413 });
+  }
+
+  const payload = await event.request.arrayBuffer().catch(() => null);
+
+  if (!payload) {
+    return new Response(null, { status: 400 });
+  }
+
+  if (payload.byteLength > MAX_ENVELOPE_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+
+  if (!isKnownEnvelope(payload, INGEST)) {
+    return new Response(null, { status: 400 });
+  }
+
+  const response = await fetch(
+    `https://${INGEST.host}/api/${INGEST.projectId}/envelope/`,
+    {
+      method: 'POST',
+      headers: { 'content-type': ENVELOPE_CONTENT_TYPE },
+      body: payload,
+    },
+  ).catch(() => null);
+
+  if (!response) {
+    return new Response(null, { status: 502 });
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: toForwardedHeaders(response.headers),
+  });
+};


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds Sentry tunneling, so ad-blockers stop dropping our error and trace traffic.
  - They filter on the `sentry.io` host and the `sentry_key` query param. Both disappear when tunneling.
  - Relative path also keeps the transport preflight-free.
- Client posts envelopes to `/api/client-report`, a `handle` hook relays them to ingest.
- Path is deliberately boring. Filter lists start matching on the path once the host stops being a signal, so please don't rename it to anything with `sentry` or `monitoring` in it. `/api/monitoring` in particular is the legacy Sentry Next.js default that maintainers already target.
- Envelope header DSN is checked against ours on host and project id, and the outbound URL is built from our own constant. Can't be pointed at another project.
  - The SDK only writes that header when `tunnel` is set, so the two options have to stay together.
- Size capped, cheaply via `content-length` when it's there, authoritatively on the decoded bytes.
  - A missing header must not reject. This is the only path errors take now, so failing closed there would drop every event with no signal.
- Outbound fetch is guarded. Left to throw, a Sentry outage during a client error storm would turn every failed relay into a fresh server error.
- `retry-after` and `x-sentry-rate-limits` are forwarded, so the client keeps honouring backoff now that it talks to us instead of Sentry.
- Handler sits after `initCloudflareSentryHandle` but before `sentryHandle()`, so the relay never reports itself as a server transaction.
- Smoke tested locally against a dev server 👌 envelopes reached Sentry and came back with event ids. Deleted the test entries afterwards.
- Checked the WAF, nothing rate limits `app.trakt.tv` and no custom rule matches the path.
  - Managed + OWASP rulesets still run on all requests, so will keep an eye on Security → Analytics after deploy.
- ⚠️ Still to verify on prod: a real error landing in Sentry with the tunnel returning 200, ideally with uBlock or Brave active.
