### PR TITLE
fix(watched): uses watched state in track action label

### DIFF
--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
@@ -53,7 +53,7 @@
 <trakt-track-action class:is-watchable={isWatchable}>
   <ActionButton
     disabled={$isMarkingAsWatched || !isWatchable}
-    label={i18n.label({ title, isWatched: false, isRewatching: false })}
+    label={i18n.label({ title, isWatched: $isWatched, isRewatching: false })}
     onclick={handler}
     variant={$isWatched ? "primary" : "secondary"}
     color="purple"


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #3019
- Updates the TrackAction component to correctly reflect the media item's watched state in its action label.
