### PR TITLE
Toast: email unsubscribe message

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -10771,6 +10771,14 @@
     "text_login_rate_limited_message": {
       "default": "Please wait a moment and try again.",
       "description": "Snackbar message when sign in is refused because the viewer is rate limited."
+    },
+    "text_email_unsubscribe_title": {
+      "default": "Unsubscribed",
+      "description": "Snackbar title confirming the viewer unsubscribed from Trakt emails via an email footer link."
+    },
+    "text_email_unsubscribe_message": {
+      "default": "You'll no longer receive these emails from Trakt.",
+      "description": "Snackbar message confirming the email unsubscribe was successful."
     }
   }
 }

--- a/projects/client/src/lib/features/email-unsubscribe/EmailUnsubscribeSnackbar.svelte
+++ b/projects/client/src/lib/features/email-unsubscribe/EmailUnsubscribeSnackbar.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { page } from "$app/state";
+  import Snackbar from "$lib/components/snackbar/Snackbar.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { time } from "$lib/utils/timing/time.ts";
+  import { onMount } from "svelte";
+
+  // Must match the ref the legacy Rails unsubscribe endpoints append when they
+  // redirect here after flipping the user's email preference.
+  const UNSUBSCRIBE_REF = "trakt-og-unsubscribe";
+  const DISMISS_DURATION = time.seconds(10);
+
+  let isConfirmationVisible = $state(false);
+
+  onMount(() => {
+    if (page.url.searchParams.get("ref") !== UNSUBSCRIBE_REF) {
+      return;
+    }
+
+    isConfirmationVisible = true;
+
+    const url = new URL(page.url);
+    url.searchParams.delete("ref");
+    goto(url, { replaceState: true });
+  });
+</script>
+
+{#if isConfirmationVisible}
+  <Snackbar
+    open
+    title={m.text_email_unsubscribe_title()}
+    message={m.text_email_unsubscribe_message()}
+    dismissDurationMs={DISMISS_DURATION}
+    onDismiss={() => (isConfirmationVisible = false)}
+  />
+{/if}

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
   import ConfirmationProvider from "$lib/features/confirmation/ConfirmationProvider.svelte";
   import { DeploymentEndpoint } from "$lib/features/deployment/DeploymentEndpoint.js";
   import EditModeProvider from "$lib/features/edit-mode/EditModeProvider.svelte";
+  import EmailUnsubscribeSnackbar from "$lib/features/email-unsubscribe/EmailUnsubscribeSnackbar.svelte";
   import ErrorProvider from "$lib/features/errors/ErrorProvider.svelte";
   import FeatureFlagProvider from "$lib/features/feature-flag/FeatureFlagProvider.svelte";
   import FilterProvider from "$lib/features/filters/FilterProvider.svelte";
@@ -143,6 +144,7 @@
                                         </RenderFor>
 
                                         <LoginErrorSnackbar />
+                                        <EmailUnsubscribeSnackbar />
                                         <QueryDevtools
                                           client={data.queryClient}
                                           buttonPosition="bottom-right"


### PR DESCRIPTION
# Why

Every unsubscribe link in Trakt emails flips the user's email preference server-side and then redirects to the web app with `?ref=trakt-og-unsubscribe` — where nothing acknowledged it. The unsubscribe silently works, but to the user it looks like the link goes nowhere ([forum report](https://forums.trakt.tv/t/email-unsubscribe-links-transports-nowhere-effective/107201)).

# What

- New `EmailUnsubscribeSnackbar`, mounted in the root layout next to `LoginErrorSnackbar`. When the app loads with `ref=trakt-og-unsubscribe` it shows a confirmation snackbar and strips the param via `replaceState` so a reload or shared link won't re-trigger it.
- Auto-dismisses after 10 seconds through the existing `dismissDurationMs` countdown ring, and can be dismissed manually.
- Adds `text_email_unsubscribe_title` / `text_email_unsubscribe_message` to `i18n/meta/en.json`. The message stays generic because the Rails redirect uses the same ref for the global unsubscribe and every per-type one.

Built on the plain `Snackbar` component rather than the action-toast store, since that store is gated behind the `ActionConfirmations` feature flag and would silently drop the toast for most users.

# Screenshots

<img width="1111" height="539" alt="image" src="https://github.com/user-attachments/assets/ff64ddfc-9273-4794-a3f8-ce588ad5a050" />