### PR TITLE
fix(spoiler): reveals blurred content on click everywhere

### DIFF
--- a/projects/client/src/lib/features/spoilers/components/Spoiler.svelte
+++ b/projects/client/src/lib/features/spoilers/components/Spoiler.svelte
@@ -17,6 +17,7 @@
 <trakt-spoiler
   use:spoiler={isSpoilerHidden}
   use:spoilMeAnyway={variant !== "persistent"}
+  data-variant={variant}
 >
   {@render children()}
 </trakt-spoiler>
@@ -40,9 +41,17 @@
       :global(p:not(button p):not(a p)),
       :global(.trakt-comment p),
       :global(span:not(button span):not(a span)) {
-        pointer-events: none;
-
         @include spoiler-blur();
+      }
+
+      :global(p:not(button p):not(a p)),
+      :global(.trakt-comment p),
+      :global(span:not(button span):not(a span)) {
+        pointer-events: none;
+      }
+
+      &[data-variant="dismissible"] {
+        cursor: pointer;
       }
     }
   }

--- a/projects/client/src/lib/features/spoilers/components/spoilMeAnyway.spec.ts
+++ b/projects/client/src/lib/features/spoilers/components/spoilMeAnyway.spec.ts
@@ -30,6 +30,31 @@ describe('action: spoilMeAnyway', () => {
     component.destroy();
   });
 
+  it('should prevent the default action when revealing', async () => {
+    const commentNode = document.createElement('div');
+    commentNode.classList.add(SPOILER_CLASS_NAME);
+
+    const component = await renderStore(() => spoilMeAnyway(commentNode, true));
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    commentNode.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+
+    component.destroy();
+  });
+
+  it('should let the click through when nothing is hidden', async () => {
+    const commentNode = document.createElement('div');
+
+    const component = await renderStore(() => spoilMeAnyway(commentNode, true));
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    commentNode.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+
+    component.destroy();
+  });
+
   it('should keep spoilers when the variant is persistent', async () => {
     const commentNode = document.createElement('div');
     commentNode.classList.add(SPOILER_CLASS_NAME);

--- a/projects/client/src/lib/features/spoilers/components/spoilMeAnyway.ts
+++ b/projects/client/src/lib/features/spoilers/components/spoilMeAnyway.ts
@@ -8,8 +8,18 @@ export function spoilMeAnyway(node: HTMLElement, isDismissible = true) {
       return;
     }
 
+    const { target } = e;
+    const isHidden = node.classList.contains(SPOILER_CLASS_NAME) ||
+      target.classList.contains(SPOILER_CLASS_NAME);
+
+    if (!isHidden) {
+      return;
+    }
+
+    e.preventDefault();
+
     node.classList.remove(SPOILER_CLASS_NAME);
-    e.target.classList.remove(SPOILER_CLASS_NAME);
+    target.classList.remove(SPOILER_CLASS_NAME);
   }
 
   node.addEventListener('click', handleClick);

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
@@ -102,6 +102,11 @@
     :global(p.trakt-spoiler span) {
       pointer-events: none;
     }
+
+    &:global(.trakt-spoiler),
+    :global(p.trakt-spoiler) {
+      cursor: pointer;
+    }
   }
 
   .trakt-comment-preview {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #3165
- Improves the spoiler reveal interaction by ensuring that clicking anywhere within a blurred spoiler container, including its child elements, will correctly reveal the content.
