### PR TITLE
fix(summary): stops long overviews overflowing on mobile

### DIFF
--- a/projects/client/src/lib/components/text/ClampedText.svelte
+++ b/projects/client/src/lib/components/text/ClampedText.svelte
@@ -61,6 +61,10 @@
 
     @include for-tablet-sm-and-below {
       flex-direction: column;
+
+      .line-clamp-content {
+        width: 100%;
+      }
     }
   }
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #3171
- Ensures clamped text content, such as person overviews, properly utilizes available width on mobile and small tablet screens, preventing overflow.