### PR TITLE
feat: large screen cards in drilled down lists

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -10602,6 +10602,14 @@
       "default": "Pick your favorite genres from a visual grid instead of a list of tags.",
       "description": "Description for the Genre Picker preview feature."
     },
+    "preview_feature_title_large_screen_cards": {
+      "default": "Large Screen Cards",
+      "description": "Title for the Large Screen Cards preview feature."
+    },
+    "preview_feature_description_large_screen_cards": {
+      "default": "On bigger screens, view all lists use the same cards as the rest of the app. Selecting one opens a quick glance instead of leaving the list.",
+      "description": "Description for the Large Screen Cards preview feature."
+    },
     "preview_feature_title_list_counts": {
       "default": "List Counts",
       "description": "Title for the List Counts preview feature."

--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -13,7 +13,7 @@
     promotedItems?: T[];
     dimensionObserver?: (node: HTMLElement) => void;
     listActions?: Snippet;
-    sizing?: "default" | "auto";
+    sizing?: "default" | "auto" | "cover";
     groupBy?: (item: T) => string;
     groupHeader?: Snippet<[string]>;
   };
@@ -123,17 +123,22 @@
 
     gap: var(--list-header-gap);
 
-    &[data-sizing="auto"] {
+    &[data-sizing="auto"],
+    &[data-sizing="cover"] {
       .trakt-list-items {
         grid-template-columns: repeat(
           auto-fill,
           minmax(var(--width-item), 1fr)
         );
-
-        :global(.trakt-card) {
-          --width-override-card: 100%;
-        }
       }
+    }
+
+    &[data-sizing="auto"] .trakt-list-items :global(.trakt-card) {
+      --width-override-card: 100%;
+    }
+
+    &[data-sizing="cover"] .trakt-list-items {
+      justify-items: center;
     }
   }
 

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -10,4 +10,5 @@ export enum FeatureFlag {
   ReviewerStats = 'reviewer-stats',
   GenrePicker = 'genre-picker',
   ActionConfirmations = 'action-confirmations',
+  LargeScreenCards = 'large-screen-cards',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -1,4 +1,5 @@
 import CheckIcon from '$lib/components/icons/CheckIcon.svelte';
+import CoverImageIcon from '$lib/components/icons/CoverImageIcon.svelte';
 import EditModeIcon from '$lib/components/icons/EditModeIcon.svelte';
 import EyeIcon from '$lib/components/icons/EyeIcon.svelte';
 import FastRewindIcon from '$lib/components/icons/FastRewindIcon.svelte';
@@ -101,6 +102,17 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     title: () => m.preview_feature_title_genre_picker(),
     addedAt: new Date('2026-08-24'),
     description: () => m.preview_feature_description_genre_picker(),
+  },
+  [FeatureFlag.LargeScreenCards]: {
+    icon: CoverImageIcon,
+    title: () => m.preview_feature_title_large_screen_cards(),
+    addedAt: new Date('2026-09-03'),
+    description: () => m.preview_feature_description_large_screen_cards(),
+    featureLink: () =>
+      openFeatureLink(
+        UrlBuilder.trending(),
+        m.preview_feature_title_large_screen_cards(),
+      ),
   },
   [FeatureFlag.ParentalGuide]: {
     icon: NoSpoilerIcon,

--- a/projects/client/src/lib/features/large-screen-cards/useLargeScreenCards.ts
+++ b/projects/client/src/lib/features/large-screen-cards/useLargeScreenCards.ts
@@ -1,0 +1,24 @@
+import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
+import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
+import { useMedia, WellKnownMediaQuery } from '$lib/stores/css/useMedia.ts';
+import {
+  combineLatest,
+  distinctUntilChanged,
+  map,
+  type Observable,
+} from 'rxjs';
+
+export function useLargeScreenCards(): Observable<boolean> {
+  const { isEnabled } = useFeatureFlag();
+
+  return combineLatest([
+    isEnabled(FeatureFlag.LargeScreenCards),
+    useMedia(WellKnownMediaQuery.tabletLarge),
+    useMedia(WellKnownMediaQuery.desktop),
+  ]).pipe(
+    map(([isFlagEnabled, isTabletLarge, isDesktop]) =>
+      isFlagEnabled && (isTabletLarge || isDesktop)
+    ),
+    distinctUntilChanged(),
+  );
+}

--- a/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { page } from "$app/state";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import { drilldownGrid } from "$lib/sections/lists/utils/drilldownGrid.ts";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaType } from "$lib/requests/models/MediaType";
@@ -35,13 +37,16 @@
 
   const list = $derived($credits?.get(selectedPosition) ?? []);
   const hasMatchingType = $derived($mode === "media" || $mode === type);
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const grid = $derived(drilldownGrid($isLargeScreenCards));
 </script>
 
 <GridList
   id={`credits-list-${slug}-${type}-${selectedPosition}`}
   items={list}
-  sizing="auto"
-  --width-item="var(--width-summary-card)"
+  sizing={grid.sizing}
+  --width-item={grid.itemWidth}
 >
   {#snippet item(entry)}
     <CreditMediaItem

--- a/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import type { SocialActivity } from "$lib/requests/models/SocialActivity";
   import UserRating from "$lib/sections/components/UserRating.svelte";
   import ActivityItem from "../../components/ActivityItem.svelte";
+  import { resolveItemCardStyle } from "../../components/_internal/resolveItemCardStyle.ts";
   import ActivitySummaryCard from "../../components/ActivitySummaryCard.svelte";
   import UserAvatar from "../../components/UserAvatar.svelte";
   import UserProfileLink from "../../components/UserProfileLink.svelte";
@@ -15,6 +17,11 @@
   };
 
   const { activity, style = "cover" }: SocialActivityItemProps = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const resolvedStyle = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards),
+  );
 
   const hasMultipleUsers = $derived(activity.users.length > 1);
   const cappedUsers = $derived(activity.users.slice(0, maxUsers));
@@ -57,9 +64,10 @@
   </div>
 {/snippet}
 
-{#if style === "cover"}
+{#if resolvedStyle === "cover"}
   <ActivityItem
     {activity}
+    {style}
     activityAt={activity.activityAt}
     badge={profileBadges}
     source="social-activity"
@@ -68,7 +76,7 @@
   />
 {/if}
 
-{#if style === "summary"}
+{#if resolvedStyle === "summary"}
   <ActivitySummaryCard
     {activity}
     activityAt={activity.activityAt}

--- a/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
@@ -4,7 +4,7 @@
   import type { SocialActivity } from "$lib/requests/models/SocialActivity";
   import UserRating from "$lib/sections/components/UserRating.svelte";
   import ActivityItem from "../../components/ActivityItem.svelte";
-  import { resolveItemCardStyle } from "../../components/_internal/resolveItemCardStyle.ts";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import ActivitySummaryCard from "../../components/ActivitySummaryCard.svelte";
   import UserAvatar from "../../components/UserAvatar.svelte";
   import UserProfileLink from "../../components/UserProfileLink.svelte";

--- a/projects/client/src/lib/sections/lists/components/ActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivityItem.svelte
@@ -12,6 +12,7 @@
     source,
     action,
     activityType,
+    style,
   }: ActivityItemProps & {
     action?: Snippet;
   } = $props();
@@ -28,6 +29,7 @@
     {source}
     {action}
     {activityType}
+    {style}
   />
 {/if}
 
@@ -42,5 +44,6 @@
     {source}
     {action}
     {activityType}
+    {style}
   />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -18,7 +18,7 @@
   import type { Snippet } from "svelte";
   import type { MediaCardProps } from "../components/models/MediaCardProps";
   import DefaultMediaPopupActions from "./DefaultMediaPopupActions.svelte";
-  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import MediaItem from "./MediaItem.svelte";
   import MediaSwipe from "./MediaSwipe.svelte";
 
@@ -58,7 +58,7 @@
   {/if}
 {/snippet}
 
-{#snippet defaultTag()}
+{#snippet defaultTag(hasCertification: boolean)}
   {#if "episode" in media}
     <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} year={media.year} />
     <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
@@ -69,7 +69,7 @@
     {/if}
   {/if}
 
-  {#if isSummary && media.certification}
+  {#if hasCertification && media.certification}
     <CertificationTag certification={media.certification} />
   {/if}
 {/snippet}
@@ -97,12 +97,19 @@
         </RenderFor>
       {/if}
       {@render externalTag?.()}
-      {@render defaultTag()}
+      {@render defaultTag(true)}
     {:else if externalTag}
       {@render externalTag()}
     {:else}
-      {@render defaultTag()}
+      {@render defaultTag(false)}
     {/if}
+  </TagBar>
+{/snippet}
+
+{#snippet hoverTag()}
+  <TagBar>
+    {@render externalTag?.()}
+    {@render defaultTag(true)}
   </TagBar>
 {/snippet}
 
@@ -128,6 +135,7 @@
       {media}
       {style}
       tag={rest.variant !== "next" ? tag : undefined}
+      {hoverTag}
       coverTag={externalCoverTag}
       contextualTag={mode === "mixed" ? contextualTag : undefined}
       indicators={indicatorTags}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -8,6 +8,7 @@
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TagBar from "$lib/components/tags/TagBar.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import type { MediaInputDefault } from "$lib/models/MediaInput";
   import { manageListsDrawerStore } from "$lib/sections/components/lists-drawer/manageListsDrawerStore";
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
@@ -17,6 +18,7 @@
   import type { Snippet } from "svelte";
   import type { MediaCardProps } from "../components/models/MediaCardProps";
   import DefaultMediaPopupActions from "./DefaultMediaPopupActions.svelte";
+  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
   import MediaItem from "./MediaItem.svelte";
   import MediaSwipe from "./MediaSwipe.svelte";
 
@@ -43,7 +45,10 @@
 
   const isDeemphasized = $derived(canDeemphasize && $isWatched);
 
-  const isSummary = $derived(style === "summary");
+  const isLargeScreenCards = useLargeScreenCards();
+  const isSummary = $derived(
+    resolveItemCardStyle(style ?? "cover", $isLargeScreenCards) === "summary",
+  );
 
 </script>
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -13,13 +13,15 @@
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { mediaGlanceNavigation } from "$lib/sections/summary/components/glance/mediaGlanceNavigation.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import type { Snippet } from "svelte";
-  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
+  import MediaHoverCard from "./_internal/MediaHoverCard.svelte";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import SummaryCardRating from "./_internal/SummaryCardRating.svelte";
   import EpisodeCard from "./EpisodeCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
@@ -54,6 +56,22 @@
       })
       : props.urlOverride,
   );
+
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+  const hasHoverPanel = $derived(
+    resolvedStyle === "cover" && $isMouse && style === "summary" && isListItem,
+  );
+
+  const hoverSubtitle = $derived.by(() => {
+    const numberLabel = episodeNumberLabel({
+      seasonNumber: props.episode.season,
+      episodeNumber: props.episode.number,
+    });
+
+    return $spoilerFreeTitle
+      ? `${numberLabel} - ${$spoilerFreeTitle}`
+      : numberLabel;
+  });
 
   const runtime = $derived(
     isNaN(props.episode.runtime) ? props.media.runtime : props.episode.runtime,
@@ -249,7 +267,7 @@
     />
   {/if}
 
-  {#if resolvedStyle === "cover"}
+  {#snippet episodeCard()}
     <EpisodeCard
       {...props}
       {tag}
@@ -257,6 +275,19 @@
       {urlOverride}
       indicators={hasIndicators ? indicatorTags : undefined}
     />
+  {/snippet}
+
+  {#if resolvedStyle === "cover"}
+    {#if hasHoverPanel}
+      <MediaHoverCard
+        media={props.media}
+        subtitle={hoverSubtitle}
+        {tag}
+        children={episodeCard}
+      />
+    {:else}
+      {@render episodeCard()}
+    {/if}
   {/if}
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -13,6 +13,7 @@
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { mediaGlanceNavigation } from "$lib/sections/summary/components/glance/mediaGlanceNavigation.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
@@ -41,6 +42,17 @@
   );
   const summaryCardLayout = $derived(
     style === "compact" || style === "minimal" ? style : "default",
+  );
+
+  const { buildEpisodeGlanceLink } = mediaGlanceNavigation();
+  const urlOverride = $derived(
+    $isLargeScreenCards && style === "summary"
+      ? buildEpisodeGlanceLink({
+        slug: props.media.slug,
+        season: props.episode.season,
+        episode: props.episode.number,
+      })
+      : props.urlOverride,
   );
 
   const runtime = $derived(
@@ -228,7 +240,7 @@
         },
       }}
       popupActions={props.popupActions}
-      urlOverride={props.urlOverride}
+      {urlOverride}
       layout={summaryCardLayout}
       badge={action}
       {sortTag}
@@ -237,11 +249,12 @@
     />
   {/if}
 
-  {#if style === "cover"}
+  {#if resolvedStyle === "cover"}
     <EpisodeCard
       {...props}
       {tag}
       {action}
+      {urlOverride}
       indicators={hasIndicators ? indicatorTags : undefined}
     />
   {/if}

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -12,11 +12,13 @@
   import TagBar from "$lib/components/tags/TagBar.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import type { Snippet } from "svelte";
+  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
   import SummaryCardRating from "./_internal/SummaryCardRating.svelte";
   import EpisodeCard from "./EpisodeCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
@@ -31,9 +33,11 @@
   const isHidden = $derived(props.status === "hidden");
   const isListItem = $derived(props.variant === "list-item");
 
+  const isLargeScreenCards = useLargeScreenCards();
+
   const style = $derived(props.style ?? "cover");
-  const resolvedStyle: "cover" | "summary" = $derived(
-    style === "compact" || style === "minimal" ? "summary" : style,
+  const resolvedStyle = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards),
   );
   const summaryCardLayout = $derived(
     style === "compact" || style === "minimal" ? style : "default",

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -40,6 +40,13 @@
   const activitySubtitle = $derived(
     "subtitle" in rest ? rest.subtitle : undefined,
   );
+
+  const urlOverride = $derived(rest.urlOverride);
+  const linkProps = $derived({
+    href: urlOverride?.href ?? UrlBuilder.media(type, media.slug),
+    noscroll: urlOverride?.noscroll,
+    replacestate: urlOverride?.replacestate,
+  });
 </script>
 
 {#snippet content(mediaCoverImageUrl: string, mediaCoverOverlay?: string)}
@@ -60,7 +67,7 @@
 
   <Link
     focusable={false}
-    href={UrlBuilder.media(type, media.slug)}
+    {...linkProps}
     onclick={() => {
       rest.onclick?.(media);
       source && track({ source, type: media.type });
@@ -102,7 +109,7 @@
   <PortraitCard>
     {@render content(media.poster.url.thumb)}
     <CardFooter {action} {tag}>
-      <Link href={UrlBuilder.media(type, media.slug)}>
+      <Link {...linkProps}>
         <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
@@ -115,7 +122,7 @@
   <LandscapeCard>
     {@render content(media.thumb.url)}
     <CardFooter {action} {tag}>
-      <Link href={UrlBuilder.media(type, media.slug)}>
+      <Link {...linkProps}>
         <p
           class="trakt-card-title ellipsis"
           class:small={variant !== "activity"}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -4,9 +4,11 @@
   import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { mediaGlanceNavigation } from "$lib/sections/summary/components/glance/mediaGlanceNavigation.ts";
   import type { Snippet } from "svelte";
-  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
+  import MediaHoverCard from "./_internal/MediaHoverCard.svelte";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import MediaCard from "./MediaCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { MediaCardProps } from "./models/MediaCardProps";
@@ -14,8 +16,15 @@
   const {
     contextualTag,
     sortTag,
+    hoverTag,
+    hoverSubtitle,
     ...props
-  }: MediaCardProps & { contextualTag?: Snippet; sortTag?: Snippet } = $props();
+  }: MediaCardProps & {
+    contextualTag?: Snippet;
+    sortTag?: Snippet;
+    hoverTag?: Snippet;
+    hoverSubtitle?: string;
+  } = $props();
 
   const isLargeScreenCards = useLargeScreenCards();
 
@@ -30,7 +39,7 @@
         type: props.media.type,
         slug: props.media.slug,
       })
-      : undefined,
+      : props.urlOverride,
   );
 
   const summaryCardLayout = $derived(
@@ -38,6 +47,12 @@
   );
 
   const isCover = $derived(resolvedStyle === "cover");
+
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+  const hasHoverPanel = $derived(
+    isCover && $isMouse && style === "summary" &&
+      (props.variant == null || props.variant === "start"),
+  );
 </script>
 
 {#snippet coverTag()}
@@ -68,7 +83,7 @@
   </div>
 {/snippet}
 
-{#if resolvedStyle === "cover"}
+{#snippet mediaCard()}
   <MediaCard
     {...props}
     {coverTag}
@@ -77,6 +92,20 @@
     action={props.action}
     popupActions={props.badge ? undefined : props.popupActions}
   />
+{/snippet}
+
+{#if resolvedStyle === "cover"}
+  {#if hasHoverPanel}
+    <MediaHoverCard
+      media={props.media}
+      tag={hoverTag}
+      subtitle={hoverSubtitle}
+      {contextualTag}
+      children={mediaCard}
+    />
+  {:else}
+    {@render mediaCard()}
+  {/if}
 {/if}
 
 {#if resolvedStyle === "summary"}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -3,7 +3,9 @@
   import MediaStatusTag from "$lib/components/media/tags/MediaStatusTag.svelte";
   import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import type { Snippet } from "svelte";
+  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
   import MediaCard from "./MediaCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { MediaCardProps } from "./models/MediaCardProps";
@@ -14,9 +16,11 @@
     ...props
   }: MediaCardProps & { contextualTag?: Snippet; sortTag?: Snippet } = $props();
 
+  const isLargeScreenCards = useLargeScreenCards();
+
   const style = $derived(props.style ?? "cover");
-  const resolvedStyle = $derived<"cover" | "summary">(
-    style === "compact" || style === "minimal" ? "summary" : style,
+  const resolvedStyle = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards),
   );
   const summaryCardLayout = $derived(
     style === "compact" || style === "minimal" ? style : "default",

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -4,6 +4,7 @@
   import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { mediaGlanceNavigation } from "$lib/sections/summary/components/glance/mediaGlanceNavigation.ts";
   import type { Snippet } from "svelte";
   import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
   import MediaCard from "./MediaCard.svelte";
@@ -22,6 +23,16 @@
   const resolvedStyle = $derived(
     resolveItemCardStyle(style, $isLargeScreenCards),
   );
+  const { buildMediaGlanceLink } = mediaGlanceNavigation();
+  const urlOverride = $derived(
+    $isLargeScreenCards && style === "summary"
+      ? buildMediaGlanceLink({
+        type: props.media.type,
+        slug: props.media.slug,
+      })
+      : undefined,
+  );
+
   const summaryCardLayout = $derived(
     style === "compact" || style === "minimal" ? style : "default",
   );
@@ -61,6 +72,7 @@
   <MediaCard
     {...props}
     {coverTag}
+    {urlOverride}
     style={resolvedStyle}
     action={props.action}
     popupActions={props.badge ? undefined : props.popupActions}

--- a/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { swipeIndicatorHeight } from "./_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { BaseMediaInput } from "$lib/models/MediaInput";
@@ -14,6 +16,8 @@
     };
 
   const { type, media, style, children }: MediaSwipeProps = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
 
   const target = $derived({ type, media });
 
@@ -51,7 +55,7 @@
         addToWatchlist();
       }
     }}
-    --indicator-height="var(--height-summary-card-cover)"
+    --indicator-height={swipeIndicatorHeight($isLargeScreenCards)}
   >
     {#snippet indicator({ isActive, direction })}
       {#if direction === "left"}

--- a/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { hasSwipeGesture } from "./_internal/hasSwipeGesture.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { swipeIndicatorHeight } from "./_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -18,6 +20,15 @@
   const { type, media, style, children }: MediaSwipeProps = $props();
 
   const isLargeScreenCards = useLargeScreenCards();
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+
+  const hasSwipe = $derived(
+    hasSwipeGesture({
+      style,
+      isLargeScreenCards: $isLargeScreenCards,
+      isMouse: $isMouse,
+    }),
+  );
 
   const target = $derived({ type, media });
 
@@ -41,7 +52,7 @@
   );
 </script>
 
-{#if style === "summary"}
+{#if hasSwipe}
   <SwipeX
     {children}
     directions={["left", "right"]}

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -13,10 +13,12 @@
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { scrollActiveItemIntoView } from "$lib/utils/actions/scrollActiveItemIntoView";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
   import type { Snippet } from "svelte";
+  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { SeasonCardProps } from "./models/SeasonCardProps";
 
@@ -44,6 +46,11 @@
 
   const isEmphasized = $derived(isCurrentSeason && !season.title);
 
+  const isLargeScreenCards = useLargeScreenCards();
+  const resolvedStyle = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards),
+  );
+
   const scrollToItem = (element: HTMLElement, active: boolean) => {
     if (variant === "list-item") return;
     return scrollActiveItemIntoView(element, active);
@@ -64,7 +71,7 @@
   data-variant={variant}
   use:scrollToItem={isCurrentSeason}
 >
-  {#if style === "cover"}
+  {#if resolvedStyle === "cover"}
     {#snippet tag()}
       <TagBar>
         <SeasonLabelTag seasonNumber={season.number} />
@@ -125,7 +132,7 @@
     </PortraitCard>
   {/if}
 
-  {#if style === "summary"}
+  {#if resolvedStyle === "summary"}
     <MediaSummaryCard
       type="season"
       {season}

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -14,12 +14,14 @@
   import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { mediaGlanceNavigation } from "$lib/sections/summary/components/glance/mediaGlanceNavigation.ts";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { scrollActiveItemIntoView } from "$lib/utils/actions/scrollActiveItemIntoView";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
   import type { Snippet } from "svelte";
-  import { resolveItemCardStyle } from "./_internal/resolveItemCardStyle.ts";
+  import MediaHoverCard from "./_internal/MediaHoverCard.svelte";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { SeasonCardProps } from "./models/SeasonCardProps";
 
@@ -50,6 +52,11 @@
   const isLargeScreenCards = useLargeScreenCards();
   const resolvedStyle = $derived(
     resolveItemCardStyle(style, $isLargeScreenCards),
+  );
+
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+  const hasHoverPanel = $derived(
+    resolvedStyle === "cover" && $isMouse && style === "summary",
   );
 
   const { buildSeasonGlanceLink } = mediaGlanceNavigation();
@@ -86,58 +93,70 @@
       </TagBar>
     {/snippet}
 
-    <PortraitCard>
-      {#if popupActions}
-        <CardActionBar>
-          {#snippet actions()}
-            <PopupMenu
-              label={m.button_label_popup_menu({
-                title: seasonLabel(season.number),
-              })}
-              title={seasonLabel(season.number)}
-            >
-              {#snippet items()}
-                {@render popupActions()}
-              {/snippet}
-            </PopupMenu>
-          {/snippet}
-        </CardActionBar>
-      {/if}
-
-      <Link
-        focusable={false}
-        {href}
-        onclick={() => source && track({ source, type: "season" })}
-        noscroll
-      >
-        <CardCover
-          title={seasonLabel(season.number)}
-          src={season.poster?.url.medium ?? media.poster.url.medium}
-          alt={seasonLabel(season.number)}
-        />
-
-        <IndicatorTags>
-          {@render indicatorTags()}
-        </IndicatorTags>
-      </Link>
-      <CardFooter tag={variant === "list-item" ? tag : undefined}>
-        {#if variant === "default"}
-          <p
-            use:lineClamp={{ lines: 2 }}
-            class="trakt-season-title"
-            class:trakt-card-title={isEmphasized}
-            class:trakt-card-subtitle={!isEmphasized}
-          >
-            {seasonLabel(season.number)}
-          </p>
-          {#if season.title}
-            <p class="trakt-season-subtitle trakt-card-subtitle ellipsis">
-              {season.title}
-            </p>
-          {/if}
+    {#snippet seasonCard()}
+      <PortraitCard>
+        {#if popupActions}
+          <CardActionBar>
+            {#snippet actions()}
+              <PopupMenu
+                label={m.button_label_popup_menu({
+                  title: seasonLabel(season.number),
+                })}
+                title={seasonLabel(season.number)}
+              >
+                {#snippet items()}
+                  {@render popupActions()}
+                {/snippet}
+              </PopupMenu>
+            {/snippet}
+          </CardActionBar>
         {/if}
-      </CardFooter>
-    </PortraitCard>
+
+        <Link
+          focusable={false}
+          {href}
+          onclick={() => source && track({ source, type: "season" })}
+          noscroll
+        >
+          <CardCover
+            title={seasonLabel(season.number)}
+            src={season.poster?.url.medium ?? media.poster.url.medium}
+            alt={seasonLabel(season.number)}
+          />
+
+          <IndicatorTags>
+            {@render indicatorTags()}
+          </IndicatorTags>
+        </Link>
+        <CardFooter tag={variant === "list-item" ? tag : undefined}>
+          {#if variant === "default"}
+            <p
+              use:lineClamp={{ lines: 2 }}
+              class="trakt-season-title"
+              class:trakt-card-title={isEmphasized}
+              class:trakt-card-subtitle={!isEmphasized}
+            >
+              {seasonLabel(season.number)}
+            </p>
+            {#if season.title}
+              <p class="trakt-season-subtitle trakt-card-subtitle ellipsis">
+                {season.title}
+              </p>
+            {/if}
+          {/if}
+        </CardFooter>
+      </PortraitCard>
+    {/snippet}
+
+    {#if hasHoverPanel}
+      <MediaHoverCard
+        {media}
+        subtitle={seasonLabel(season.number)}
+        children={seasonCard}
+      />
+    {:else}
+      {@render seasonCard()}
+    {/if}
   {/if}
 
   {#if resolvedStyle === "summary"}

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -14,6 +14,7 @@
   import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { mediaGlanceNavigation } from "$lib/sections/summary/components/glance/mediaGlanceNavigation.ts";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { scrollActiveItemIntoView } from "$lib/utils/actions/scrollActiveItemIntoView";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
@@ -49,6 +50,13 @@
   const isLargeScreenCards = useLargeScreenCards();
   const resolvedStyle = $derived(
     resolveItemCardStyle(style, $isLargeScreenCards),
+  );
+
+  const { buildSeasonGlanceLink } = mediaGlanceNavigation();
+  const href = $derived(
+    $isLargeScreenCards && style === "summary"
+      ? buildSeasonGlanceLink({ slug: media.slug, season: season.number }).href
+      : urlBuilder(),
   );
 
   const scrollToItem = (element: HTMLElement, active: boolean) => {
@@ -98,7 +106,7 @@
 
       <Link
         focusable={false}
-        href={urlBuilder()}
+        {href}
         onclick={() => source && track({ source, type: "season" })}
         noscroll
       >

--- a/projects/client/src/lib/sections/lists/components/_internal/ActivityItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/_internal/ActivityItemProps.ts
@@ -2,6 +2,7 @@ import type { ActivityType } from '$lib/models/ActivityType.ts';
 import type { SocialActivity } from '$lib/requests/models/SocialActivity.ts';
 import type { Snippet } from 'svelte';
 import type { HistoryEntry } from '../../stores/models/HistoryEntry.ts';
+import type { BaseItemProps } from '../models/BaseItemProps.ts';
 
 export type ActivityItemProps = {
   activity: SocialActivity | HistoryEntry;
@@ -10,4 +11,5 @@ export type ActivityItemProps = {
   popupActions?: Snippet;
   source?: string;
   activityType: ActivityType;
+  style?: BaseItemProps['style'];
 };

--- a/projects/client/src/lib/sections/lists/components/_internal/MediaHoverCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/MediaHoverCard.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+  import GenreList from "$lib/components/summary/GenreList.svelte";
+  import type { MediaInputDefault } from "$lib/models/MediaInput";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import type { Snippet } from "svelte";
+  import { cubicOut } from "svelte/easing";
+  import SummaryCardBackgroundImage from "./SummaryCardBackgroundImage.svelte";
+  import SummaryCardRating from "./SummaryCardRating.svelte";
+
+  const {
+    children,
+    media,
+    tag,
+    contextualTag,
+    subtitle,
+  }: {
+    children: Snippet;
+    media: MediaInputDefault;
+    tag?: Snippet;
+    contextualTag?: Snippet;
+    subtitle?: string;
+  } = $props();
+
+  let isExpanded = $state(false);
+  let isFlipped = $state(false);
+
+  const prefersReducedMotion = useMedia(WellKnownMediaQuery.reducedMotion);
+
+  function reveal(_node: HTMLElement) {
+    if ($prefersReducedMotion) {
+      return { duration: 90, css: (t: number) => `opacity: ${t}` };
+    }
+
+    return {
+      duration: 150,
+      easing: cubicOut,
+      css: (t: number) => `
+        width: calc(
+          var(--panel-collapsed-width) +
+            (var(--panel-width) - var(--panel-collapsed-width)) * ${t}
+        );
+        opacity: ${Math.min(1, t * 2.5)};
+      `,
+    };
+  }
+
+  const hasDistinctOriginalTitle = $derived(
+    media.originalTitle
+      ? media.title.toLowerCase() !== media.originalTitle.toLowerCase()
+      : false,
+  );
+
+  function hoverReveal(node: HTMLElement) {
+    const isPopupOpen = () =>
+      node.querySelector('[data-popup-state="opened"]') != null;
+
+    const onEnter = () => {
+      const { right, width } = node.getBoundingClientRect();
+      isFlipped = right + width > globalThis.window.innerWidth;
+      isExpanded = true;
+    };
+
+    const onLeave = () => {
+      if (isPopupOpen()) {
+        return;
+      }
+
+      isExpanded = false;
+    };
+
+    node.addEventListener("mouseenter", onEnter);
+    node.addEventListener("mouseleave", onLeave);
+
+    return {
+      destroy() {
+        node.removeEventListener("mouseenter", onEnter);
+        node.removeEventListener("mouseleave", onLeave);
+      },
+    };
+  }
+</script>
+
+<div
+  class="trakt-media-hover-card"
+  class:is-expanded={isExpanded}
+  class:is-flipped={isFlipped}
+  use:hoverReveal
+>
+  {#if isExpanded}
+    <div class="hover-panel" transition:reveal>
+      <SummaryCardBackgroundImage
+        src={media.cover.url.thumb}
+        alt={media.title}
+        align={isFlipped ? "start" : "end"}
+      />
+
+      <div class="hover-panel-details">
+        <div class="hover-panel-titles">
+          <p class="trakt-card-title">{media.title}</p>
+
+          {#if subtitle}
+            <p class="trakt-card-subtitle small secondary">
+              <bdi dir="ltr">{subtitle}</bdi>
+            </p>
+          {:else}
+            {#if hasDistinctOriginalTitle}
+              <p class="trakt-card-subtitle secondary">
+                ({media.originalTitle})
+              </p>
+            {/if}
+
+            <GenreList
+              classList="trakt-card-subtitle small secondary"
+              separator=", "
+              genres={media.genres}
+            />
+          {/if}
+        </div>
+
+        {#if tag}
+          <div class="hover-panel-tags">
+            {@render tag()}
+          </div>
+        {/if}
+      </div>
+
+      <div class="hover-panel-bottom">
+        {@render contextualTag?.()}
+        <SummaryCardRating item={media} />
+      </div>
+    </div>
+  {/if}
+
+  <div class="hover-card-base">
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .trakt-media-hover-card {
+    --panel-inset: calc(0.5 * var(--list-gap));
+
+    position: relative;
+
+    &.is-expanded {
+      z-index: var(--layer-top);
+
+      .hover-card-base :global(.trakt-card-footer) {
+        visibility: hidden;
+      }
+
+      .hover-card-base :global(.trakt-card-cover) {
+        outline-color: transparent;
+      }
+    }
+  }
+
+  .hover-panel {
+    --drift-sign: -1;
+    --panel-width: calc(
+      2 * var(--width-portrait-card) + var(--list-gap) + 2 * var(--panel-inset)
+    );
+    --panel-collapsed-width: calc(
+      var(--width-portrait-card) + 2 * var(--panel-inset)
+    );
+    --panel-content-width: calc(
+      var(--width-portrait-card) + var(--list-gap)
+    );
+
+    position: absolute;
+    inset-block-start: calc(-1 * var(--panel-inset));
+    inset-inline-start: calc(-1 * var(--panel-inset));
+
+    width: var(--panel-width);
+    height: calc(100% + 2 * var(--panel-inset));
+
+    box-sizing: border-box;
+    padding: var(--panel-inset);
+    padding-inline-start: calc(var(--width-portrait-card) + var(--panel-inset));
+
+    display: flex;
+    flex-direction: column;
+
+    background: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+    box-shadow: var(--shadow-menu);
+    outline: var(--border-thickness-xs) solid var(--color-card-border-hover);
+
+    overflow: hidden;
+
+    .is-flipped & {
+      --drift-sign: 1;
+
+      align-items: flex-end;
+
+      inset-inline-start: auto;
+      inset-inline-end: calc(-1 * var(--panel-inset));
+
+      padding-inline-start: var(--panel-inset);
+      padding-inline-end: calc(var(--width-portrait-card) + var(--panel-inset));
+    }
+  }
+
+  .hover-panel-details,
+  .hover-panel-bottom {
+    width: var(--panel-content-width);
+    box-sizing: border-box;
+
+    animation: hover-panel-drift var(--transition-increment)
+      cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  @keyframes hover-panel-drift {
+    from {
+      opacity: 0;
+      transform: translateX(
+        calc(var(--rtl-sign) * var(--drift-sign) * var(--ni-12))
+      );
+    }
+
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .hover-panel-details {
+    position: relative;
+    z-index: var(--layer-raised);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+
+    flex-grow: 1;
+    overflow: hidden;
+
+    padding: var(--ni-12);
+    padding-top: var(--ni-10);
+  }
+
+  .hover-panel-titles {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-micro);
+
+    min-height: var(--ni-66);
+
+    .trakt-card-title,
+    .trakt-card-subtitle,
+    :global(.trakt-card-subtitle) {
+      display: -webkit-box;
+
+      line-clamp: 2;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+
+      white-space: initial;
+      overflow: hidden;
+    }
+
+    .trakt-card-title {
+      min-width: 0;
+      font-size: var(--font-size-text);
+    }
+  }
+
+  .hover-panel-tags {
+    :global(.trakt-tag-bar) {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+
+      :global(:not(:last-child))::after {
+        display: none;
+      }
+    }
+  }
+
+  .hover-panel-bottom {
+    position: relative;
+    z-index: var(--layer-raised);
+
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    padding: var(--ni-12);
+    padding-top: 0;
+
+    :global(.trakt-summary-card-rating) {
+      margin-inline-start: auto;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBackgroundImage.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBackgroundImage.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
 
-  const { src, alt }: { src: string; alt: string } = $props();
+  const { src, alt, align = "end" }: {
+    src: string;
+    alt: string;
+    align?: "start" | "end";
+  } = $props();
 </script>
 
-<div class="trakt-summary-card-background">
+<div class="trakt-summary-card-background" data-align={align}>
   <CrossOriginImage loading="eager" {src} {alt} />
 </div>
 
@@ -38,6 +42,19 @@
       width: 75%;
 
       object-fit: cover;
+    }
+
+    &[data-align="start"] {
+      --mask-angle: 120deg;
+
+      &:dir(rtl) {
+        --mask-angle: 240deg;
+      }
+
+      :global(img) {
+        inset-inline-end: auto;
+        inset-inline-start: 0;
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/_internal/hasSwipeGesture.ts
+++ b/projects/client/src/lib/sections/lists/components/_internal/hasSwipeGesture.ts
@@ -1,0 +1,13 @@
+import type { BaseItemProps } from '../models/BaseItemProps.ts';
+
+type HasSwipeGestureProps = {
+  style: BaseItemProps['style'];
+  isLargeScreenCards: boolean;
+  isMouse: boolean;
+};
+
+export function hasSwipeGesture(
+  { style, isLargeScreenCards, isMouse }: HasSwipeGestureProps,
+) {
+  return style === 'summary' && !(isLargeScreenCards && isMouse);
+}

--- a/projects/client/src/lib/sections/lists/components/_internal/resolveItemCardStyle.ts
+++ b/projects/client/src/lib/sections/lists/components/_internal/resolveItemCardStyle.ts
@@ -1,0 +1,16 @@
+import type { BaseItemProps } from '../models/BaseItemProps.ts';
+
+export function resolveItemCardStyle(
+  style: NonNullable<BaseItemProps['style']>,
+  isLargeScreenCards: boolean,
+): 'cover' | 'summary' {
+  if (style === 'compact' || style === 'minimal') {
+    return 'summary';
+  }
+
+  if (style === 'summary' && isLargeScreenCards) {
+    return 'cover';
+  }
+
+  return style;
+}

--- a/projects/client/src/lib/sections/lists/components/_internal/swipeIndicatorHeight.ts
+++ b/projects/client/src/lib/sections/lists/components/_internal/swipeIndicatorHeight.ts
@@ -1,0 +1,3 @@
+export function swipeIndicatorHeight(isLargeScreenCards: boolean) {
+  return isLargeScreenCards ? '100%' : 'var(--height-summary-card-cover)';
+}

--- a/projects/client/src/lib/sections/lists/components/models/CardUrlOverride.ts
+++ b/projects/client/src/lib/sections/lists/components/models/CardUrlOverride.ts
@@ -1,4 +1,4 @@
-export type EpisodeUrlOverride = {
+export type CardUrlOverride = {
   href: string;
   noscroll?: boolean;
   replacestate?: boolean;

--- a/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
@@ -3,7 +3,7 @@ import type { ShowInput } from '$lib/models/MediaInput.ts';
 import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { EpisodeProgressEntry } from '$lib/requests/models/EpisodeProgressEntry.ts';
 import type { BaseItemProps } from './BaseItemProps.ts';
-import type { EpisodeUrlOverride } from './EpisodeUrlOverride.ts';
+import type { CardUrlOverride } from './CardUrlOverride.ts';
 
 type EpisodeContext = 'show' | 'standalone';
 
@@ -30,7 +30,7 @@ export type EpisodeItemVariant =
 
 export type EpisodeCardProps = BaseItemProps & EpisodeItemVariant & {
   media: ShowInput;
-  urlOverride?: EpisodeUrlOverride;
+  urlOverride?: CardUrlOverride;
   /**
    * FIXME: We should migrate these on the backend and remove from the client.
    */

--- a/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
@@ -3,6 +3,7 @@ import type { MediaInput, MediaInputDefault } from '$lib/models/MediaInput.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Snippet } from 'svelte';
 import type { BaseItemProps } from './BaseItemProps.ts';
+import type { CardUrlOverride } from './CardUrlOverride.ts';
 
 export type MediaItemVariant<T> =
   | { variant?: Nil } & MediaInput<T>
@@ -21,6 +22,7 @@ type BaseMediaProps<T> = BaseItemProps & MediaItemVariant<T> & {
   coverTag?: Snippet;
   mode?: 'standalone' | 'mixed';
   onclick?: (item: T) => void;
+  urlOverride?: CardUrlOverride;
 };
 
 export type MediaCardProps<T = MediaInputDefault> =

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts" generics="T extends { key: string }, M">
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import PaginatedList from "$lib/components/lists/PaginatedList.svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { drilldownGrid } from "$lib/sections/lists/utils/drilldownGrid.ts";
   import type { DrilledMediaListProps } from "./MediaListProps";
 
   const {
@@ -9,11 +11,14 @@
     empty: externalEmpty,
     useList,
     actions,
-    cardOrientation = "portrait",
+    variant = "portrait",
     id,
     listActions,
     ...props
   }: DrilledMediaListProps<T, M> = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const grid = $derived(drilldownGrid($isLargeScreenCards, variant));
 </script>
 
 <PaginatedList {type} {filter} {useList}>
@@ -24,8 +29,8 @@
       {actions}
       {items}
       {listActions}
-      sizing="auto"
-      --width-item="var(--width-summary-card)"
+      sizing={grid.sizing}
+      --width-item={grid.itemWidth}
     >
       {#snippet empty()}
         {#if !isLoading}

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -27,7 +27,6 @@ export type DrilledMediaListProps<T, M> =
     id: string;
     useList: PaginatableStore<T, M>;
     actions?: Snippet<[]>;
-    cardOrientation?: 'landscape' | 'portrait';
     listActions?: Snippet;
     groupBy?: (item: T) => string;
     groupHeader?: Snippet<[string]>;

--- a/projects/client/src/lib/sections/lists/history/CreditsHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/CreditsHistoryPaginatedList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import { drilldownGrid } from "$lib/sections/lists/utils/drilldownGrid.ts";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages";
@@ -24,13 +26,16 @@
     filter$: filterMap,
     mode$: mode,
   });
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const grid = $derived(drilldownGrid($isLargeScreenCards));
 </script>
 
 <GridList
   id={`credits-history-list-${slug}`}
   items={$list}
-  sizing="auto"
-  --width-item="var(--width-summary-card)"
+  sizing={grid.sizing}
+  --width-item={grid.itemWidth}
 >
   {#snippet item(entry)}
     <CreditMediaItem

--- a/projects/client/src/lib/sections/lists/history/MediaWatchHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/MediaWatchHistoryPaginatedList.svelte
@@ -17,6 +17,7 @@
 
 <DrilledMediaList
   id="media-watch-history-list-{type}"
+  variant="landscape"
   title={m.list_title_history()}
   {type}
   useList={(params) => useRecentlyWatchedList({ ...params, id: media.id })}

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -14,7 +14,7 @@
   import { NOOP_FN } from "$lib/utils/constants";
   import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle";
   import ActivityItem from "../components/ActivityItem.svelte";
-  import { resolveItemCardStyle } from "../components/_internal/resolveItemCardStyle.ts";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import ActivitySummaryCard from "../components/ActivitySummaryCard.svelte";
   import type { HistoryEntry } from "../stores/models/HistoryEntry";
 

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -4,6 +4,7 @@
   import Popover from "$lib/components/popover/Popover.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import UserRating from "$lib/sections/components/UserRating.svelte";
   import RemoveFromHistoryAction from "$lib/sections/media-actions/remove-from-history/RemoveFromHistoryAction.svelte";
@@ -13,6 +14,7 @@
   import { NOOP_FN } from "$lib/utils/constants";
   import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle";
   import ActivityItem from "../components/ActivityItem.svelte";
+  import { resolveItemCardStyle } from "../components/_internal/resolveItemCardStyle.ts";
   import ActivitySummaryCard from "../components/ActivitySummaryCard.svelte";
   import type { HistoryEntry } from "../stores/models/HistoryEntry";
 
@@ -27,6 +29,11 @@
     style = "cover",
     isActionable = false,
   }: RecentlyWatchedItemProps = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const resolvedStyle = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards),
+  );
 
   const { ratings } = useUser();
 
@@ -112,9 +119,10 @@
   {/if}
 {/snippet}
 
-{#if style === "cover"}
+{#if resolvedStyle === "cover"}
   <ActivityItem
     activityAt={activity.watchedAt}
+    {style}
     {activity}
     popupActions={isActionable ? popupActions : undefined}
     action={isActionable ? action : undefined}
@@ -123,7 +131,7 @@
   />
 {/if}
 
-{#if style === "summary"}
+{#if resolvedStyle === "summary"}
   <ActivitySummaryCard
     activityAt={activity.watchedAt}
     {activity}

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
@@ -9,6 +9,7 @@
 
 <DrilledMediaList
   id="recently-watched-list-paginated-{mode}-{slug}"
+  variant="landscape"
   type={mode}
   useList={({ limit }: { limit: number }) =>
     useRecentlyWatchedList({

--- a/projects/client/src/lib/sections/lists/library/_internal/LibraryMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/library/_internal/LibraryMediaItem.svelte
@@ -2,12 +2,19 @@
   import DateTag from "$lib/components/media/tags/DateTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import type { LibraryItem } from "$lib/requests/models/LibraryItem";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { resolveItemCardStyle } from "../../components/_internal/resolveItemCardStyle.ts";
   import MediaItem from "../../components/MediaItem.svelte";
 
   const {
     item,
     style = "cover",
   }: { item: LibraryItem; style?: "summary" | "cover" } = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const isSummary = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards) === "summary",
+  );
 
   const target = $derived.by(() => {
     if (item.type === "episode") {
@@ -37,7 +44,7 @@
   variant="start"
   {style}
   coverTag={addedAtTag}
-  tag={style === "summary" ? addedAtTag : undefined}
+  tag={isSummary ? addedAtTag : undefined}
 />
 
 <style>

--- a/projects/client/src/lib/sections/lists/library/_internal/LibraryMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/library/_internal/LibraryMediaItem.svelte
@@ -3,7 +3,7 @@
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import type { LibraryItem } from "$lib/requests/models/LibraryItem";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
-  import { resolveItemCardStyle } from "../../components/_internal/resolveItemCardStyle.ts";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import MediaItem from "../../components/MediaItem.svelte";
 
   const {

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -18,7 +18,7 @@
   <DrilledMediaList
     id={`view-all-up-next-${$mode}`}
     type={$mode}
-    cardOrientation="landscape"
+    variant="landscape"
     filter={$filterMap}
     useList={(listParams) =>
       useStablePaginated({

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextMovieSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextMovieSwipe.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { swipeIndicatorHeight } from "$lib/sections/lists/components/_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { MovieEntry } from "$lib/requests/models/MovieEntry";
@@ -16,6 +18,8 @@
 
   const { movie, playbackId, style, children }: UpNextMovieSwipeProps =
     $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
 
   const { markAsWatched } = $derived(
     useMarkAsWatched({
@@ -58,7 +62,7 @@
         confirmDrop();
       }
     }}
-    --indicator-height="var(--height-summary-card-cover)"
+    --indicator-height={swipeIndicatorHeight($isLargeScreenCards)}
   >
     {#snippet indicator({ isActive, direction })}
       {#if direction === "left"}

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextMovieSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextMovieSwipe.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { hasSwipeGesture } from "$lib/sections/lists/components/_internal/hasSwipeGesture.ts";
   import { swipeIndicatorHeight } from "$lib/sections/lists/components/_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -20,6 +22,15 @@
     $props();
 
   const isLargeScreenCards = useLargeScreenCards();
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+
+  const hasSwipe = $derived(
+    hasSwipeGesture({
+      style,
+      isLargeScreenCards: $isLargeScreenCards,
+      isMouse: $isMouse,
+    }),
+  );
 
   const { markAsWatched } = $derived(
     useMarkAsWatched({
@@ -47,7 +58,7 @@
   );
 </script>
 
-{#if style === "summary"}
+{#if hasSwipe}
   <SwipeX
     {children}
     directions={["left", "right"]}

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextSwipe.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { swipeIndicatorHeight } from "$lib/sections/lists/components/_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
@@ -18,6 +20,8 @@
   } & ChildrenProps;
 
   const { target, show, style, children }: UpNextEpisodeProps = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
 
   const { markAsWatched } = $derived(useMarkAsWatched(target));
 
@@ -53,7 +57,7 @@
         confirmDrop();
       }
     }}
-    --indicator-height="var(--height-summary-card-cover)"
+    --indicator-height={swipeIndicatorHeight($isLargeScreenCards)}
   >
     {#snippet indicator({ isActive, direction })}
       {#if direction === "left"}

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextSwipe.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { hasSwipeGesture } from "$lib/sections/lists/components/_internal/hasSwipeGesture.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { swipeIndicatorHeight } from "$lib/sections/lists/components/_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -22,6 +24,15 @@
   const { target, show, style, children }: UpNextEpisodeProps = $props();
 
   const isLargeScreenCards = useLargeScreenCards();
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+
+  const hasSwipe = $derived(
+    hasSwipeGesture({
+      style,
+      isLargeScreenCards: $isLargeScreenCards,
+      isMouse: $isMouse,
+    }),
+  );
 
   const { markAsWatched } = $derived(useMarkAsWatched(target));
 
@@ -43,7 +54,7 @@
   );
 </script>
 
-{#if style === "summary"}
+{#if hasSwipe}
   <SwipeX
     {children}
     directions={["left", "right"]}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -10,7 +10,7 @@
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import type { BaseItemProps } from "$lib/sections/lists/components/models/BaseItemProps";
-  import type { EpisodeUrlOverride } from "$lib/sections/lists/components/models/EpisodeUrlOverride";
+  import type { CardUrlOverride } from "$lib/sections/lists/components/models/CardUrlOverride";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchedUntilHereDrawer from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/WatchedUntilHereDrawer.svelte";
   import { useWatchUntilHereEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/useWatchUntilHereEpisodes.ts";
@@ -28,7 +28,7 @@
     isCurrentEpisode?: boolean;
     style?: BaseItemProps["style"];
     source: string;
-    urlOverride?: EpisodeUrlOverride;
+    urlOverride?: CardUrlOverride;
   };
 
   const {

--- a/projects/client/src/lib/sections/lists/utils/drilldownGrid.ts
+++ b/projects/client/src/lib/sections/lists/utils/drilldownGrid.ts
@@ -1,0 +1,15 @@
+import { mediaCardWidthResolver } from './mediaCardWidthResolver.ts';
+
+export function drilldownGrid(
+  isLargeScreenCards: boolean,
+  variant: 'portrait' | 'landscape' = 'portrait',
+) {
+  if (!isLargeScreenCards) {
+    return { sizing: 'auto', itemWidth: 'var(--width-summary-card)' } as const;
+  }
+
+  return {
+    sizing: 'cover',
+    itemWidth: mediaCardWidthResolver(variant),
+  } as const;
+}

--- a/projects/client/src/lib/sections/lists/utils/resolveItemCardStyle.spec.ts
+++ b/projects/client/src/lib/sections/lists/utils/resolveItemCardStyle.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { resolveItemCardStyle } from './resolveItemCardStyle.ts';
+
+describe('util: resolveItemCardStyle', () => {
+  describe('with large screen cards enabled', () => {
+    it('should upgrade a summary card to a cover card', () => {
+      expect(resolveItemCardStyle('summary', true)).toBe('cover');
+    });
+
+    it('should keep the drawer compact layout as a summary card', () => {
+      expect(resolveItemCardStyle('compact', true)).toBe('summary');
+    });
+
+    it('should keep the drawer minimal layout as a summary card', () => {
+      expect(resolveItemCardStyle('minimal', true)).toBe('summary');
+    });
+
+    it('should leave a cover card untouched', () => {
+      expect(resolveItemCardStyle('cover', true)).toBe('cover');
+    });
+  });
+
+  describe('with large screen cards disabled', () => {
+    it('should leave a summary card untouched', () => {
+      expect(resolveItemCardStyle('summary', false)).toBe('summary');
+    });
+
+    it('should leave a cover card untouched', () => {
+      expect(resolveItemCardStyle('cover', false)).toBe('cover');
+    });
+
+    it.each(['compact', 'minimal'] as const)(
+      'should resolve the %s layout to a summary card',
+      (style) => {
+        expect(resolveItemCardStyle(style, false)).toBe('summary');
+      },
+    );
+  });
+});

--- a/projects/client/src/lib/sections/lists/utils/resolveItemCardStyle.ts
+++ b/projects/client/src/lib/sections/lists/utils/resolveItemCardStyle.ts
@@ -1,4 +1,4 @@
-import type { BaseItemProps } from '../models/BaseItemProps.ts';
+import type { BaseItemProps } from '../components/models/BaseItemProps.ts';
 
 export function resolveItemCardStyle(
   style: NonNullable<BaseItemProps['style']>,

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/MovieStartWatchingSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/MovieStartWatchingSwipe.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { hasSwipeGesture } from "$lib/sections/lists/components/_internal/hasSwipeGesture.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { swipeIndicatorHeight } from "$lib/sections/lists/components/_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -18,6 +20,15 @@
   const { media, style, children }: StartWatchingMovieProps = $props();
 
   const isLargeScreenCards = useLargeScreenCards();
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
+
+  const hasSwipe = $derived(
+    hasSwipeGesture({
+      style,
+      isLargeScreenCards: $isLargeScreenCards,
+      isMouse: $isMouse,
+    }),
+  );
 
   const { markAsWatched } = $derived(
     useMarkAsWatched({
@@ -40,7 +51,7 @@
   );
 </script>
 
-{#if style === "summary"}
+{#if hasSwipe}
   <SwipeX
     {children}
     directions={["left", "right"]}

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/MovieStartWatchingSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/MovieStartWatchingSwipe.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { swipeIndicatorHeight } from "$lib/sections/lists/components/_internal/swipeIndicatorHeight.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { MovieEntry } from "$lib/requests/models/MovieEntry";
@@ -14,6 +16,8 @@
   } & ChildrenProps;
 
   const { media, style, children }: StartWatchingMovieProps = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
 
   const { markAsWatched } = $derived(
     useMarkAsWatched({
@@ -50,7 +54,7 @@
         confirmRemove();
       }
     }}
-    --indicator-height="var(--height-summary-card-cover)"
+    --indicator-height={swipeIndicatorHeight($isLargeScreenCards)}
   >
     {#snippet indicator({ isActive, direction })}
       {#if direction === "left"}

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/StartWatchingItem.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/StartWatchingItem.svelte
@@ -11,7 +11,8 @@
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import type { Snippet } from "svelte";
   import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
-  import { resolveItemCardStyle } from "../../components/_internal/resolveItemCardStyle.ts";
+  import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
+  import { resolveItemCardStyle } from "$lib/sections/lists/utils/resolveItemCardStyle.ts";
   import MediaItem from "../../components/MediaItem.svelte";
   import UpNextSwipe from "../../progress/_internal/UpNextSwipe.svelte";
   import { mapToMarkAsWatchedTarget } from "./mapToMarkAsWatchedTarget";
@@ -51,6 +52,15 @@
       media: entry,
     };
   });
+
+  const hoverSubtitle = $derived(
+    mediaEntry.episode
+      ? episodeNumberLabel({
+        seasonNumber: mediaEntry.episode.season,
+        episodeNumber: mediaEntry.episode.number,
+      })
+      : undefined,
+  );
 
   const commonActionProps = $derived({
     style: "dropdown-item" as const,
@@ -102,6 +112,8 @@
     {action}
     {sortTag}
     tag={isSummary ? summaryTag : undefined}
+    hoverTag={summaryTag}
+    {hoverSubtitle}
     variant="start"
     source="start-watching"
   />

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/StartWatchingItem.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/StartWatchingItem.svelte
@@ -10,6 +10,8 @@
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import type { Snippet } from "svelte";
+  import { useLargeScreenCards } from "$lib/features/large-screen-cards/useLargeScreenCards.ts";
+  import { resolveItemCardStyle } from "../../components/_internal/resolveItemCardStyle.ts";
   import MediaItem from "../../components/MediaItem.svelte";
   import UpNextSwipe from "../../progress/_internal/UpNextSwipe.svelte";
   import { mapToMarkAsWatchedTarget } from "./mapToMarkAsWatchedTarget";
@@ -24,6 +26,11 @@
     style: "summary" | "cover";
     sortTag?: Snippet;
   } = $props();
+
+  const isLargeScreenCards = useLargeScreenCards();
+  const isSummary = $derived(
+    resolveItemCardStyle(style, $isLargeScreenCards) === "summary",
+  );
 
   const markAsWatchedTarget = $derived(mapToMarkAsWatchedTarget(entry));
   const mediaEntry = $derived.by(() => {
@@ -94,7 +101,7 @@
     {popupActions}
     {action}
     {sortTag}
-    tag={style === "summary" ? summaryTag : undefined}
+    tag={isSummary ? summaryTag : undefined}
     variant="start"
     source="start-watching"
   />

--- a/projects/client/src/lib/sections/summary/MovieSummary.svelte
+++ b/projects/client/src/lib/sections/summary/MovieSummary.svelte
@@ -45,7 +45,7 @@
 <SummaryDrawer {sentiment} {studios} {crew} {media} {videos} type="movie" />
 
 <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
-  <MediaSummaryV2 {media} {studios} {crew} {intl} type="movie" />
+  <MediaSummaryV2 {media} {crew} {intl} type="movie" />
 </RenderFor>
 
 <RenderFor audience="all" device={["tablet-lg", "desktop"]}>

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -73,7 +73,7 @@
 />
 
 <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
-  <MediaSummaryV2 {media} {studios} {intl} {crew} type="show" />
+  <MediaSummaryV2 {media} {intl} {crew} type="show" />
 </RenderFor>
 
 <RenderFor audience="all" device={["tablet-lg", "desktop"]}>

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -184,6 +184,7 @@
 
 {#if drawer === SummaryDrawers.Episode && seasons && currentSeason != null && sourceEpisode != null && showEntry}
   <EpisodeDrawerHost
+    slug={showEntry.slug}
     show={showEntry}
     {seasons}
     season={currentSeason}

--- a/projects/client/src/lib/sections/summary/components/_internal/GlanceTitleLink.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/GlanceTitleLink.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+
+  const { children, href }: { href: string } & ChildrenProps = $props();
+</script>
+
+<div class="trakt-glance-title-link">
+  <Link {href} target="_self">
+    {@render children()}
+    <CaretRightIcon />
+  </Link>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-glance-title-link {
+    --glance-caret-size: calc(var(--font-size-text) * 0.9);
+
+    min-width: 0;
+    max-width: 100%;
+
+    :global(.trakt-link) {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-xxs);
+      min-width: 0;
+      max-width: 100%;
+
+      padding-inline-start: calc(
+        var(--glance-caret-size) + var(--gap-xxs)
+      );
+
+      text-decoration: none;
+
+      > :global(*:first-child) {
+        min-width: 0;
+
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      :global(svg) {
+        flex-shrink: 0;
+
+        width: var(--glance-caret-size);
+        height: var(--glance-caret-size);
+
+        color: var(--color-text-primary);
+
+        transition: color var(--transition-increment) ease-in-out;
+      }
+
+      @include for-mouse {
+        &:hover {
+          color: var(--color-link-active);
+
+          :global(svg) {
+            color: var(--color-link-active);
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/ResponsiveTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/ResponsiveTitle.svelte
@@ -32,5 +32,9 @@
     @include for-tablet-sm-and-below {
       font-size: initial;
     }
+
+    :global(.trakt-summary[data-variant="drawer"]) & {
+      font-size: initial;
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
@@ -9,26 +9,30 @@
     meta,
     sideActions,
     color,
+    variant = "page",
   }: {
     poster: Snippet;
     meta: Snippet;
-    sideActions: Snippet;
+    sideActions?: Snippet;
     color?: string;
+    variant?: "page" | "drawer";
   } & ChildrenProps = $props();
 
   const mainColor = $derived(color ?? "rgba(0, 0, 0, 0.56)");
 </script>
 
-<div class="trakt-summary">
+<div class="trakt-summary" data-variant={variant}>
   <div class="trakt-summary-main" style={`--main-color: ${mainColor}`}>
     <SummarySideActions>
-      <BackButton />
+      {#if variant === "page"}
+        <BackButton />
+      {/if}
     </SummarySideActions>
 
     {@render poster()}
 
     <SummarySideActions>
-      {@render sideActions()}
+      {@render sideActions?.()}
     </SummarySideActions>
   </div>
 
@@ -46,6 +50,23 @@
     gap: var(--gap-m);
 
     padding: var(--gap-m) var(--layout-distance-side);
+
+    &[data-variant="drawer"] {
+      --summary-poster-width: var(--ni-220);
+      --summary-side-action-bar-width: var(--ni-0);
+
+      --glance-line-height: var(--ni-16);
+      --glance-title-lines: 1;
+      --glance-ratings-height: var(--ni-24);
+      --glance-actions-height: var(--ni-56);
+      --glance-overview-lines: 3;
+      --glance-overview-height: calc(
+        var(--glance-overview-lines) * var(--font-size-text) * 1.5
+      );
+
+      padding-inline: 0;
+      padding-block-start: 0;
+    }
   }
 
   .trakt-summary-main {

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
@@ -7,10 +7,18 @@
   import { mapToMainCredit } from "./mapToMainCredit";
   import { mapToSummaryStatus } from "./mapToSummaryStatus";
   import { mapToSummarySubtitle } from "./mapToSummarySubtitle";
+  import GlanceTitleLink from "./GlanceTitleLink.svelte";
   import ResponsiveTitle from "./ResponsiveTitle.svelte";
   import type { SummaryTitleProps } from "./SummaryTitleProps";
 
-  const { title, crew, ...target }: SummaryTitleProps = $props();
+  const {
+    title,
+    crew,
+    href,
+    hasDetails = true,
+    hasReservedRows = false,
+    ...target
+  }: SummaryTitleProps = $props();
 
   const subtitle = $derived(mapToSummarySubtitle(target));
   const mainCredit = $derived(mapToMainCredit(target.type, crew));
@@ -26,10 +34,19 @@
 </script>
 
 <div class="trakt-summary-title">
-  <ResponsiveTitle {title} />
+  <div class="trakt-summary-title-slot">
+    {#if href}
+      <GlanceTitleLink {href}>
+        <ResponsiveTitle {title} />
+      </GlanceTitleLink>
+    {:else}
+      <ResponsiveTitle {title} />
+    {/if}
+  </div>
 
-  {#if mainCredit}
+  {#if mainCredit || hasReservedRows}
     <p class="tiny trakt-media-main-credit">
+      {#if mainCredit}
       <MessageWithLink
         message={mainCredit.text}
         href={UrlBuilder.people(mainCredit.key, mainCredit.positions)}
@@ -41,6 +58,7 @@
           )}
           target="_self">{mainCredit.others[0].name}</Link
         >{/if}
+      {/if}
     </p>
   {/if}
 
@@ -49,18 +67,29 @@
       {subtitle}
     </p>
 
-    <DetailsButton style="action" size="small" {title} />
+    {#if hasDetails}
+      <DetailsButton style="action" size="small" {title} />
+    {/if}
   </div>
 
-  {#if status}
+  {#if status || hasReservedRows}
     <p class="capitalize bold trakt-media-status">
-      {toTranslatedStatus(status)}
+      {status ? toTranslatedStatus(status) : ""}
     </p>
   {/if}
 </div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
+
+  @mixin compact-title {
+    gap: var(--gap-micro);
+    align-items: center;
+
+    :global(.trakt-responsive-title) {
+      text-align: center;
+    }
+  }
 
   .trakt-summary-title {
     display: flex;
@@ -70,11 +99,29 @@
     transition: gap var(--transition-increment) ease-in-out;
 
     @include for-tablet-sm-and-below {
-      gap: var(--gap-micro);
-      align-items: center;
+      @include compact-title;
+    }
 
-      :global(.trakt-responsive-title) {
-        text-align: center;
+    :global(.trakt-summary[data-variant="drawer"]) & {
+      @include compact-title;
+
+      min-width: 0;
+      max-width: 100%;
+
+      .trakt-summary-title-slot {
+        display: flex;
+        align-items: flex-start;
+
+        min-width: 0;
+        max-width: 100%;
+
+        min-height: calc(var(--glance-title-lines) * 1lh);
+      }
+
+      .trakt-media-main-credit,
+      .trakt-media-status,
+      .trakt-summary-subtitle {
+        min-height: var(--glance-line-height);
       }
     }
   }

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryTitleProps.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryTitleProps.ts
@@ -12,4 +12,7 @@ export type EpisodeSummaryEntry = {
 export type SummaryTitleProps = {
   title: string;
   crew: MediaCrew;
+  href?: string;
+  hasDetails?: boolean;
+  hasReservedRows?: boolean;
 } & (EpisodeSummaryEntry | MediaSummaryEntry);

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
   import InfoIcon from "$lib/components/icons/InfoIcon.svelte";
   import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
@@ -34,20 +35,45 @@
   import { useEpisodePeople } from "./_internal/useEpisodePeople.ts";
   import { useEpisodeStreamOn } from "./_internal/useEpisodeStreamOn.ts";
   import { useEpisodeSummary } from "./_internal/useEpisodeSummary.ts";
+  import { useQuery } from "$lib/features/query/useQuery.ts";
+  import { of } from "rxjs";
+  import { showSummaryQuery } from "$lib/requests/queries/shows/showSummaryQuery.ts";
+  import { filter, map } from "rxjs/operators";
 
   const {
     onClose,
+    slug,
     show,
     seasons,
+    variant = "default",
     season,
     episode,
   }: {
-    show: ShowEntry;
-    seasons: Season[];
+    slug: string;
+    show?: ShowEntry;
+    seasons?: Season[];
+    variant?: "default" | "glance";
     season: number;
     episode: number;
     onClose: () => void;
   } = $props();
+
+  const isDefined = (value: string | null): value is string =>
+    value != null;
+
+  const showQuery = useQuery(
+    fromRune(() => (show ? null : slug)).pipe(
+      filter(isDefined),
+      map(($slug) => showSummaryQuery({ slug: $slug })),
+    ),
+  );
+
+  const resolvedShow = $derived(show ?? $showQuery?.data);
+
+  const isGlance = $derived(variant === "glance");
+  const episodeHref = $derived(
+    UrlBuilder.episodeDrawer(slug, season, episode),
+  );
 
   let isOpen = $state(false);
   let activeTab = $state("info");
@@ -70,13 +96,13 @@
 
   const socialTarget = $derived({
     type: "episode" as const,
-    slug: show.slug,
+    slug,
     season,
     episode,
   });
 
   const params$ = fromRune(() => ({
-    slug: show.slug,
+    slug,
     season,
     episode,
   }));
@@ -129,16 +155,24 @@
   const isEpisodeTitleTruncated = writable(false);
 
   const { isSpoilerHidden } = $derived(
-    useMediaSpoiler({
-      show,
-      media: $episodeEntry ? [$episodeEntry] : [],
-      type: "episode",
-    }),
+    resolvedShow
+      ? useMediaSpoiler({
+        show: resolvedShow,
+        media: $episodeEntry ? [$episodeEntry] : [],
+        type: "episode",
+      })
+      : { isSpoilerHidden: of(false) },
   );
 
-  const socialTitle = $derived(
-    $episodeEntry ? episodeActivityTitle($episodeEntry, show) : show.title,
-  );
+  const socialTitle = $derived.by(() => {
+    if (!resolvedShow) {
+      return "";
+    }
+
+    return $episodeEntry
+      ? episodeActivityTitle($episodeEntry, resolvedShow)
+      : resolvedShow.title;
+  });
 </script>
 
 {#snippet episodeMetaInfo()}
@@ -152,8 +186,8 @@
       use:trackTextOverflow={isEpisodeTitleTruncated}
     >
       {numberLabel}
-      {#if $episodeEntry}
-        <Spoiler media={$episodeEntry} {show} type="episode">
+      {#if $episodeEntry && resolvedShow}
+        <Spoiler media={$episodeEntry} show={resolvedShow} type="episode">
           - {$episodeEntry.title}
         </Spoiler>
       {/if}
@@ -175,17 +209,22 @@
 
 {#snippet infoContent()}
   <div class="episode-info-content">
-    {#if $episodeEntry}
-      <MediaStats type="episode" episode={$episodeEntry} {show} crew={$crew} />
+    {#if $episodeEntry && resolvedShow}
+      <MediaStats
+        type="episode"
+        episode={$episodeEntry}
+        show={resolvedShow}
+        crew={$crew}
+      />
     {:else}
       <MediaStatsSkeleton />
     {/if}
 
-    {#if $episodeEntry}
+    {#if $episodeEntry && resolvedShow}
       <WhereToWatchList
         type="episode"
         episode={$episodeEntry}
-        media={show}
+        media={resolvedShow}
         streamOn={$streamOn}
         isLoading={$isStreamOnLoading}
         variant="inline"
@@ -195,7 +234,7 @@
     {:else if $isAired}
       <WhereToWatchListSkeleton
         type="episode"
-        slug={show.slug}
+        {slug}
         variant="inline"
         --inset-override-list-item="0"
       />
@@ -210,27 +249,29 @@
 {/snippet}
 
 {#snippet reviewsContent()}
-  {#if $episodeEntry}
-    <EpisodeReviewsTab {show} episode={$episodeEntry} />
+  {#if $episodeEntry && resolvedShow}
+    <EpisodeReviewsTab show={resolvedShow} episode={$episodeEntry} />
   {:else if $isLoading}
     <EpisodeReviewsTabSkeleton />
   {/if}
 {/snippet}
 
 {#snippet episodesContent()}
-  <SeasonEpisodesTab
-    {show}
-    {seasons}
-    currentSeason={season}
-    currentEpisode={episode}
-    showSeasonSelector
-  />
+  {#if resolvedShow && seasons}
+    <SeasonEpisodesTab
+      show={resolvedShow}
+      {seasons}
+      currentSeason={season}
+      currentEpisode={episode}
+      showSeasonSelector
+    />
+  {/if}
 {/snippet}
 
 <Drawer
   {onClose}
   onOpened={() => (isOpen = true)}
-  title={show.title}
+  title={resolvedShow?.title}
   metaInfo={episodeMetaInfo}
   size="large"
   classList="trakt-episode-drawer"
@@ -242,8 +283,11 @@
       {/key}
 
       <EpisodeInfoHeader
-        {show}
+        {slug}
+        show={resolvedShow}
         {seasons}
+        hasEpisodeNavigation={!isGlance}
+        titleHref={isGlance ? episodeHref : undefined}
         {season}
         {episode}
         entry={$episodeEntry}
@@ -256,41 +300,43 @@
         onHistoryOpen={() => openStacked("history")}
       />
 
-      <TabView
-        value={activeTab}
-        onChange={(value) => (activeTab = value)}
-        tabs={[
-          {
-            value: "info",
-            label: m.tab_text_seasons_info(),
-            icon: infoIcon,
-            content: infoContent,
-          },
-          {
-            value: "reviews",
-            label: m.tab_text_seasons_reviews(),
-            icon: reviewsIcon,
-            content: reviewsContent,
-          },
-          {
-            value: "episodes",
-            label: m.tab_text_seasons_episodes(),
-            icon: episodesIcon,
-            content: episodesContent,
-          },
-        ]}
-      />
+      {#if !isGlance}
+        <TabView
+          value={activeTab}
+          onChange={(value) => (activeTab = value)}
+          tabs={[
+            {
+              value: "info",
+              label: m.tab_text_seasons_info(),
+              icon: infoIcon,
+              content: infoContent,
+            },
+            {
+              value: "reviews",
+              label: m.tab_text_seasons_reviews(),
+              icon: reviewsIcon,
+              content: reviewsContent,
+            },
+            {
+              value: "episodes",
+              label: m.tab_text_seasons_episodes(),
+              icon: episodesIcon,
+              content: episodesContent,
+            },
+          ]}
+        />
+      {/if}
     </div>
   {/if}
 </Drawer>
 
-{#if openDrawer === "ratings" && $episodeEntry}
+{#if openDrawer === "ratings" && $episodeEntry && resolvedShow}
   <RatingsDrawer
     type="episode"
     episode={$episodeEntry}
-    {show}
+    show={resolvedShow}
     crew={$crew}
-    {seasons}
+    seasons={seasons ?? []}
     elevated
     onClose={closeStacked}
   />
@@ -305,22 +351,22 @@
   />
 {/if}
 
-{#if openDrawer === "history" && $episodeEntry}
+{#if openDrawer === "history" && $episodeEntry && resolvedShow}
   <HistoryDrawerHost
     type="episode"
     episode={$episodeEntry}
-    {show}
+    show={resolvedShow}
     crew={$crew}
     elevated
     onClose={closeStacked}
   />
 {/if}
 
-{#if openDrawer === "where-to-watch" && $episodeEntry}
+{#if openDrawer === "where-to-watch" && $episodeEntry && resolvedShow}
   <WhereToWatchDrawerHost
     type="episode"
     episode={$episodeEntry}
-    media={show}
+    media={resolvedShow}
     elevated
     onClose={closeStacked}
   />

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
@@ -6,6 +6,7 @@
   import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
+  import GlanceTitleLink from "../../_internal/GlanceTitleLink.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import Skeleton from "$lib/components/skeleton/Skeleton.svelte";
   import RatingList from "$lib/components/summary/RatingList.svelte";
@@ -40,8 +41,11 @@
   import { useEpisodeRating } from "./useEpisodeRating.ts";
 
   const {
+    slug,
     show,
     seasons,
+    hasEpisodeNavigation = true,
+    titleHref,
     season,
     episode,
     entry,
@@ -53,8 +57,11 @@
     onSocialOpen,
     onHistoryOpen,
   }: {
-    show: ShowEntry;
-    seasons: Season[];
+    slug: string;
+    show?: ShowEntry;
+    seasons?: Season[];
+    hasEpisodeNavigation?: boolean;
+    titleHref?: string;
     season: number;
     episode: number;
     entry: EpisodeEntry | Nil;
@@ -72,7 +79,7 @@
   // The ratings query only needs the slug/season/episode numbers, so it can
   // resolve independently of the episode summary entry.
   const params$ = fromRune(() => ({
-    slug: show.slug,
+    slug,
     season,
     episode,
   }));
@@ -84,13 +91,13 @@
   // transition when the entry resolves, instead of it being suppressed as part
   // of a freshly mounted child's first render.
   const { isRateable } = $derived(
-    entry
+    entry && show
       ? useIsRateable({ type: "episode", media: entry, show })
       : { isRateable: of(false) },
   );
 
   const spoilerFreeTitle = $derived(
-    entry
+    entry && show
       ? useSpoilerFreeEpisodeTitle({ episode: entry, show })
       : of(""),
   );
@@ -100,7 +107,7 @@
   // Seasons that actually have episodes, ordered so previous/next can
   // cross season boundaries instead of clamping to the current season.
   const orderedSeasons = $derived(
-    seasons
+    (seasons ?? [])
       .filter((s) => s.episodes.count > 0)
       .sort((a, b) => a.number - b.number),
   );
@@ -141,21 +148,25 @@
   });
 
   const previousEpisodeLink = $derived(
-    previousTarget ? buildEpisodeDrawerLink(previousTarget) : undefined,
+    hasEpisodeNavigation && previousTarget
+      ? buildEpisodeDrawerLink(previousTarget)
+      : undefined,
   );
 
   const nextEpisodeLink = $derived(
-    nextTarget ? buildEpisodeDrawerLink(nextTarget) : undefined,
+    hasEpisodeNavigation && nextTarget
+      ? buildEpisodeDrawerLink(nextTarget)
+      : undefined,
   );
 
-  const genre = $derived(show.genres.at(0));
+  const genre = $derived(show?.genres.at(0));
 
   const subtitle = $derived(
     entry
       ? [
           toHumanDate(new Date(), entry.airDate, getLocale()),
           toHumanDuration({ minutes: entry.runtime }, languageTag()),
-          show.certification,
+          show?.certification,
           genre ? toTranslatedGenre(genre) : undefined,
         ]
           .filter(Boolean)
@@ -207,7 +218,7 @@
 />
 
 {#snippet cover()}
-  {#if entry}
+  {#if entry && show}
     <EpisodeInfoPoster {show} episode={entry} {onHistoryOpen} />
   {:else}
     <div class="skeleton-cover">
@@ -220,7 +231,7 @@
 
 <div class="episode-info-header" bind:this={headerElement}>
   <div class="episode-info-poster-ratings">
-    {#if $isTouch}
+    {#if $isTouch && hasEpisodeNavigation}
       <SwipeX
         children={cover}
         directions={["left", "right"]}
@@ -273,25 +284,40 @@
     </div>
   </div>
 
-  <div class="episode-info-switcher">
-    {#if previousEpisodeLink}
-      <Link {...previousEpisodeLink} label={m.button_label_previous_episode()}>
-        <CaretLeftIcon />
-      </Link>
-    {:else}
-      <span class="episode-switcher-spacer"></span>
+  <div
+    class="episode-info-switcher"
+    class:is-static={!hasEpisodeNavigation}
+  >
+    {#if hasEpisodeNavigation}
+      {#if previousEpisodeLink}
+        <Link {...previousEpisodeLink} label={m.button_label_previous_episode()}>
+          <CaretLeftIcon />
+        </Link>
+      {:else}
+        <span class="episode-switcher-spacer"></span>
+      {/if}
     {/if}
 
-    <span class="bold">
-      {m.text_season_episode_number({ season, number: episode })}
-    </span>
-
-    {#if nextEpisodeLink}
-      <Link {...nextEpisodeLink} label={m.button_label_next_episode()}>
-        <CaretRightIcon />
-      </Link>
+    {#if titleHref}
+      <GlanceTitleLink href={titleHref}>
+        <span class="bold">
+          {m.text_season_episode_number({ season, number: episode })}
+        </span>
+      </GlanceTitleLink>
     {:else}
-      <span class="episode-switcher-spacer"></span>
+      <span class="bold">
+        {m.text_season_episode_number({ season, number: episode })}
+      </span>
+    {/if}
+
+    {#if hasEpisodeNavigation}
+      {#if nextEpisodeLink}
+        <Link {...nextEpisodeLink} label={m.button_label_next_episode()}>
+          <CaretRightIcon />
+        </Link>
+      {:else}
+        <span class="episode-switcher-spacer"></span>
+      {/if}
     {/if}
   </div>
 
@@ -329,7 +355,7 @@
 
   <RenderFor audience="authenticated">
     <div class="episode-info-actions">
-      {#if entry}
+      {#if entry && show}
         <div class="episode-info-actions-content" in:fade={fadeIn}>
           <EpisodeActions
             episode={entry}
@@ -360,7 +386,7 @@
           onclick={onSocialOpen}
         />
 
-        {#if entry && $isRateable}
+        {#if entry && show && $isRateable}
           <div
             class="episode-info-rate"
             transition:slide={{ axis: "x", duration: 150 }}
@@ -373,7 +399,7 @@
   </RenderFor>
 
   <div class="episode-info-overview">
-    {#if entry}
+    {#if entry && show}
       {#if entry.overview}
         <div in:fade={fadeIn}>
           <SpoilerSection media={entry} {show} type="episode">
@@ -486,6 +512,11 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+
+    &.is-static {
+      justify-content: center;
+    }
+
     gap: var(--gap-s);
     align-self: stretch;
 

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawerHost.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import Drawer from "$lib/components/drawer/Drawer.svelte";
-  import { fade } from "svelte/transition";
+  import GlanceDrawer from "./_internal/GlanceDrawer.svelte";
   import MediaGlance from "./_internal/MediaGlance.svelte";
   import type { MediaGlanceTarget } from "./MediaGlanceTarget.ts";
 
@@ -8,19 +7,8 @@
     onClose,
     ...target
   }: { onClose: () => void } & MediaGlanceTarget = $props();
-
-  let isOpen = $state(false);
 </script>
 
-<Drawer
-  {onClose}
-  size="large"
-  classList="trakt-media-glance-drawer"
-  onOpened={() => (isOpen = true)}
->
-  {#if isOpen}
-    <div transition:fade={{ duration: 150 }}>
-      <MediaGlance {...target} />
-    </div>
-  {/if}
-</Drawer>
+<GlanceDrawer classList="trakt-media-glance-drawer" {onClose}>
+  <MediaGlance {...target} />
+</GlanceDrawer>

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawerHost.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import { fade } from "svelte/transition";
+  import MediaGlance from "./_internal/MediaGlance.svelte";
+  import type { MediaGlanceTarget } from "./MediaGlanceTarget.ts";
+
+  const {
+    onClose,
+    ...target
+  }: { onClose: () => void } & MediaGlanceTarget = $props();
+
+  let isOpen = $state(false);
+</script>
+
+<Drawer
+  {onClose}
+  size="large"
+  classList="trakt-media-glance-drawer"
+  onOpened={() => (isOpen = true)}
+>
+  {#if isOpen}
+    <div transition:fade={{ duration: 150 }}>
+      <MediaGlance {...target} />
+    </div>
+  {/if}
+</Drawer>

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawers.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawers.ts
@@ -1,3 +1,5 @@
 export enum MediaGlanceDrawers {
   Media = 'glance',
+  Episode = 'glance-episode',
+  Season = 'glance-season',
 }

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawers.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceDrawers.ts
@@ -1,0 +1,3 @@
+export enum MediaGlanceDrawers {
+  Media = 'glance',
+}

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceProvider.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceProvider.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import MediaGlanceDrawerHost from "./MediaGlanceDrawerHost.svelte";
+  import { MediaGlanceDrawers } from "./MediaGlanceDrawers.ts";
+  import { mediaGlanceNavigation } from "./mediaGlanceNavigation.ts";
+
+  const { drawer, type, slug, close } = $derived(
+    mediaGlanceNavigation(page.url.searchParams),
+  );
+</script>
+
+{#if drawer === MediaGlanceDrawers.Media && type && slug}
+  <MediaGlanceDrawerHost {type} {slug} onClose={close} />
+{/if}

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceProvider.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceProvider.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import EpisodeDrawerHost from "../episode-drawer/EpisodeDrawerHost.svelte";
+  import SeasonGlanceHost from "./_internal/SeasonGlanceHost.svelte";
   import MediaGlanceDrawerHost from "./MediaGlanceDrawerHost.svelte";
   import { MediaGlanceDrawers } from "./MediaGlanceDrawers.ts";
   import { mediaGlanceNavigation } from "./mediaGlanceNavigation.ts";
 
-  const { drawer, type, slug, close } = $derived(
+  const { drawer, type, slug, season, episode, close } = $derived(
     mediaGlanceNavigation(page.url.searchParams),
   );
 </script>
 
-{#if drawer === MediaGlanceDrawers.Media && type && slug}
-  <MediaGlanceDrawerHost {type} {slug} onClose={close} />
+{#if slug}
+  {#if drawer === MediaGlanceDrawers.Media && type}
+    <MediaGlanceDrawerHost {type} {slug} onClose={close} />
+  {:else if drawer === MediaGlanceDrawers.Episode && season != null && episode != null}
+    <EpisodeDrawerHost
+      {slug}
+      {season}
+      {episode}
+      variant="glance"
+      onClose={close}
+    />
+  {:else if drawer === MediaGlanceDrawers.Season && season != null}
+    <SeasonGlanceHost {slug} {season} onClose={close} />
+  {/if}
 {/if}

--- a/projects/client/src/lib/sections/summary/components/glance/MediaGlanceTarget.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/MediaGlanceTarget.ts
@@ -1,0 +1,6 @@
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+
+export type MediaGlanceTarget = {
+  type: MediaType;
+  slug: string;
+};

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/GlanceDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/GlanceDrawer.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import { fade } from "svelte/transition";
+
+  const {
+    classList,
+    onClose,
+    children,
+  }: {
+    classList: string;
+    onClose: () => void;
+  } & ChildrenProps = $props();
+
+  let isOpen = $state(false);
+</script>
+
+<Drawer
+  {onClose}
+  size="large"
+  {classList}
+  onOpened={() => (isOpen = true)}
+>
+  {#if isOpen}
+    <div transition:fade={{ duration: 150 }}>
+      {@render children()}
+    </div>
+  {/if}
+</Drawer>

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlance.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlance.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { MediaGlanceTarget } from "../MediaGlanceTarget.ts";
+  import MovieGlance from "./MovieGlance.svelte";
+  import ShowGlance from "./ShowGlance.svelte";
+
+  const { type, slug }: MediaGlanceTarget = $props();
+</script>
+
+{#if type === "show"}
+  <ShowGlance {slug} />
+{:else}
+  <MovieGlance {slug} />
+{/if}

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlanceActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlanceActions.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import TrackAction from "$lib/sections/media-actions/mark-as-watched/TrackAction.svelte";
+  import SummaryActionsBar from "../../_internal/SummaryActionsBar.svelte";
+  import BookmarkAction from "../../media/v2/_internal/BookmarkAction.svelte";
+  import TrailerButton from "../../media/v2/_internal/TrailerButton.svelte";
+
+  const { media }: { media: MediaEntry } = $props();
+
+  const targetProps = $derived({
+    title: media.title,
+    type: media.type,
+    media,
+  });
+</script>
+
+<SummaryActionsBar>
+  <TrackAction {...targetProps} />
+  <BookmarkAction {media} />
+  <TrailerButton slug={media.slug} trailer={media.trailer} style="action" />
+</SummaryActionsBar>

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlanceDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlanceDetails.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { MediaCrew } from "$lib/requests/models/MediaCrew";
+  import type { MediaIntl } from "$lib/requests/models/MediaIntl";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import SummaryRateNow from "../../_internal/SummaryRateNow.svelte";
+  import MediaSummaryBody from "../../media/MediaSummaryBody.svelte";
+  import type { MediaSummaryEntry } from "../../media/models/MediaSummaryEntry";
+  import { useIsRateable } from "../../rating/_internal/useIsRateable";
+  import MediaGlanceActions from "./MediaGlanceActions.svelte";
+
+  const {
+    intl,
+    crew,
+    ...target
+  }: {
+    intl: MediaIntl;
+    crew: MediaCrew;
+  } & MediaSummaryEntry = $props();
+
+  const media = $derived(target.media);
+  const href = $derived(UrlBuilder.media(target.type, media.slug));
+
+  const { isRateable } = $derived(useIsRateable(target));
+</script>
+
+{#snippet actions()}
+  <RenderFor audience="authenticated">
+    <div class="trakt-media-glance-actions">
+      <MediaGlanceActions {media} />
+    </div>
+
+    {#if $isRateable}
+      <SummaryRateNow {...target} />
+    {/if}
+  </RenderFor>
+{/snippet}
+
+<MediaSummaryBody
+  {intl}
+  {crew}
+  {actions}
+  variant="drawer"
+  color={media.colors?.at(0)}
+  titleHref={href}
+  hasDetails={false}
+  hasReservedRows
+  {...target}
+/>
+
+<style>
+  .trakt-media-glance-actions {
+    min-height: var(--glance-actions-height);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlanceSkeleton.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/MediaGlanceSkeleton.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import Skeleton from "$lib/components/skeleton/Skeleton.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import Summary from "../../_internal/Summary.svelte";
+</script>
+
+<Summary variant="drawer">
+  {#snippet poster()}
+    <div class="trakt-summary-poster-container skeleton-poster">
+      <Skeleton height="100%" radius="var(--border-radius-xxl)" />
+    </div>
+  {/snippet}
+
+
+  {#snippet meta()}
+    <div class="skeleton-titles">
+      <div class="skeleton-title">
+        <Skeleton width="60%" height="var(--glance-line-height)" />
+      </div>
+
+      <div class="skeleton-line">
+        <Skeleton width="var(--ni-148)" height="var(--ni-12)" />
+      </div>
+
+      <div class="skeleton-line">
+        <Skeleton width="var(--ni-220)" height="var(--ni-12)" />
+      </div>
+
+      <div class="skeleton-line">
+        <Skeleton width="var(--ni-88)" height="var(--ni-12)" />
+      </div>
+    </div>
+
+    <div class="skeleton-ratings">
+      <Skeleton width="var(--ni-64)" height="var(--ni-24)" />
+      <Skeleton width="var(--ni-64)" height="var(--ni-24)" />
+    </div>
+
+    <RenderFor audience="authenticated">
+      <div class="skeleton-actions">
+        <Skeleton
+          width="var(--ni-280)"
+          height="var(--ni-56)"
+          radius="var(--border-radius-xl)"
+        />
+      </div>
+    </RenderFor>
+
+  {/snippet}
+
+  <div class="skeleton-overview">
+    <Skeleton height="var(--glance-line-height)" />
+    <Skeleton width="60%" height="var(--glance-line-height)" />
+  </div>
+</Summary>
+
+<style>
+  .skeleton-poster {
+    width: var(--summary-poster-width);
+    aspect-ratio: 2 / 3;
+  }
+
+  .skeleton-titles {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-micro);
+
+    width: 100%;
+  }
+
+  .skeleton-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 100%;
+    height: calc(var(--glance-title-lines) * 1lh);
+  }
+
+  .skeleton-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    min-height: var(--glance-line-height);
+  }
+
+  .skeleton-ratings {
+    display: flex;
+    justify-content: center;
+    gap: var(--gap-s);
+
+    min-height: var(--glance-ratings-height);
+  }
+
+  .skeleton-actions {
+    display: flex;
+    justify-content: center;
+
+    min-height: var(--glance-actions-height);
+  }
+
+  .skeleton-overview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+
+    min-height: var(--glance-overview-height);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/MovieGlance.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/MovieGlance.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { movieIntlQuery } from "$lib/requests/queries/movies/movieIntlQuery.ts";
+  import { moviePeopleQuery } from "$lib/requests/queries/movies/moviePeopleQuery.ts";
+  import { movieSummaryQuery } from "$lib/requests/queries/movies/movieSummaryQuery.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import MediaGlanceDetails from "./MediaGlanceDetails.svelte";
+  import MediaGlanceSkeleton from "./MediaGlanceSkeleton.svelte";
+  import { useMediaGlance } from "./useMediaGlance.ts";
+
+  const { slug }: { slug: string } = $props();
+
+  const { media, crew, intl, isLoading } = useMediaGlance(
+    fromRune(() => slug),
+    {
+      type: "movie",
+      summary: movieSummaryQuery,
+      people: moviePeopleQuery,
+      intl: movieIntlQuery,
+    },
+  );
+</script>
+
+{#if $isLoading || !$media}
+  <MediaGlanceSkeleton />
+{:else}
+  <MediaGlanceDetails type="movie" media={$media} crew={$crew} intl={$intl} />
+{/if}

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/SeasonGlance.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/SeasonGlance.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import GlanceTitleLink from "../../_internal/GlanceTitleLink.svelte";
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import { seasonLabel } from "$lib/utils/intl/seasonLabel";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import SummaryCardRating from "$lib/sections/lists/components/_internal/SummaryCardRating.svelte";
+  import Summary from "../../_internal/Summary.svelte";
+  import SeasonEpisodesTab from "../../seasons/SeasonEpisodesTab.svelte";
+  import { mediaGlanceNavigation } from "../mediaGlanceNavigation.ts";
+  import MediaGlanceSkeleton from "./MediaGlanceSkeleton.svelte";
+  import { useShowGlance } from "./useShowGlance.ts";
+
+  const {
+    slug,
+    season,
+  }: {
+    slug: string;
+    season: number;
+  } = $props();
+
+  const { show, seasons, isLoading } = useShowGlance(fromRune(() => slug));
+
+  const entry = $derived($seasons?.find(({ number }) => number === season));
+  const href = $derived(UrlBuilder.seasonDrawer(slug, season));
+
+  const { buildEpisodeGlanceLink } = mediaGlanceNavigation();
+  const buildEpisodeLink = (target: { season: number; episode: number }) =>
+    buildEpisodeGlanceLink({ slug, ...target });
+</script>
+
+{#if $isLoading}
+  <MediaGlanceSkeleton />
+{:else if $show && entry}
+  <Summary variant="drawer">
+    {#snippet poster()}
+      <SummaryPoster
+        src={entry.poster?.url.medium ?? $show.poster.url.medium}
+        alt={seasonLabel(entry.number)}
+        {href}
+        target="_self"
+      />
+    {/snippet}
+
+
+    {#snippet meta()}
+      <div class="trakt-season-glance-titles">
+        <GlanceTitleLink {href}>
+          <p class="trakt-card-title">
+            {entry.title ?? seasonLabel(entry.number)}
+          </p>
+        </GlanceTitleLink>
+
+        <p class="small secondary">
+          {entry.title ? seasonLabel(entry.number) : $show.title}
+        </p>
+      </div>
+
+      <div class="trakt-season-glance-rating">
+        <SummaryCardRating item={entry} />
+      </div>
+    {/snippet}
+
+    <div class="trakt-season-glance-overview">
+      <p class="secondary small">{entry.overview ?? ""}</p>
+    </div>
+
+    <SeasonEpisodesTab
+      show={$show}
+      seasons={$seasons ?? []}
+      currentSeason={season}
+      {buildEpisodeLink}
+    />
+  </Summary>
+{/if}
+
+<style lang="scss">
+  .trakt-season-glance-titles {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-micro);
+  }
+
+  .trakt-card-title {
+    font-size: var(--font-size-text);
+  }
+
+  .trakt-season-glance-rating {
+    display: flex;
+    justify-content: center;
+
+    min-height: var(--glance-ratings-height);
+  }
+
+  .trakt-season-glance-overview {
+    min-height: var(--glance-overview-height);
+
+    p {
+      display: -webkit-box;
+
+      line-clamp: var(--glance-overview-lines);
+      -webkit-line-clamp: var(--glance-overview-lines);
+      -webkit-box-orient: vertical;
+
+      overflow: hidden;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/SeasonGlanceHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/SeasonGlanceHost.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import GlanceDrawer from "./GlanceDrawer.svelte";
+  import SeasonGlance from "./SeasonGlance.svelte";
+
+  const {
+    slug,
+    season,
+    onClose,
+  }: {
+    slug: string;
+    season: number;
+    onClose: () => void;
+  } = $props();
+</script>
+
+<GlanceDrawer classList="trakt-season-glance-drawer" {onClose}>
+  <SeasonGlance {slug} {season} />
+</GlanceDrawer>

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/ShowGlance.svelte
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/ShowGlance.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { showIntlQuery } from "$lib/requests/queries/shows/showIntlQuery.ts";
+  import { showPeopleQuery } from "$lib/requests/queries/shows/showPeopleQuery.ts";
+  import { showSummaryQuery } from "$lib/requests/queries/shows/showSummaryQuery.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import MediaGlanceDetails from "./MediaGlanceDetails.svelte";
+  import MediaGlanceSkeleton from "./MediaGlanceSkeleton.svelte";
+  import { useMediaGlance } from "./useMediaGlance.ts";
+
+  const { slug }: { slug: string } = $props();
+
+  const { media, crew, intl, isLoading } = useMediaGlance(
+    fromRune(() => slug),
+    {
+      type: "show",
+      summary: showSummaryQuery,
+      people: showPeopleQuery,
+      intl: showIntlQuery,
+    },
+  );
+</script>
+
+{#if $isLoading || !$media}
+  <MediaGlanceSkeleton />
+{:else}
+  <MediaGlanceDetails type="show" media={$media} crew={$crew} intl={$intl} />
+{/if}

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/useMediaGlance.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/useMediaGlance.ts
@@ -1,0 +1,85 @@
+import {
+  type AvailableLanguage,
+  getLanguageAndRegion,
+  languageTag,
+} from '$lib/features/i18n/index.ts';
+import type { CreateQueryOptions } from '$lib/features/query/types.ts';
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { EMPTY_CREW } from '$lib/requests/_internal/mapToMediaCrew.ts';
+import type { MediaCrew } from '$lib/requests/models/MediaCrew.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { MediaIntl } from '$lib/requests/models/MediaIntl.ts';
+import { findRegionalIntl } from '$lib/utils/media/findRegionalIntl.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { combineLatest, type Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+type IntlQueryParams = {
+  slug: string;
+  language: AvailableLanguage;
+  enabled: boolean;
+};
+
+export type MediaGlanceQueries<T extends MediaEntry> = {
+  type: T['type'];
+  summary: (params: { slug: string }) => CreateQueryOptions<T, Error>;
+  people: (
+    params: { slug: string },
+  ) => CreateQueryOptions<MediaCrew, Error>;
+  intl: (
+    params: IntlQueryParams,
+  ) => CreateQueryOptions<Array<MediaIntl>, Error>;
+};
+
+export function useMediaGlance<T extends MediaEntry>(
+  slug$: Observable<string>,
+  queries: MediaGlanceQueries<T>,
+) {
+  const { user, history } = useUser();
+
+  const isHistoryPending = combineLatest([user, history]).pipe(
+    map(([$user, $history]) => $user != null && $history == null),
+  );
+
+  const isLocaleSkipped = languageTag() === 'en';
+  const { language } = getLanguageAndRegion();
+
+  const summary = useQuery(
+    slug$.pipe(map((slug) => queries.summary({ slug }))),
+  );
+
+  const crew = useQuery(
+    slug$.pipe(map((slug) => queries.people({ slug }))),
+  );
+
+  const intl = useQuery(
+    slug$.pipe(
+      map((slug) =>
+        queries.intl({ slug, language, enabled: !isLocaleSkipped })
+      ),
+    ),
+  );
+
+  return {
+    media: summary.pipe(map(($summary) => $summary.data)),
+    crew: crew.pipe(map(($crew) => $crew.data ?? EMPTY_CREW)),
+    intl: combineLatest([intl, summary]).pipe(
+      map(([$intl, $summary]) =>
+        findRegionalIntl({
+          type: queries.type,
+          translations: $intl.data,
+          fallback: $summary.data,
+        })
+      ),
+    ),
+    isLoading: combineLatest([summary, crew, isHistoryPending]).pipe(
+      map(([$summary, $crew, $isHistoryPending]) =>
+        toLoadingState($summary) ||
+        $summary.data == null ||
+        toLoadingState($crew) ||
+        $isHistoryPending
+      ),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/glance/_internal/useShowGlance.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/_internal/useShowGlance.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { showSeasonsQuery } from '$lib/requests/queries/shows/showSeasonsQuery.ts';
+import { showSummaryQuery } from '$lib/requests/queries/shows/showSummaryQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { combineLatest, type Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export function useShowGlance(slug$: Observable<string>) {
+  const show = useQuery(
+    slug$.pipe(map((slug) => showSummaryQuery({ slug }))),
+  );
+
+  const seasons = useQuery(
+    slug$.pipe(map((slug) => showSeasonsQuery({ slug }))),
+  );
+
+  return {
+    show: show.pipe(map(($show) => $show.data)),
+    seasons: seasons.pipe(map(($seasons) => $seasons.data)),
+    isLoading: combineLatest([show, seasons]).pipe(
+      map(($queries) =>
+        $queries.some(toLoadingState) ||
+        $queries.some(($query) => $query.data == null)
+      ),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/glance/constants.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/constants.ts
@@ -1,2 +1,4 @@
 export const GLANCE_TYPE_PARAM = 'glance_type';
 export const GLANCE_SLUG_PARAM = 'glance_slug';
+export const GLANCE_SEASON_PARAM = 'glance_season';
+export const GLANCE_EPISODE_PARAM = 'glance_episode';

--- a/projects/client/src/lib/sections/summary/components/glance/constants.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/constants.ts
@@ -1,0 +1,2 @@
+export const GLANCE_TYPE_PARAM = 'glance_type';
+export const GLANCE_SLUG_PARAM = 'glance_slug';

--- a/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.spec.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MediaGlanceDrawers } from './MediaGlanceDrawers.ts';
+import { mediaGlanceNavigation } from './mediaGlanceNavigation.ts';
+
+const searchParamsOf = (url: string) => {
+  window.history.replaceState({}, '', url);
+  return new URL(window.location.href).searchParams;
+};
+
+describe('mediaGlanceNavigation', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/discover/trending');
+  });
+
+  describe('reading the current drawer', () => {
+    it('should resolve a media glance from its params', () => {
+      const { drawer, type, slug } = mediaGlanceNavigation(
+        searchParamsOf(
+          '/discover/trending?view=glance&glance_type=show&glance_slug=silo',
+        ),
+      );
+
+      expect(drawer).toBe(MediaGlanceDrawers.Media);
+      expect(type).toBe('show');
+      expect(slug).toBe('silo');
+    });
+
+    it('should resolve an episode glance from its params', () => {
+      const { drawer, slug, season, episode } = mediaGlanceNavigation(
+        searchParamsOf(
+          '/discover/trending?view=glance-episode&glance_slug=silo&glance_season=2&glance_episode=3',
+        ),
+      );
+
+      expect(drawer).toBe(MediaGlanceDrawers.Episode);
+      expect(slug).toBe('silo');
+      expect(season).toBe(2);
+      expect(episode).toBe(3);
+    });
+
+    it('should resolve a season glance from its params', () => {
+      const { drawer, season } = mediaGlanceNavigation(
+        searchParamsOf(
+          '/discover/trending?view=glance-season&glance_slug=silo&glance_season=1',
+        ),
+      );
+
+      expect(drawer).toBe(MediaGlanceDrawers.Season);
+      expect(season).toBe(1);
+    });
+
+    it('should ignore a drawer it does not own', () => {
+      const { drawer } = mediaGlanceNavigation(
+        searchParamsOf('/shows/silo?view=episode&season=2&episode=3'),
+      );
+
+      expect(drawer).toBeNull();
+    });
+
+    it('should report nothing without params', () => {
+      const { drawer, type, slug, season, episode } = mediaGlanceNavigation();
+
+      expect(drawer).toBeNull();
+      expect(type).toBeNull();
+      expect(slug).toBeNull();
+      expect(season).toBeNull();
+      expect(episode).toBeNull();
+    });
+  });
+
+  describe('rejecting malformed params', () => {
+    it.each(['abc', '1.5', ''])(
+      'should refuse "%s" as a season number',
+      (value) => {
+        const { season } = mediaGlanceNavigation(
+          searchParamsOf(
+            `/discover/trending?view=glance-season&glance_slug=silo&glance_season=${value}`,
+          ),
+        );
+
+        expect(season).toBeNull();
+      },
+    );
+
+    it('should refuse an unknown media type', () => {
+      const { type } = mediaGlanceNavigation(
+        searchParamsOf(
+          '/discover/trending?view=glance&glance_type=person&glance_slug=silo',
+        ),
+      );
+
+      expect(type).toBeNull();
+    });
+  });
+
+  describe('building links', () => {
+    it('should open a media glance over the current page', () => {
+      const { buildMediaGlanceLink } = mediaGlanceNavigation();
+
+      const { href, noscroll, replacestate } = buildMediaGlanceLink({
+        type: 'movie',
+        slug: 'heretic-2024',
+      });
+      const target = new URL(href);
+
+      expect(target.pathname).toBe('/discover/trending');
+      expect(target.searchParams.get('view')).toBe(MediaGlanceDrawers.Media);
+      expect(target.searchParams.get('glance_type')).toBe('movie');
+      expect(target.searchParams.get('glance_slug')).toBe('heretic-2024');
+      expect(noscroll).toBe(true);
+      expect(replacestate).toBe(true);
+    });
+
+    it('should open an episode glance over the current page', () => {
+      const { buildEpisodeGlanceLink } = mediaGlanceNavigation();
+
+      const target = new URL(
+        buildEpisodeGlanceLink({ slug: 'silo', season: 2, episode: 3 }).href,
+      );
+
+      expect(target.pathname).toBe('/discover/trending');
+      expect(target.searchParams.get('view')).toBe(MediaGlanceDrawers.Episode);
+      expect(target.searchParams.get('glance_slug')).toBe('silo');
+      expect(target.searchParams.get('glance_season')).toBe('2');
+      expect(target.searchParams.get('glance_episode')).toBe('3');
+    });
+
+    it('should switch drawers when one glance replaces another', () => {
+      searchParamsOf(
+        '/discover/trending?view=glance&glance_type=show&glance_slug=silo',
+      );
+      const { buildSeasonGlanceLink } = mediaGlanceNavigation();
+
+      const target = new URL(
+        buildSeasonGlanceLink({ slug: 'community', season: 1 }).href,
+      );
+      const { drawer, slug, season } = mediaGlanceNavigation(
+        target.searchParams,
+      );
+
+      expect(drawer).toBe(MediaGlanceDrawers.Season);
+      expect(slug).toBe('community');
+      expect(season).toBe(1);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.ts
@@ -50,7 +50,7 @@ function mapToType(value: string | Nil): MediaType | null {
 }
 
 function mapToNumber(value: string | Nil) {
-  if (value == null) {
+  if (value == null || value.trim() === '') {
     return null;
   }
 

--- a/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.ts
@@ -1,7 +1,12 @@
 import { DRAWER_VIEW_PARAM } from '$lib/components/drawer/constants/index.ts';
 import { drawerNavigation } from '$lib/components/drawer/drawerNavigation.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-import { GLANCE_SLUG_PARAM, GLANCE_TYPE_PARAM } from './constants.ts';
+import {
+  GLANCE_EPISODE_PARAM,
+  GLANCE_SEASON_PARAM,
+  GLANCE_SLUG_PARAM,
+  GLANCE_TYPE_PARAM,
+} from './constants.ts';
 import { MediaGlanceDrawers } from './MediaGlanceDrawers.ts';
 
 const mediaGlanceParams = {
@@ -9,12 +14,25 @@ const mediaGlanceParams = {
     [GLANCE_TYPE_PARAM]: '',
     [GLANCE_SLUG_PARAM]: '',
   },
+  [MediaGlanceDrawers.Episode]: {
+    [GLANCE_SLUG_PARAM]: '',
+    [GLANCE_SEASON_PARAM]: '',
+    [GLANCE_EPISODE_PARAM]: '',
+  },
+  [MediaGlanceDrawers.Season]: {
+    [GLANCE_SLUG_PARAM]: '',
+    [GLANCE_SEASON_PARAM]: '',
+  },
 } satisfies Partial<Record<MediaGlanceDrawers, Record<string, string>>>;
 
 function mapToDrawer(value: string | Nil) {
   switch (value) {
     case MediaGlanceDrawers.Media:
       return MediaGlanceDrawers.Media;
+    case MediaGlanceDrawers.Episode:
+      return MediaGlanceDrawers.Episode;
+    case MediaGlanceDrawers.Season:
+      return MediaGlanceDrawers.Season;
     default:
       return null;
   }
@@ -31,6 +49,15 @@ function mapToType(value: string | Nil): MediaType | null {
   }
 }
 
+function mapToNumber(value: string | Nil) {
+  if (value == null) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
 export function mediaGlanceNavigation(searchParams?: URLSearchParams) {
   const { buildDrawerLink, close } = drawerNavigation(mediaGlanceParams);
 
@@ -38,6 +65,8 @@ export function mediaGlanceNavigation(searchParams?: URLSearchParams) {
     drawer: mapToDrawer(searchParams?.get(DRAWER_VIEW_PARAM)),
     type: mapToType(searchParams?.get(GLANCE_TYPE_PARAM)),
     slug: searchParams?.get(GLANCE_SLUG_PARAM) ?? null,
+    season: mapToNumber(searchParams?.get(GLANCE_SEASON_PARAM)),
+    episode: mapToNumber(searchParams?.get(GLANCE_EPISODE_PARAM)),
     close,
     buildMediaGlanceLink: (
       { type, slug }: { type: MediaType; slug: string },
@@ -45,6 +74,25 @@ export function mediaGlanceNavigation(searchParams?: URLSearchParams) {
       buildDrawerLink(MediaGlanceDrawers.Media, {
         [GLANCE_TYPE_PARAM]: type,
         [GLANCE_SLUG_PARAM]: slug,
+      }),
+    buildEpisodeGlanceLink: (
+      { slug, season, episode }: {
+        slug: string;
+        season: number;
+        episode: number;
+      },
+    ) =>
+      buildDrawerLink(MediaGlanceDrawers.Episode, {
+        [GLANCE_SLUG_PARAM]: slug,
+        [GLANCE_SEASON_PARAM]: String(season),
+        [GLANCE_EPISODE_PARAM]: String(episode),
+      }),
+    buildSeasonGlanceLink: (
+      { slug, season }: { slug: string; season: number },
+    ) =>
+      buildDrawerLink(MediaGlanceDrawers.Season, {
+        [GLANCE_SLUG_PARAM]: slug,
+        [GLANCE_SEASON_PARAM]: String(season),
       }),
   };
 }

--- a/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.ts
+++ b/projects/client/src/lib/sections/summary/components/glance/mediaGlanceNavigation.ts
@@ -1,0 +1,50 @@
+import { DRAWER_VIEW_PARAM } from '$lib/components/drawer/constants/index.ts';
+import { drawerNavigation } from '$lib/components/drawer/drawerNavigation.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { GLANCE_SLUG_PARAM, GLANCE_TYPE_PARAM } from './constants.ts';
+import { MediaGlanceDrawers } from './MediaGlanceDrawers.ts';
+
+const mediaGlanceParams = {
+  [MediaGlanceDrawers.Media]: {
+    [GLANCE_TYPE_PARAM]: '',
+    [GLANCE_SLUG_PARAM]: '',
+  },
+} satisfies Partial<Record<MediaGlanceDrawers, Record<string, string>>>;
+
+function mapToDrawer(value: string | Nil) {
+  switch (value) {
+    case MediaGlanceDrawers.Media:
+      return MediaGlanceDrawers.Media;
+    default:
+      return null;
+  }
+}
+
+function mapToType(value: string | Nil): MediaType | null {
+  switch (value) {
+    case 'movie':
+      return 'movie';
+    case 'show':
+      return 'show';
+    default:
+      return null;
+  }
+}
+
+export function mediaGlanceNavigation(searchParams?: URLSearchParams) {
+  const { buildDrawerLink, close } = drawerNavigation(mediaGlanceParams);
+
+  return {
+    drawer: mapToDrawer(searchParams?.get(DRAWER_VIEW_PARAM)),
+    type: mapToType(searchParams?.get(GLANCE_TYPE_PARAM)),
+    slug: searchParams?.get(GLANCE_SLUG_PARAM) ?? null,
+    close,
+    buildMediaGlanceLink: (
+      { type, slug }: { type: MediaType; slug: string },
+    ) =>
+      buildDrawerLink(MediaGlanceDrawers.Media, {
+        [GLANCE_TYPE_PARAM]: type,
+        [GLANCE_SLUG_PARAM]: slug,
+      }),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummaryBody.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummaryBody.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import RatingList from "$lib/components/summary/RatingList.svelte";
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import type { MediaCrew } from "$lib/requests/models/MediaCrew";
+  import type { MediaIntl } from "$lib/requests/models/MediaIntl";
+  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
+  import { useIsRewatching } from "$lib/sections/media-actions/rewatching/useIsRewatching";
+  import { useIsWatchlisted } from "$lib/stores/useIsWatchlisted";
+  import { useWatchCount } from "$lib/stores/useWatchCount";
+  import type { Snippet } from "svelte";
+  import SpoilerSection from "../_internal/SpoilerSection.svelte";
+  import Summary from "../_internal/Summary.svelte";
+  import SummaryPosterTags from "../_internal/SummaryPosterTags.svelte";
+  import SummaryTitle from "../_internal/SummaryTitle.svelte";
+  import { useIsStarted } from "../_internal/useIsStarted";
+  import type { MediaSummaryEntry } from "./models/MediaSummaryEntry";
+  import { useMediaMetaInfo } from "./useMediaMetaInfo";
+
+  const {
+    intl,
+    crew,
+    actions,
+    sideActions,
+    variant = "page",
+    color,
+    titleHref,
+    hasDetails = true,
+    hasReservedRows = false,
+    ratingsDrilldown,
+    ...target
+  }: {
+    intl: MediaIntl;
+    crew: MediaCrew;
+    actions?: Snippet;
+    sideActions?: Snippet;
+    variant?: "page" | "drawer";
+    color?: string;
+    titleHref?: string;
+    hasDetails?: boolean;
+    hasReservedRows?: boolean;
+    ratingsDrilldown?: {
+      href: string;
+      noscroll: boolean;
+      replacestate: boolean;
+    };
+  } & MediaSummaryEntry = $props();
+
+  const media = $derived(target.media);
+  const title = $derived(intl?.title ?? media?.title ?? "");
+
+  const { ratings, isLoading } = $derived(useMediaMetaInfo(target));
+  const { watchCount } = $derived(useWatchCount(target));
+  const { isDropped } = $derived(useIsDropped(media));
+  const { isStarted } = $derived(useIsStarted(target));
+  const { isRewatching } = $derived(useIsRewatching(target));
+  const { isWatchlisted } = $derived(useIsWatchlisted(target));
+</script>
+
+{#snippet tags()}
+  <SummaryPosterTags
+    postCreditsCount={media.postCredits?.length ?? 0}
+    watchCount={$watchCount}
+    isDropped={$isDropped}
+    isStarted={$isStarted}
+    isRewatching={$isRewatching}
+    isWatchlisted={$isWatchlisted}
+  />
+{/snippet}
+
+<Summary {variant} {color} {sideActions}>
+  {#snippet poster()}
+    <SummaryPoster
+      src={media.poster.url.medium}
+      alt={title}
+      href={titleHref}
+      target={titleHref ? "_self" : undefined}
+      {tags}
+    />
+  {/snippet}
+
+
+  {#snippet meta()}
+    <SummaryTitle
+      {title}
+      {crew}
+      href={titleHref}
+      {hasDetails}
+      {hasReservedRows}
+      {...target}
+    />
+
+    <div class="trakt-media-summary-ratings">
+      <RatingList
+        ratings={$ratings}
+        entry={media}
+        drilldown={ratingsDrilldown}
+        isLoading={$isLoading}
+      />
+    </div>
+
+    {@render actions?.()}
+  {/snippet}
+
+  <div class="trakt-media-summary-overview">
+    <SpoilerSection {media} type={media.type}>
+      <p class="secondary small">{intl?.overview ?? media.overview}</p>
+    </SpoilerSection>
+  </div>
+</Summary>
+
+<style lang="scss">
+  :global(.trakt-summary[data-variant="drawer"]) {
+    .trakt-media-summary-ratings {
+      display: flex;
+      justify-content: center;
+
+      min-height: var(--glance-ratings-height);
+    }
+
+    .trakt-media-summary-overview {
+      min-height: var(--glance-overview-height);
+
+      :global(p) {
+        display: -webkit-box;
+
+        line-clamp: var(--glance-overview-lines);
+        -webkit-line-clamp: var(--glance-overview-lines);
+        -webkit-box-orient: vertical;
+
+        overflow: hidden;
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -1,72 +1,51 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import RatingList from "$lib/components/summary/RatingList.svelte";
-  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaCrew } from "$lib/requests/models/MediaCrew";
   import type { MediaIntl } from "$lib/requests/models/MediaIntl";
-  import type { MediaStudio } from "$lib/requests/models/MediaStudio";
-  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
-  import { useIsRewatching } from "$lib/sections/media-actions/rewatching/useIsRewatching";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { useIsWatchlisted } from "$lib/stores/useIsWatchlisted";
-  import { useWatchCount } from "$lib/stores/useWatchCount";
   import { SummaryDrawers } from "$lib/sections/summary/SummaryDrawers.ts";
   import { summaryDrawerNavigation } from "$lib/sections/summary/summaryDrawerNavigation.ts";
   import SocialActivitiesButton from "../../_internal/SocialActivitiesButton.svelte";
-  import SpoilerSection from "../../_internal/SpoilerSection.svelte";
-  import Summary from "../../_internal/Summary.svelte";
-  import SummaryPosterTags from "../../_internal/SummaryPosterTags.svelte";
   import SummaryRateNow from "../../_internal/SummaryRateNow.svelte";
-  import SummaryTitle from "../../_internal/SummaryTitle.svelte";
-  import { useIsStarted } from "../../_internal/useIsStarted";
   import { useIsRateable } from "../../rating/_internal/useIsRateable";
   import type { MediaSummaryEntry } from "../models/MediaSummaryEntry";
-  import { useMediaMetaInfo } from "../useMediaMetaInfo";
+  import MediaSummaryBody from "../MediaSummaryBody.svelte";
   import MediaActions from "./_internal/MediaActions.svelte";
   import SideActions from "./_internal/SideActions.svelte";
 
   const {
     intl,
-    studios,
     crew,
     ...target
   }: {
     intl: MediaIntl;
-    studios: MediaStudio[];
     crew: MediaCrew;
   } & MediaSummaryEntry = $props();
 
   const media = $derived(target.media);
 
-  const { ratings, isLoading } = $derived(useMediaMetaInfo(target));
   const title = $derived(intl?.title ?? media?.title ?? "");
-  const { watchCount } = $derived(useWatchCount(target));
-  const postCreditsCount = $derived(media.postCredits?.length ?? 0);
   const socialTarget = $derived({
     type: target.type,
     slug: media.slug,
   });
 
   const { isRateable } = $derived(useIsRateable(target));
-  const { isDropped } = $derived(useIsDropped(media));
-  const { isStarted } = $derived(useIsStarted(target));
-  const { isRewatching } = $derived(useIsRewatching(target));
-  const { isWatchlisted } = $derived(useIsWatchlisted(target));
 
   const { buildDrawerLink } = summaryDrawerNavigation();
-  const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
+  const ratingsDrilldown = $derived(buildDrawerLink(SummaryDrawers.Ratings));
 </script>
 
-{#snippet tags()}
-  <SummaryPosterTags
-    {postCreditsCount}
-    watchCount={$watchCount}
-    isDropped={$isDropped}
-    isStarted={$isStarted}
-    isRewatching={$isRewatching}
-    isWatchlisted={$isWatchlisted}
-  />
+{#snippet sideActions()}
+  <SideActions {title} type={target.type} {media} />
+{/snippet}
+
+{#snippet actions()}
+  <RenderFor audience="authenticated">
+    <MediaActions {media} {title} />
+    <SocialActivitiesButton target={socialTarget} {title} />
+  </RenderFor>
 {/snippet}
 
 <CoverImageSetter
@@ -83,31 +62,12 @@
   </NavbarStateSetter>
 {/if}
 
-<Summary color={media.colors?.at(0)}>
-  {#snippet poster()}
-    <SummaryPoster src={media.poster.url.medium} alt={title} {tags} />
-  {/snippet}
-
-  {#snippet sideActions()}
-    <SideActions {title} type={target.type} {media} />
-  {/snippet}
-
-  {#snippet meta()}
-    <SummaryTitle {title} {crew} {...target} />
-    <RatingList
-      ratings={$ratings}
-      entry={media}
-      drilldown={ratingsDrawerLink}
-      isLoading={$isLoading}
-    />
-
-    <RenderFor audience="authenticated">
-      <MediaActions {media} {title} />
-      <SocialActivitiesButton target={socialTarget} {title} />
-    </RenderFor>
-  {/snippet}
-
-  <SpoilerSection {media} type={media.type}>
-    <p class="secondary small">{intl.overview ?? media.overview}</p>
-  </SpoilerSection>
-</Summary>
+<MediaSummaryBody
+  {intl}
+  {crew}
+  {actions}
+  {sideActions}
+  color={media.colors?.at(0)}
+  {ratingsDrilldown}
+  {...target}
+/>

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte
@@ -13,6 +13,7 @@
   import { useSeasonEpisodes } from "$lib/sections/lists/stores/useSeasonEpisodes";
   import SeasonProgressCard from "$lib/sections/summary/components/seasons/SeasonProgressCard.svelte";
   import { summaryDrawerNavigation } from "$lib/sections/summary/summaryDrawerNavigation.ts";
+  import type { CardUrlOverride } from "$lib/sections/lists/components/models/CardUrlOverride.ts";
   import { countWatchedEpisodes } from "$lib/utils/media/countWatchedEpisodes";
   import { sumRemainingRuntime } from "$lib/utils/media/sumRemainingRuntime.ts";
   import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
@@ -23,20 +24,25 @@
     currentSeason,
     currentEpisode,
     showSeasonSelector = false,
+    buildEpisodeLink,
   }: {
     show: ShowEntry;
     seasons: Season[];
     currentSeason: number;
     currentEpisode?: number;
     showSeasonSelector?: boolean;
+    buildEpisodeLink?: (
+      target: { season: number; episode: number },
+    ) => CardUrlOverride;
   } = $props();
 
   const { buildEpisodeDrawerLink } = summaryDrawerNavigation();
+  const buildLink = $derived(buildEpisodeLink ?? buildEpisodeDrawerLink);
 
   // Selecting a season jumps to its first episode, keeping the episode drawer
   // open while the list and progress card follow along.
   const buildSeasonLink = (seasonNumber: number) =>
-    buildEpisodeDrawerLink({ season: seasonNumber, episode: 1 }).href;
+    buildLink({ season: seasonNumber, episode: 1 }).href;
 
   const { list: episodes, isLoading } = $derived(
     useSeasonEpisodes(show.slug, currentSeason),
@@ -131,7 +137,7 @@
             watchedBySeason={$watchedBySeason}
             isWatchedLoading={$isWatchedLoading}
             isCurrentEpisode={episode.number === currentEpisode}
-            urlOverride={buildEpisodeDrawerLink({
+            urlOverride={buildLink({
               season: episode.season,
               episode: episode.number,
             })}

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -38,6 +38,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import ManageListsDrawerProvider from "$lib/sections/components/lists-drawer/ManageListsDrawerProvider.svelte";
   import MarkAsWatchedDrawerProvider from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedDrawerProvider.svelte";
+  import MediaGlanceProvider from "$lib/sections/summary/components/glance/MediaGlanceProvider.svelte";
   import MobileNavbar from "$lib/sections/navbar/MobileNavbar.svelte";
   import SideNavbar from "$lib/sections/navbar/SideNavbar.svelte";
   import TopNavbar from "$lib/sections/navbar/TopNavbar.svelte";
@@ -102,6 +103,7 @@
                                   <ActionToastHost />
                                   <AddNoteDrawerProvider />
                                   <ReportDialogProvider />
+                                  <MediaGlanceProvider />
                                   <CoverImage />
                                   <SeasonalFlair />
                                   <EditModeProvider>


### PR DESCRIPTION
Sorry for the chunky delta 😅 A lot of it is plumbing (drawer routing, hosts, glance wiring), the core of the feature re-uses existing components. Split it up into standalone commits, which should make it easier to review one at a time.

## 🎶 Notes 🎶

- Fixes #1997
- ⚠️ Behind the `large-screen-cards` preview flag
- On tablet-lg and desktop, drilled down lists show the regular cover cards instead of the summary variants
  - Summary card code left untouched for now
- Adds a `cover` sizing mode to the grid list, so drilled down cards grow/shrink with the viewport like the section lists
- Clicking a card in that state opens a quick glance drawer instead of going straight to the summary page
  - Reuses the mobile summary body, so it stays in sync with the page
  - Space is reserved up front, no content jumping as it loads
  - Title and poster still link to the summary page
- Episodes and seasons open the existing episode/season drawers, in a slimmed down `glance` variant
- Activity and history cards get the same treatment
- On mouse, hovering a drilled down card expands it into a panel 2 cards wide with the info the summary card used to show
  - Flips towards the start near the window edge
  - Portrait only for now, landscape (up next, continue watching) is gated off
- Adds specs for the card style resolver and the glance navigation params

## 👀 Example 👀

https://github.com/user-attachments/assets/74e0b72b-ce7a-459a-ae28-330d19f27e06

