### PR TITLE
feat(profile): split the up to date progress filter into up to date and ended

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8724,6 +8724,10 @@
       "default": "Up to date",
       "description": "Text for the button that allows users to filter the list to only display shows that are completed. This title should be as short and concise as possible."
     },
+    "button_text_progress_ended": {
+      "default": "Ended",
+      "description": "Text for the button that allows users to filter the list to only display shows that have ended or been canceled. This title should be as short and concise as possible."
+    },
     "button_text_progress_dropped": {
       "default": "Dropped",
       "description": "Text for the button that allows users to filter the list to only display shows that are dropped. This title should be as short and concise as possible."
@@ -8735,6 +8739,10 @@
     "button_label_progress_completed": {
       "default": "View completed shows",
       "description": "Aria-label for the button that allows users to filter the list to only display shows that are completed."
+    },
+    "button_label_progress_ended": {
+      "default": "View ended shows",
+      "description": "Aria-label for the button that allows users to filter the list to only display shows that have ended or been canceled."
     },
     "button_label_progress_dropped": {
       "default": "View dropped shows",

--- a/projects/client/src/lib/components/toggles/ToggleIcon.svelte
+++ b/projects/client/src/lib/components/toggles/ToggleIcon.svelte
@@ -91,6 +91,10 @@
   <TrackIcon />
 {/if}
 
+{#if option.value === "ended"}
+  <FinaleIcon />
+{/if}
+
 {#if option.value === "dropped"}
   <DropIcon />
 {/if}

--- a/projects/client/src/lib/components/toggles/_internal/constants.ts
+++ b/projects/client/src/lib/components/toggles/_internal/constants.ts
@@ -18,7 +18,7 @@ type DiscoverToggleType = DiscoverMode;
 type SocialToggleType = 'following' | 'followers' | 'requests';
 type CommentToggleType = CommentSortType;
 type TriviaToggleType = 'spoilers' | 'no-spoilers';
-type ProgressToggleType = 'in-progress' | 'dropped' | 'completed';
+type ProgressToggleType = 'in-progress' | 'dropped' | 'completed' | 'ended';
 type ActivityToggleType = 'reviews' | 'ratings';
 type LibraryToggleType = 'plex' | 'other';
 type EpisodeTypeToggleType = EpisodeTypeFilter;
@@ -128,6 +128,11 @@ const progress: ToggleDefinition<'progress'> = {
       value: 'completed',
       text: m.button_text_progress_completed,
       label: m.button_label_progress_completed,
+    },
+    {
+      value: 'ended',
+      text: m.button_text_progress_ended,
+      label: m.button_label_progress_ended,
     },
     {
       value: 'in-progress',

--- a/projects/client/src/lib/sections/profile/components/ProgressList.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProgressList.svelte
@@ -16,7 +16,7 @@
   const { current, set, options } = useToggler("progress");
 
   const cta = $derived(
-    $current.value === "in-progress" || $current.value === "completed"
+    $current.value !== "dropped"
       ? {
           type: "progress" as const,
           mediaType: "show" as const,

--- a/projects/client/src/lib/sections/profile/components/ProgressPaginatedList.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProgressPaginatedList.svelte
@@ -4,12 +4,13 @@
   import type { ListSortProps } from "$lib/sections/lists/user/models/ListSortProps.ts";
   import { useSort } from "$lib/sections/lists/user/useSort.ts";
   import ProgressItem from "./_internal/progress/ProgressItem.svelte";
-  import { useProgressList } from "./_internal/useProgressList.ts";
-
-  type ProgressType = "in-progress" | "completed" | "dropped";
+  import {
+    type ProgressListType,
+    useProgressList,
+  } from "./_internal/useProgressList.ts";
 
   type ProgressPaginatedListProps = {
-    type: ProgressType;
+    type: ProgressListType;
   } & ListSortProps;
 
   const { type, sortBy, sortHow }: ProgressPaginatedListProps = $props();

--- a/projects/client/src/lib/sections/profile/components/_internal/progress/ProgressItem.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/progress/ProgressItem.svelte
@@ -4,6 +4,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { ProgressEntry } from "$lib/requests/models/ProgressEntry.ts";
   import MediaItem from "$lib/sections/lists/components/MediaItem.svelte";
+  import type { ProgressListType } from "$lib/sections/profile/components/_internal/useProgressList.ts";
   import DropAction from "$lib/sections/media-actions/drop/DropAction.svelte";
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import type { Snippet } from "svelte";
@@ -11,7 +12,7 @@
   type ProgressItemProps = {
     entry: ProgressEntry;
     style?: "cover" | "summary";
-    type: "in-progress" | "completed" | "dropped";
+    type: ProgressListType;
     sortTag?: Snippet;
   };
 

--- a/projects/client/src/lib/sections/profile/components/_internal/useProgressList.spec.ts
+++ b/projects/client/src/lib/sections/profile/components/_internal/useProgressList.spec.ts
@@ -1,3 +1,4 @@
+import { HiddenShowProgressResponseMock } from '$mocks/data/users/response/HiddenShowProgressResponseMock.ts';
 import { UpNextResponseMock } from '$mocks/data/sync/response/UpNextResponseMock.ts';
 import { server } from '$mocks/server.ts';
 import type { ProgressEntry } from '$lib/requests/models/ProgressEntry.ts';
@@ -12,6 +13,7 @@ const [baseEntry] = UpNextResponseMock;
 
 const ENDED_SHOW = 'ended-show';
 const AIRING_SHOW = 'airing-show';
+const DROPPED_SHOW = 'dropped-show';
 
 function withShow(
   { status, slug, trakt }: {
@@ -48,6 +50,30 @@ function serveCompletedBucket() {
   );
 }
 
+/**
+ * The dropped bucket comes from a different endpoint and must not be split on
+ * status, so it is served an ended show: if the status predicate ever leaked
+ * onto this branch, the show would vanish and this fails.
+ */
+function serveDroppedBucket() {
+  const [base] = HiddenShowProgressResponseMock;
+
+  server.use(
+    http.get('http://localhost/users/hidden/dropped*', () =>
+      HttpResponse.json([
+        {
+          ...base,
+          show: {
+            ...base.show,
+            status: 'ended',
+            title: DROPPED_SHOW,
+            ids: { ...base.show.ids, slug: DROPPED_SHOW, trakt: 103 },
+          },
+        },
+      ])),
+  );
+}
+
 function listTitles(type: ProgressListType) {
   return runQuery({
     factory: () => useProgressList({ type }).list,
@@ -69,6 +95,12 @@ describe('store: useProgressList', () => {
 
   it('should keep only finished shows under "ended"', async () => {
     expect(await listTitles('ended')).toEqual([ENDED_SHOW]);
+  });
+
+  it('should not filter the dropped bucket by status', async () => {
+    serveDroppedBucket();
+
+    expect(await listTitles('dropped')).toEqual([DROPPED_SHOW]);
   });
 
   it('should not filter by status on the in progress bucket', async () => {

--- a/projects/client/src/lib/sections/profile/components/_internal/useProgressList.spec.ts
+++ b/projects/client/src/lib/sections/profile/components/_internal/useProgressList.spec.ts
@@ -1,0 +1,80 @@
+import { UpNextResponseMock } from '$mocks/data/sync/response/UpNextResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import type { ProgressEntry } from '$lib/requests/models/ProgressEntry.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { setAuthorization } from '$test/beds/store/renderStore.ts';
+import type { UpNextResponse } from '@trakt/api';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type ProgressListType, useProgressList } from './useProgressList.ts';
+
+const [baseEntry] = UpNextResponseMock;
+
+const ENDED_SHOW = 'ended-show';
+const AIRING_SHOW = 'airing-show';
+
+function withShow(
+  { status, slug, trakt }: {
+    status: string;
+    slug: string;
+    trakt: number;
+  },
+): UpNextResponse {
+  return {
+    ...baseEntry,
+    show: {
+      ...baseEntry.show,
+      status,
+      title: slug,
+      ids: { ...baseEntry.show.ids, slug, trakt },
+    },
+  };
+}
+
+function serveCompletedBucket() {
+  server.use(
+    http.get(
+      'http://localhost/sync/progress/up_next*',
+      () =>
+        HttpResponse.json([
+          withShow({ status: 'ended', slug: ENDED_SHOW, trakt: 101 }),
+          withShow({
+            status: 'returning series',
+            slug: AIRING_SHOW,
+            trakt: 102,
+          }),
+        ]),
+    ),
+  );
+}
+
+function listTitles(type: ProgressListType) {
+  return runQuery({
+    factory: () => useProgressList({ type }).list,
+    waitFor: (entries: ProgressEntry[]) => entries.length > 0,
+    mapper: (entries: ProgressEntry[]) =>
+      entries.map((entry) => entry.show.title),
+  });
+}
+
+describe('store: useProgressList', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+    serveCompletedBucket();
+  });
+
+  it('should keep only still airing shows under "up to date"', async () => {
+    expect(await listTitles('completed')).toEqual([AIRING_SHOW]);
+  });
+
+  it('should keep only finished shows under "ended"', async () => {
+    expect(await listTitles('ended')).toEqual([ENDED_SHOW]);
+  });
+
+  it('should not filter by status on the in progress bucket', async () => {
+    expect(await listTitles('in-progress')).toEqual([
+      ENDED_SHOW,
+      AIRING_SHOW,
+    ]);
+  });
+});

--- a/projects/client/src/lib/sections/profile/components/_internal/useProgressList.ts
+++ b/projects/client/src/lib/sections/profile/components/_internal/useProgressList.ts
@@ -9,11 +9,19 @@ import type { SortBy } from '$lib/sections/lists/user/models/SortBy.ts';
 import type {
   SortDirection,
 } from '$lib/sections/lists/user/models/SortDirection.ts';
+import { hasEnded } from '$lib/utils/media/hasEnded.ts';
+import { map } from 'rxjs';
 import { DEFAULT_PAGE_SIZE } from '../../../../utils/constants.ts';
 import { usePaginatedListQuery } from '../../../lists/stores/usePaginatedListQuery.ts';
 
+export type ProgressListType =
+  | 'in-progress'
+  | 'completed'
+  | 'ended'
+  | 'dropped';
+
 type UseProgressListProps = {
-  type: 'in-progress' | 'completed' | 'dropped';
+  type: ProgressListType;
   limit?: number;
   sortBy?: SortBy;
   sortHow?: SortDirection;
@@ -32,7 +40,14 @@ function typeToQuery(
         sortBy: props.sortBy,
         sortHow: props.sortHow,
       }) as InfiniteQuery<ProgressEntry>;
+    /**
+     * Up to date and ended are the two halves of one API bucket. The up next
+     * endpoint has no status filter, so both ask for `completed` and split the
+     * response on the show status it already returns. Sharing the query also
+     * means toggling between the two costs no extra request.
+     */
     case 'completed':
+    case 'ended':
       return progressWatchedQuery({
         limit,
         intent: 'completed',
@@ -46,6 +61,15 @@ function typeToQuery(
   }
 }
 
+function toStatusPredicate(
+  type: ProgressListType,
+): (entry: ProgressEntry) => boolean {
+  if (type === 'completed') return (entry) => !hasEnded(entry.show.status);
+  if (type === 'ended') return (entry) => hasEnded(entry.show.status);
+
+  return () => true;
+}
+
 export function useProgressList(props: UseProgressListProps) {
   const { list, isLoading: baseLoading, ...rest } = usePaginatedListQuery(
     typeToQuery(props),
@@ -55,8 +79,13 @@ export function useProgressList(props: UseProgressListProps) {
     getTargets: progressEntryTargets,
   });
 
+  const isInBucket = toStatusPredicate(props.type);
+
   return {
-    list: list.pipe(overlay.operator),
+    list: list.pipe(
+      map((entries) => entries.filter(isInBucket)),
+      overlay.operator,
+    ),
     isLoading: withOverlayLoading(baseLoading, overlay.intlLoading$),
     ...rest,
   };

--- a/projects/client/src/lib/utils/media/hasEnded.spec.ts
+++ b/projects/client/src/lib/utils/media/hasEnded.spec.ts
@@ -1,0 +1,35 @@
+import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
+import { describe, expect, it } from 'vitest';
+import { hasEnded } from './hasEnded.ts';
+
+describe('util: hasEnded', () => {
+  it('should return true for shows that wrapped up', () => {
+    expect(hasEnded('ended')).toBe(true);
+  });
+
+  it('should return true for shows that were canceled', () => {
+    expect(hasEnded('canceled')).toBe(true);
+  });
+
+  it('should return false for shows that are still airing', () => {
+    const airingStatuses: MediaStatus[] = [
+      'returning series',
+      'continuing',
+      'in production',
+      'planned',
+      'post production',
+      'rumored',
+      'upcoming',
+      'released',
+      'pilot',
+    ];
+
+    airingStatuses.forEach((status) => {
+      expect(hasEnded(status)).toBe(false);
+    });
+  });
+
+  it('should treat an unknown status as still airing', () => {
+    expect(hasEnded('unknown')).toBe(false);
+  });
+});

--- a/projects/client/src/lib/utils/media/hasEnded.ts
+++ b/projects/client/src/lib/utils/media/hasEnded.ts
@@ -1,0 +1,15 @@
+import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
+
+/**
+ * Statuses that mean a show will not air new episodes. Every other status -
+ * an unknown one included - counts as still airing, so a show only leaves the
+ * "up to date" bucket when Trakt is explicit about it being over.
+ */
+const ENDED_STATUSES: ReadonlySet<MediaStatus> = new Set([
+  'ended',
+  'canceled',
+]);
+
+export function hasEnded(status: MediaStatus): boolean {
+  return ENDED_STATUSES.has(status);
+}


### PR DESCRIPTION
Closes #3210

### Why

The `Up to date` filter in Profile > Progress answers two questions at once. It lists every show whose aired episodes are all watched, so a series that wrapped up years ago sits next to a series that is still airing and simply has nothing unwatched right now. From the progress list there is no way to tell which shows are actually finished without opening each one.

### What changed

`Up to date` becomes two filters: **Up to date** (still airing, caught up) and **Ended** (status `ended` or `canceled`). `In progress` and `Dropped` are untouched.

No API change is involved. `up_next_nitro` already returns the full show object with `status`, and `mapToShowEntry` already maps it onto `ProgressEntry.show.status` - the value was simply unused. Verified against the live API:

```
GET /sync/progress/up_next_nitro?intent=completed&limit=100
  16 shows -> 10 ended, 6 returning series, 0 without a status
```

- **Both filters share one query.** `typeToQuery` maps `completed` and `ended` to the same `progressWatchedQuery({ intent: 'completed' })`, so the dependencies match and toggling between them costs no request. The split happens in the rxjs pipe, before the intl overlay, so discarded entries never get an overlay fetch.
- **`hasEnded` lands in `lib/utils/media/`** next to `hasAired`, since it is a question about a show rather than about this screen. An unknown status counts as still airing, which preserves today's behaviour.
- **`ProgressListType` is exported from `useProgressList.ts`** and reused by `ProgressPaginatedList` and `ProgressItem`. The union was previously written out three times and would have drifted.
- **The progress CTA condition became `!== 'dropped'`.** It was `in-progress || completed`, which is the same set today, but as written it would have silently left `Ended` with no CTA and no empty-state copy.

### Localisation

Two new keys in `i18n/meta/en.json`, `button_text_progress_ended` and `button_label_progress_ended`, following the existing `button_*_progress_*` pattern with descriptions. They ship English-only and pick up translations on the next Crowdin sync.

I deliberately did not touch `button_label_progress_completed` ("View completed shows"). With the split its wording is arguably stale, but changing it would invalidate that string across every locale for a small gain. Happy to change it if you would rather.

### Testing

- `hasEnded.spec.ts` - covers ended, canceled, the nine airing statuses, and unknown.
- `useProgressList.spec.ts` - serves a completed bucket holding one ended and one airing show through MSW, then asserts `Up to date` keeps only the airing one, `Ended` keeps only the finished one, and neither `In progress` nor `Dropped` filters by status. The dropped case is served an ended show on purpose, so the predicate leaking onto that branch would make the show vanish. Confirmed the split assertions fail when the predicate is inverted.

Both new files land at 100% line coverage.

```
deno task check    0 errors, 0 warnings
eslint             clean on all changed files
vitest             8 passed (2 files)
```

Full suite: 3134 passed, 1 unrelated timeout in `hooks.client.spec.ts` (a filesystem walk that passes in isolation on my machine).


### An empty segment, caught by running it

The progress toggler renders in its icon variant, and `ToggleIcon` resolves the glyph from the option value, so the new filter first shipped as a blank segment - the option was there and clickable, just invisible. Second commit maps `ended` to `FinaleIcon`, the checkered flag already used for season finales. The episode type toggler that owns it never shares a surface with this one.

### Screenshots

Captured against my own account on `dev:contrib`, so these are live API responses, not fixtures.

**`Up to date` - 6 shows, all still airing**

<!-- (1/4) ARRASTE AQUI: screenshots/01-progress-up-to-date.png -- depois apague esta linha -->
<img width="2800" height="1900" alt="01-progress-up-to-date" src="https://github.com/user-attachments/assets/bb86c016-2e72-40f9-8f8e-22f7b9fd593b" />


**`Ended` - 10 shows, all finished**

<!-- (2/4) ARRASTE AQUI: screenshots/02-progress-ended.png -- depois apague esta linha -->
<img width="2800" height="1900" alt="02-progress-ended" src="https://github.com/user-attachments/assets/34755ff6-8518-4e8c-ad1a-000474af10a7" />


**`In progress` - 14 shows, unchanged by this PR**

<!-- (3/4) ARRASTE AQUI: screenshots/03-progress-in-progress.png -- depois apague esta linha -->
<img width="2800" height="1900" alt="03-progress-in-progress" src="https://github.com/user-attachments/assets/5be5a07c-922d-45e1-bc12-499cb2d699b7" />


**`Dropped` - unchanged by this PR**

<!-- (4/4) ARRASTE AQUI: screenshots/04-progress-dropped.png -- depois apague esta linha -->
<img width="2800" height="1900" alt="04-progress-dropped" src="https://github.com/user-attachments/assets/dc1182bf-8f42-4eaf-9210-32e775e042f4" />


Every show rendered under each filter was cross-checked against the status the API returned for it:

```
UI "up to date" (6)                        UI "ended" (10)
  paradise-2025      returning series        grace-and-frankie   ended
  georgie-mandy-...  returning series        i-will-find-you     ended
  the-rookie-2018    returning series        better-call-saul    ended
  the-pitt           returning series        the-big-bang-theory ended
  old-dog-new-tricks returning series        narcos              ended
  untamed            returning series        sherlock            ended
                                             hannibal            ended
                                             sons-of-anarchy     ended
                                             breaking-bad        ended
                                             house               ended
```

16 of 16 correct, and 6 + 10 is exactly the 16 the single `Up to date` filter listed before - nothing is dropped by the partition.



