### PR TITLE
fix(list): navigate to the new slug after renaming a list

### DIFF
--- a/projects/client/src/lib/requests/queries/users/updateListRequest.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/updateListRequest.spec.ts
@@ -1,0 +1,45 @@
+import { server } from '$mocks/server.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { updateListRequest } from './updateListRequest.ts';
+
+const UPDATE_URL = 'http://localhost/users/me/lists/old-slug/';
+const RENAMED_LIST = {
+  name: 'New name',
+  ids: { trakt: 30998548, slug: 'new-name' },
+};
+
+function updateList() {
+  return updateListRequest({
+    userId: 'me',
+    listId: 'old-slug',
+    name: 'New name',
+    privacy: 'private',
+  });
+}
+
+describe('updateListRequest', () => {
+  it('should return the regenerated slug from an object response', async () => {
+    server.use(
+      http.put(UPDATE_URL, () => HttpResponse.json(RENAMED_LIST)),
+    );
+
+    expect(await updateList()).to.equal('new-name');
+  });
+
+  it('should return the regenerated slug from an array response', async () => {
+    server.use(
+      http.put(UPDATE_URL, () => HttpResponse.json([RENAMED_LIST])),
+    );
+
+    expect(await updateList()).to.equal('new-name');
+  });
+
+  it('should return undefined when the update fails', async () => {
+    server.use(
+      http.put(UPDATE_URL, () => new HttpResponse(null, { status: 409 })),
+    );
+
+    expect(await updateList()).to.equal(undefined);
+  });
+});

--- a/projects/client/src/lib/requests/queries/users/updateListRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/updateListRequest.ts
@@ -1,5 +1,13 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { z } from 'zod';
 import type { ListPrivacy } from '../../models/ListPrivacy.ts';
+
+const UpdatedListSchema = z.preprocess(
+  (body) => Array.isArray(body) ? body.at(0) : body,
+  z.object({
+    ids: z.object({ slug: z.string() }),
+  }),
+);
 
 type UpdateListRequest = {
   userId: string;
@@ -11,7 +19,7 @@ type UpdateListRequest = {
 
 export function updateListRequest(
   { userId, listId, name, fetch, description, privacy }: UpdateListRequest,
-): Promise<boolean> {
+): Promise<string | Nil> {
   return api({ fetch })
     .users
     .lists
@@ -27,5 +35,12 @@ export function updateListRequest(
         privacy,
       },
     })
-    .then(({ status }) => status === 200);
+    .then(({ status, body }) => {
+      if (status !== 200) {
+        return undefined;
+      }
+
+      const parsed = UpdatedListSchema.safeParse(body);
+      return parsed.success ? parsed.data.ids.slug : undefined;
+    });
 }

--- a/projects/client/src/lib/sections/lists/user/_internal/SaveListDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SaveListDrawer.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
+  import { page } from "$app/state";
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import Form from "$lib/components/form/Form.svelte";
   import FormInput from "$lib/components/form/FormInput.svelte";
@@ -8,6 +10,7 @@
   import type { ListPrivacy } from "$lib/requests/models/ListPrivacy";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import { iffy } from "$lib/utils/function/iffy";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   import { writable } from "$lib/utils/store/WritableSubject.ts";
   import { useSaveList } from "./useSaveList";
@@ -60,12 +63,33 @@
       : useSaveList({ type: "update", listId: props.list.slug }),
   );
 
+  const listOwner = $derived(
+    props.type === "update" ? props.list.user.slug : undefined,
+  );
+  const currentListPageOwner = $derived(
+    props.type === "update" && listOwner &&
+      UrlBuilder.users(listOwner).lists(props.list.slug) === page.url.pathname
+      ? listOwner
+      : undefined,
+  );
+
   async function handleSubmit() {
-    await saveList({
+    const owner = currentListPageOwner;
+
+    const slug = await saveList({
       name: $name,
       description: $description,
       privacy: $privacy,
     });
+
+    if (owner && slug) {
+      const target = UrlBuilder.users(owner).lists(slug);
+
+      if (target !== page.url.pathname) {
+        // eslint-disable-next-line svelte/no-navigation-without-resolve
+        await goto(`${target}${page.url.search}`, { replaceState: true });
+      }
+    }
 
     $isOpen && onClose();
   }

--- a/projects/client/src/lib/sections/lists/user/_internal/useSaveList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useSaveList.ts
@@ -24,7 +24,9 @@ type UpdateListProps = {
 
 export type UseSaveListProps = CreateListProps | UpdateListProps;
 
-function saveRequest(props: UseSaveListProps & SaveListProps) {
+async function saveRequest(
+  props: UseSaveListProps & SaveListProps,
+): Promise<string | Nil> {
   const { type } = props;
 
   const payload = {
@@ -36,7 +38,8 @@ function saveRequest(props: UseSaveListProps & SaveListProps) {
 
   switch (type) {
     case 'create':
-      return createListRequest(payload);
+      await createListRequest(payload);
+      return undefined;
     case 'update':
       return updateListRequest({
         ...payload,
@@ -68,7 +71,7 @@ export function useSaveList(props: UseSaveListProps) {
     isSaving.next(true);
     track();
 
-    await saveRequest({
+    const slug = await saveRequest({
       ...props,
       name: newName,
       description,
@@ -78,6 +81,8 @@ export function useSaveList(props: UseSaveListProps) {
     await invalidate(invalidateAction);
 
     isSaving.next(false);
+
+    return slug;
   };
 
   return {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2862
- The `updateListRequest` now returns the regenerated list slug or `undefined` instead of a boolean.
- After successfully renaming a list, the `SaveListDrawer` component now redirects the user to the list's new canonical URL if they were previously viewing that list.

## 👀 Example 👀
Before/after:

https://github.com/user-attachments/assets/68e4826c-45dd-40d9-90f4-30463ce78215


https://github.com/user-attachments/assets/9a55fa46-6553-456c-a976-8b9bc3a2fcc1

