### PR TITLE
fix(settings): surfaces plex server list failures

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4456,6 +4456,10 @@
       "default": "Language",
       "description": "Text for the section that allows users to change the language."
     },
+    "row_label_loading_title": {
+      "default": "Loading name",
+      "description": "Aria-label for the placeholder shown in a settings row while its title is still unknown, such as a Plex server whose name could not be loaded."
+    },
     "text_settings_cover_image": {
       "default": "Cover Image",
       "description": "Title of the settings row that lets users reset the custom cover image shown behind their profile."

--- a/projects/client/src/lib/requests/plex/plexServersQuery.spec.ts
+++ b/projects/client/src/lib/requests/plex/plexServersQuery.spec.ts
@@ -11,15 +11,27 @@ describe('plexServersQuery', () => {
     expect(result).to.deep.equal(PlexServersMappedMock);
   });
 
-  it('should return null when the request fails', async () => {
+  it('should throw when the request fails', async () => {
     server.use(
       http.get('http://localhost/users/settings/plex/servers', () => {
         return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
       }),
     );
 
-    const result = await plexServersQuery();
+    await expect(plexServersQuery()).rejects.toThrow(
+      'Failed to load Plex servers: 401',
+    );
+  });
 
-    expect(result).toBeNull();
+  it('should throw when the request times out at the edge', async () => {
+    server.use(
+      http.get('http://localhost/users/settings/plex/servers', () => {
+        return new HttpResponse('Gateway Timeout', { status: 504 });
+      }),
+    );
+
+    await expect(plexServersQuery()).rejects.toThrow(
+      'Failed to load Plex servers: 504',
+    );
   });
 });

--- a/projects/client/src/lib/requests/plex/plexServersQuery.ts
+++ b/projects/client/src/lib/requests/plex/plexServersQuery.ts
@@ -5,9 +5,12 @@ export type { PlexServer };
 
 export async function plexServersQuery(
   { fetch }: ApiParams = {},
-): Promise<PlexServer[] | null> {
+): Promise<PlexServer[]> {
   const response = await api({ fetch }).users.plex.servers();
 
-  if (response.status !== 200) return null;
+  if (response.status !== 200) {
+    throw new Error(`Failed to load Plex servers: ${response.status}`);
+  }
+
   return response.body.servers;
 }

--- a/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import Skeleton from "$lib/components/skeleton/Skeleton.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import type { Snippet } from "svelte";
 
   type CommonRowProps = {
-    title: string;
+    title: string | undefined;
     description?: string;
     icon: Snippet;
     tag?: Snippet;
@@ -40,7 +42,18 @@
 
   <div class="row-body">
     <div class="row-title-line">
-      <span class="row-title">{title}</span>
+      {#if title}
+        <span class="row-title">{title}</span>
+      {:else}
+        <span
+          class="row-title"
+          role="status"
+          aria-busy="true"
+          aria-label={m.row_label_loading_title()}
+        >
+          <Skeleton width="var(--ni-160)" height="var(--font-size-text)" />
+        </span>
+      {/if}
       {#if tag}
         {@render tag()}
       {/if}

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexServerDrawerHost.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexServerDrawerHost.svelte
@@ -25,7 +25,7 @@
     onRemoved,
   }: {
     serverId: string;
-    serverName: string;
+    serverName: string | undefined;
     onClose: () => void;
     onRemoved: () => void;
   } = $props();
@@ -45,6 +45,8 @@
   } = usePlexServer({ serverId: iffy(() => serverId) });
 
   const { confirm } = useConfirm();
+
+  const serverLabel = $derived(serverName ?? m.label_plex_server());
 
   const accountsErrorCopy = $derived(toPlexErrorCopy($accountsError?.code));
 
@@ -75,7 +77,7 @@
   const confirmRemove = $derived(
     confirm({
       type: ConfirmationType.RemovePlexServer,
-      server: serverName,
+      server: serverLabel,
       onConfirm: async () => {
         isRemoving = true;
 
@@ -128,7 +130,7 @@
     variant="secondary"
     style="ghost"
     color="red"
-    label={m.button_label_plex_remove_server({ server: serverName })}
+    label={m.button_label_plex_remove_server({ server: serverLabel })}
     disabled={isBusy}
     onclick={confirmRemove}
   >
@@ -136,7 +138,7 @@
   </ActionButton>
 {/snippet}
 
-<Drawer onClose={handleClose} title={serverName} size="auto" {badge}>
+<Drawer onClose={handleClose} title={serverLabel} size="auto" {badge}>
   <SettingsGroupCard variant="bare">
     {#if $isLoadingAccounts}
       <div class="loading-container">

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSync.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSync.svelte
@@ -19,11 +19,13 @@
   const {
     isConnected,
     servers,
+    serversState,
     authState,
     isSyncing,
     startAuth,
     disconnect,
     syncNow,
+    retryServers,
   } = iffy(() => usePlexSync());
 
   const hasSyncedServers = usePlexSelectedLibraries().pipe(
@@ -77,8 +79,10 @@
   {#if $isConnected}
     <PlexSyncedServers
       servers={$servers}
+      serversState={$serversState}
       isSyncing={$isSyncing}
       onSyncNow={syncNow}
+      onRetryServers={retryServers}
     />
 
     {#if $hasSyncedServers}

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServerRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServerRow.svelte
@@ -21,7 +21,7 @@
     initiallyManaging = false,
   }: {
     serverId: string;
-    serverName: string;
+    serverName: string | undefined;
     libraryUuids: string[];
     isSyncing: boolean;
     onSyncNow: (serverId: string) => void;

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.spec.ts
@@ -1,0 +1,72 @@
+import { PlexServersMappedMock } from '$mocks/data/plex/mapped/PlexServersMappedMock.ts';
+import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { setAuthorization } from '$test/beds/store/renderStore.ts';
+import { fireEvent, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PlexSyncedServers from './PlexSyncedServers.svelte';
+import type { PlexSyncedServersProps } from './PlexSyncedServersProps.ts';
+
+const SECTION_TITLE = 'Synced Servers';
+const EMPTY_STATE = 'No synced servers yet';
+const ERROR_MESSAGE = 'Plex is currently unavailable.';
+
+function renderServers(props: Partial<PlexSyncedServersProps> = {}) {
+  const onRetryServers = vi.fn();
+
+  renderComponent(PlexSyncedServers, {
+    props: {
+      servers: [],
+      serversState: 'loaded',
+      isSyncing: false,
+      onSyncNow: vi.fn(),
+      onRetryServers,
+      ...props,
+    },
+  });
+
+  return onRetryServers;
+}
+
+describe('PlexSyncedServers', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+  });
+
+  it('should render the error state when the server list fails to load', async () => {
+    renderServers({ serversState: 'error' });
+
+    expect(await screen.findByText(ERROR_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText(EMPTY_STATE)).not.toBeInTheDocument();
+  });
+
+  it('should retry the server list from the error state', async () => {
+    const onRetryServers = renderServers({ serversState: 'error' });
+
+    await fireEvent.click(
+      await screen.findByRole('button', { name: 'Retry' }),
+    );
+
+    expect(onRetryServers).toHaveBeenCalled();
+  });
+
+  it('should not render the empty state while the server list is loading', async () => {
+    renderServers({ serversState: 'loading' });
+
+    await screen.findByText(SECTION_TITLE);
+
+    expect(screen.queryByText(EMPTY_STATE)).not.toBeInTheDocument();
+    expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it('should render the empty state when the server list is loaded and empty', async () => {
+    renderServers();
+
+    expect(await screen.findByText(EMPTY_STATE)).toBeInTheDocument();
+  });
+
+  it('should render the empty state when a loaded server has not been added yet', async () => {
+    renderServers({ servers: PlexServersMappedMock });
+
+    expect(await screen.findByText(EMPTY_STATE)).toBeInTheDocument();
+  });
+});

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.spec.ts
@@ -1,19 +1,37 @@
 import { PlexServersMappedMock } from '$mocks/data/plex/mapped/PlexServersMappedMock.ts';
+import { PlexSettingsResponseMock } from '$mocks/data/plex/response/PlexSettingsResponseMock.ts';
+import { server } from '$mocks/server.ts';
 import { renderComponent } from '$test/beds/component/renderComponent.ts';
 import { setAuthorization } from '$test/beds/store/renderStore.ts';
 import { fireEvent, screen } from '@testing-library/svelte';
+import { http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PlexSyncedServers from './PlexSyncedServers.svelte';
 import type { PlexSyncedServersProps } from './PlexSyncedServersProps.ts';
 
-const SECTION_TITLE = 'Synced Servers';
+const SYNCED_SERVER_ID = PlexSettingsResponseMock.sync.selection.server_ids[0];
+const SYNCED_SERVER_NAME = PlexServersMappedMock[0].name;
 const EMPTY_STATE = 'No synced servers yet';
 const ERROR_MESSAGE = 'Plex is currently unavailable.';
+
+function serveEmptySelection() {
+  server.use(
+    http.get('http://localhost/users/settings/plex', () => {
+      return HttpResponse.json({
+        ...PlexSettingsResponseMock,
+        sync: {
+          ...PlexSettingsResponseMock.sync,
+          selection: { server_ids: [], library_ids: [], user_ids: [] },
+        },
+      });
+    }),
+  );
+}
 
 function renderServers(props: Partial<PlexSyncedServersProps> = {}) {
   const onRetryServers = vi.fn();
 
-  renderComponent(PlexSyncedServers, {
+  const { container } = renderComponent(PlexSyncedServers, {
     props: {
       servers: [],
       serversState: 'loaded',
@@ -24,7 +42,7 @@ function renderServers(props: Partial<PlexSyncedServersProps> = {}) {
     },
   });
 
-  return onRetryServers;
+  return { container, onRetryServers };
 }
 
 describe('PlexSyncedServers', () => {
@@ -36,11 +54,10 @@ describe('PlexSyncedServers', () => {
     renderServers({ serversState: 'error' });
 
     expect(await screen.findByText(ERROR_MESSAGE)).toBeInTheDocument();
-    expect(screen.queryByText(EMPTY_STATE)).not.toBeInTheDocument();
   });
 
   it('should retry the server list from the error state', async () => {
-    const onRetryServers = renderServers({ serversState: 'error' });
+    const { onRetryServers } = renderServers({ serversState: 'error' });
 
     await fireEvent.click(
       await screen.findByRole('button', { name: 'Retry' }),
@@ -50,23 +67,35 @@ describe('PlexSyncedServers', () => {
   });
 
   it('should not render the empty state while the server list is loading', async () => {
-    renderServers({ serversState: 'loading' });
+    serveEmptySelection();
+    const { container } = renderServers({ serversState: 'loading' });
 
-    await screen.findByText(SECTION_TITLE);
+    await screen.findByText('Synced Servers');
 
+    expect(container.querySelector('.trakt-skeleton')).toBeNull();
     expect(screen.queryByText(EMPTY_STATE)).not.toBeInTheDocument();
-    expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument();
   });
 
-  it('should render the empty state when the server list is loaded and empty', async () => {
+  it('should render the empty state once the server list is loaded and empty', async () => {
+    serveEmptySelection();
     renderServers();
 
     expect(await screen.findByText(EMPTY_STATE)).toBeInTheDocument();
   });
 
-  it('should render the empty state when a loaded server has not been added yet', async () => {
+  it('should name a synced server from the loaded server list', async () => {
     renderServers({ servers: PlexServersMappedMock });
 
-    expect(await screen.findByText(EMPTY_STATE)).toBeInTheDocument();
+    expect(await screen.findByText(SYNCED_SERVER_NAME)).toBeInTheDocument();
+  });
+
+  it('should skeleton a synced server name when the server list is unavailable', async () => {
+    const { container } = renderServers({ serversState: 'error' });
+
+    await screen.findByText(ERROR_MESSAGE);
+    await screen.findByRole('button', { name: 'Manage server libraries' });
+
+    expect(screen.queryByText(SYNCED_SERVER_ID)).not.toBeInTheDocument();
+    expect(container.querySelector('.trakt-skeleton')).not.toBeNull();
   });
 });

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte
@@ -2,18 +2,20 @@
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import PlexLogo from "$lib/components/icons/PlexLogo.svelte";
   import PlusIcon from "$lib/components/icons/PlusIcon.svelte";
   import ServerIcon from "$lib/components/icons/ServerIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser.ts";
   import * as m from "$lib/features/i18n/messages.ts";
-  import type { PlexServer } from "$lib/requests/plex/plexServersQuery.ts";
   import { slide } from "svelte/transition";
   import SettingsGroupCard from "../SettingsGroupCard.svelte";
   import SettingsHighlightCard from "../SettingsHighlightCard.svelte";
   import SettingsSection from "../SettingsSection.svelte";
   import SettingsVipUpsell from "../SettingsVipUpsell.svelte";
+  import SyncLoadError from "../SyncLoadError.svelte";
   import PlexSyncedServerRow from "./PlexSyncedServerRow.svelte";
+  import type { PlexSyncedServersProps } from "./PlexSyncedServersProps.ts";
   import { usePlexSelectedLibraries } from "./usePlexSelectedLibraries.ts";
 
   // FIXME: replace with sync.server_limit from plexSettingsQuery once
@@ -22,13 +24,11 @@
 
   const {
     servers,
+    serversState,
     isSyncing,
     onSyncNow,
-  }: {
-    servers: PlexServer[];
-    isSyncing: boolean;
-    onSyncNow: (serverId: string) => void;
-  } = $props();
+    onRetryServers,
+  }: PlexSyncedServersProps = $props();
 
   const { user } = useUser();
   const isVip = $derived($user?.isVip ?? false);
@@ -159,11 +159,24 @@
           onForget={forgetServer}
         />
       {:else}
-        <SettingsHighlightCard
-          icon={emptyIcon}
-          primary={emptyPrimary}
-          secondary={emptySecondary}
-        />
+        {#if serversState === "error"}
+          <SyncLoadError
+            variant="plain"
+            message={m.error_text_plex_unavailable()}
+            hint={m.error_text_plex_unavailable_hint()}
+            onRetry={onRetryServers}
+          />
+        {:else if serversState === "loading"}
+          <div class="loading-container">
+            <LoadingIndicator />
+          </div>
+        {:else}
+          <SettingsHighlightCard
+            icon={emptyIcon}
+            primary={emptyPrimary}
+            secondary={emptySecondary}
+          />
+        {/if}
       {/each}
     </SettingsGroupCard>
   </SettingsSection>
@@ -171,6 +184,13 @@
 
 <style lang="scss">
   .trakt-plex-synced-servers {
+    .loading-container {
+      display: flex;
+      justify-content: center;
+
+      padding: var(--gap-l);
+    }
+
     .empty-icon {
       display: flex;
       align-items: center;

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServers.svelte
@@ -59,8 +59,7 @@
 
     return [...persistedServers, ...pending].map((server) => ({
       ...server,
-      serverName: servers.find(({ id }) => id === server.serverId)?.name ??
-        server.serverId,
+      serverName: servers.find(({ id }) => id === server.serverId)?.name,
       isPending: !persistedIds.includes(server.serverId),
     }));
   });
@@ -148,6 +147,15 @@
     {/if}
 
     <SettingsGroupCard>
+      {#if serversState === "error"}
+        <SyncLoadError
+          variant="plain"
+          message={m.error_text_plex_unavailable()}
+          hint={m.error_text_plex_unavailable_hint()}
+          onRetry={onRetryServers}
+        />
+      {/if}
+
       {#each syncedServers as synced (synced.serverId)}
         <PlexSyncedServerRow
           serverId={synced.serverId}
@@ -159,18 +167,11 @@
           onForget={forgetServer}
         />
       {:else}
-        {#if serversState === "error"}
-          <SyncLoadError
-            variant="plain"
-            message={m.error_text_plex_unavailable()}
-            hint={m.error_text_plex_unavailable_hint()}
-            onRetry={onRetryServers}
-          />
-        {:else if serversState === "loading"}
+        {#if serversState === "loading"}
           <div class="loading-container">
             <LoadingIndicator />
           </div>
-        {:else}
+        {:else if serversState === "loaded"}
           <SettingsHighlightCard
             icon={emptyIcon}
             primary={emptyPrimary}

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServersProps.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncedServersProps.ts
@@ -1,0 +1,10 @@
+import type { PlexServer } from '$lib/requests/plex/plexServersQuery.ts';
+import type { PlexServersState } from './usePlexSync.ts';
+
+export type PlexSyncedServersProps = {
+  servers: ReadonlyArray<PlexServer>;
+  serversState: PlexServersState;
+  isSyncing: boolean;
+  onSyncNow: (serverId: string) => void;
+  onRetryServers: () => void;
+};

--- a/projects/client/src/lib/sections/settings/_internal/plex/usePlexSync.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/usePlexSync.ts
@@ -9,37 +9,52 @@ import { onDestroy } from 'svelte';
 import { BehaviorSubject } from 'rxjs';
 
 export type PlexAuthState = 'idle' | 'waiting' | 'connecting' | 'disconnecting';
+export type PlexServersState = 'loading' | 'loaded' | 'error';
 
 export function usePlexSync() {
   const isConnected = new BehaviorSubject<boolean | null>(null);
   const servers = new BehaviorSubject<PlexServer[]>([]);
+  const serversState = new BehaviorSubject<PlexServersState>('loading');
   const authState = new BehaviorSubject<PlexAuthState>('idle');
   const isSyncing = new BehaviorSubject(false);
 
   onDestroy(() => {
     isConnected.complete();
     servers.complete();
+    serversState.complete();
     authState.complete();
     isSyncing.complete();
   });
 
-  async function loadServers(): Promise<void> {
-    const [settingsResponse, result] = await Promise.all([
-      api().users.plex.settings(),
-      plexServersQuery(),
-    ]);
+  async function loadConnection(): Promise<boolean> {
+    const response = await api().users.plex.settings();
+    const connected = response.status === 200 &&
+      response.body.connection.connected;
 
-    if (
-      settingsResponse.status !== 200 ||
-      !settingsResponse.body.connection.connected
-    ) {
-      isConnected.next(false);
+    isConnected.next(connected);
+    return connected;
+  }
+
+  async function loadServers(): Promise<void> {
+    serversState.next('loading');
+
+    try {
+      servers.next(await plexServersQuery());
+      serversState.next('loaded');
+    } catch {
       servers.next([]);
+      serversState.next('error');
+    }
+  }
+
+  async function load(): Promise<void> {
+    if (!await loadConnection()) {
+      servers.next([]);
+      serversState.next('loaded');
       return;
     }
 
-    isConnected.next(true);
-    servers.next(result ?? []);
+    await loadServers();
   }
 
   function cleanPlexStatusParam() {
@@ -51,12 +66,13 @@ export function usePlexSync() {
 
   if (browser) {
     cleanPlexStatusParam();
-    loadServers();
+    load();
   }
 
   return {
     isConnected: isConnected.asObservable(),
     servers: servers.asObservable(),
+    serversState: serversState.asObservable(),
     authState: authState.asObservable(),
     isSyncing: isSyncing.asObservable(),
 
@@ -71,9 +87,11 @@ export function usePlexSync() {
 
     confirmAuth: async () => {
       authState.next('connecting');
-      await loadServers();
+      await load();
       authState.next('idle');
     },
+
+    retryServers: loadServers,
 
     cancelAuth: () => {
       authState.next('idle');
@@ -86,6 +104,7 @@ export function usePlexSync() {
 
       isConnected.next(false);
       servers.next([]);
+      serversState.next('loaded');
       authState.next('idle');
     },
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- `plexServersQuery` returned `null` on any non-200, and `usePlexSync` folded that into an empty array. A failed server list was indistinguishable from a user with no servers, so a 504 rendered the "no synced servers yet" empty state with the add button disabled and no way out.
- The query now throws, and the hook tracks the list state (`loading` / `loaded` / `error`) separately from the connection state.
- A failed list renders `SyncLoadError` with a retry, above the rows so it still shows for users who already have a server synced.
- Splits the connection lookup out of the `Promise.all`, so a slow `/servers` call no longer holds the connection row behind a spinner for the full edge timeout.
- A synced server row used to fall back to the raw server id when the list failed, rendering a hex blob where the name belongs. `SettingsGroupRow` now takes an optional title and renders the shared `Skeleton` in its place.
  - New `row_label_loading_title` aria-label so the row keeps an accessible name while the title is a placeholder.
  - `PlexServerDrawerHost` falls back to `label_plex_server` for the drawer title, the remove button and the confirmation copy.

## 👀 Examples 👀
<img width="675" height="405" alt="Screenshot 2026-09-03 at 13 49 07" src="https://github.com/user-attachments/assets/9f547438-26bc-4282-a760-c09097d9b280" />

<img width="675" height="338" alt="Screenshot 2026-09-03 at 13 55 02" src="https://github.com/user-attachments/assets/549370fe-bdb3-4927-bc46-a6af78797181" />
