### PR TITLE
fix(pwa): keep the dev service worker installable

### DIFF
--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -97,7 +97,8 @@ async function deleteCache(key: string) {
   }
 }
 
-const navigationCacheName = `${CacheKey.navigation}-${TRAKT_GIT_SHA}`;
+const buildSha = typeof TRAKT_GIT_SHA === 'string' ? TRAKT_GIT_SHA : 'dev';
+const navigationCacheName = `${CacheKey.navigation}-${buildSha}`;
 
 const CLEANUP_TIMEOUT_MS = time.seconds(3);
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Vite only inlines `define` values at build time, in dev they live on `globalThis` via `/@vite/client`, which the worker never loads. The bare `TRAKT_GIT_SHA` in the navigation cache name threw at module level, so the dev service worker never installed. Prod builds are unaffected.