### PR TITLE
fix(smart-list): scopes smart list summary query to current user

### DIFF
--- a/projects/client/src/lib/requests/queries/smart-lists/smartListSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/smart-lists/smartListSummaryQuery.ts
@@ -13,9 +13,12 @@ const smartListSummaryRequest = (
   { fetch, listId }: SmartListSummaryParams,
 ) =>
   api({ fetch })
-    .smart_lists
+    .users
+    .smartLists
+    .smartList
     .summary({
       params: {
+        id: 'me',
         list_id: listId,
       },
     });

--- a/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
@@ -17,6 +17,8 @@
   const { list, isLoading } = $derived(
     useSmartListSummary({ listId: params.list }),
   );
+
+  // FIXME: split up (or add support) for public smart lists
 </script>
 
 {#snippet actions()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Issue: smart lists that were created a while back could no longer be viewed; user scope was missing.
  - Left a FIXME in there to handle public smart lists when adding more smart list features.
- Updates `smartListSummaryQuery` to correctly scope smart list data to the current user.
- Modifies the API endpoint to include `/users/me/` and explicitly passes `id: 'me'` in the query parameters.