### PR TITLE
feat(watched): open watch again from the watched check

### DIFF
--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntlProvider.spec.ts
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntlProvider.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { MarkAsWatchedButtonIntlProvider } from './MarkAsWatchedButtonIntlProvider.ts';
+
+const TITLE = 'Silo';
+
+describe('MarkAsWatchedButtonIntlProvider', () => {
+  describe('label', () => {
+    it('should offer removal for a watched title', () => {
+      const label = MarkAsWatchedButtonIntlProvider.label({
+        title: TITLE,
+        isWatched: true,
+        isRewatching: false,
+      });
+
+      expect(label).toContain(TITLE);
+      expect(label).toMatch(/history/i);
+    });
+
+    it('should not offer removal while re-watching', () => {
+      const label = MarkAsWatchedButtonIntlProvider.label({
+        title: TITLE,
+        isWatched: true,
+        isRewatching: true,
+      });
+
+      expect(label).toContain(TITLE);
+      expect(label).not.toMatch(/history/i);
+    });
+
+    it('should match the text it labels', () => {
+      const meta = { title: TITLE, isWatched: true, isRewatching: true };
+
+      expect(MarkAsWatchedButtonIntlProvider.text(meta)).toMatch(/again/i);
+      expect(MarkAsWatchedButtonIntlProvider.label(meta)).not.toMatch(
+        /history/i,
+      );
+    });
+  });
+
+  describe('text', () => {
+    it('should offer to track an unwatched title', () => {
+      expect(
+        MarkAsWatchedButtonIntlProvider.text({
+          title: TITLE,
+          isWatched: false,
+          isRewatching: false,
+        }),
+      ).not.toMatch(/history|again/i);
+    });
+
+    it('should offer removal for a watched title', () => {
+      expect(
+        MarkAsWatchedButtonIntlProvider.text({
+          title: TITLE,
+          isWatched: true,
+          isRewatching: false,
+        }),
+      ).toMatch(/history/i);
+    });
+  });
+});

--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntlProvider.ts
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntlProvider.ts
@@ -5,8 +5,8 @@ import type {
 } from './MarkAsWatchedButtonIntl.ts';
 
 export const MarkAsWatchedButtonIntlProvider: MarkAsWatchedButtonIntl = {
-  label: ({ isWatched, title }: MarkAsWatchedButtonMeta) =>
-    isWatched
+  label: ({ isWatched, isRewatching, title }: MarkAsWatchedButtonMeta) =>
+    isWatched && !isRewatching
       ? m.button_label_remove_from_watched({ title })
       : m.button_label_mark_as_watched({ title }),
   text: ({ isWatched, isRewatching }: MarkAsWatchedButtonMeta) => {

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
@@ -3,6 +3,7 @@
   import type { MarkAsWatchedButtonIntl } from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntl";
   import { MarkAsWatchedButtonIntlProvider } from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntlProvider";
   import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import {
@@ -25,6 +26,7 @@
   const { isMarkingAsWatched, isWatchable, isWatched, removeWatched } =
     $derived(useMarkAsWatched({ ...target, isToastEnabled: false }));
 
+  const { user } = useUser();
   const { confirm } = useConfirm();
   const openMarkAsWatchedDrawer = $derived(() => {
     markAsWatchedDrawerStore.open({
@@ -40,8 +42,20 @@
     }),
   );
 
+  /**
+   * A filled check reads as "done", so tapping it again should mean "watched
+   * again", not "undo everything". Removal lives in the overflow menu, where
+   * destructive actions belong.
+   *
+   * When the account opts out of multiple plays there is no second play to
+   * record, so the check keeps its removal role.
+   */
+  const isWatchAgain = $derived(
+    $isWatched && $user.preferences.hasWatchAgain,
+  );
+
   const handler = (ev: MouseEvent) => {
-    if ($isWatched) {
+    if ($isWatched && !isWatchAgain) {
       confirmRemoveWatched(ev);
       return;
     }
@@ -53,7 +67,11 @@
 <trakt-track-action class:is-watchable={isWatchable}>
   <ActionButton
     disabled={$isMarkingAsWatched || !isWatchable}
-    label={i18n.label({ title, isWatched: $isWatched, isRewatching: false })}
+    label={i18n.label({
+      title,
+      isWatched: $isWatched,
+      isRewatching: isWatchAgain,
+    })}
     onclick={handler}
     variant={$isWatched ? "primary" : "secondary"}
     color="purple"

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
@@ -55,7 +55,7 @@
   );
 
   const handler = (ev: MouseEvent) => {
-    if ($isWatched && !isWatchAgain) {
+    if ($isWatched && !$user.preferences.hasWatchAgain) {
       confirmRemoveWatched(ev);
       return;
     }

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
@@ -40,6 +40,16 @@
     {title}
     {show}
   />
+
+  <!-- The check now records another play, so removal belongs here. -->
+  <MarkAsWatchedAction
+    style="dropdown-item"
+    type="episode"
+    media={episode}
+    mode="hybrid"
+    {title}
+    {show}
+  />
 {/if}
 
 <EpisodeSideActions

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -56,6 +56,15 @@
     {title}
     {media}
   />
+
+  <!-- The check now records another play, so removal belongs here. -->
+  <MarkAsWatchedAction
+    style="dropdown-item"
+    type={media.type}
+    mode="hybrid"
+    {title}
+    {media}
+  />
 {/if}
 
 {#if show}


### PR DESCRIPTION
Closes #3213

### Why

On a watched title, the purple check in the action bar is the natural "I watched this again" affordance. Clicking it opens the **Remove from history?** confirmation. A filled check reads as "done", so clicking it again reads as "done again", not "undo everything" - and re-watching is two clicks deep in the overflow while the most prominent control is wired to the destructive action.

### What changed

**`TrackAction`** - on a watched title the check now opens the same date drawer the overflow's **Watch again** already used. Accounts with multiple plays disabled keep the removal confirmation, reusing the `hasWatchAgain` gate `MarkAsWatchedButton` already applies. One derived value drives both the handler and the label, so they cannot drift.

**Both overflow menus** - `MediaPopupActions` and `EpisodePopupActions` gain a `mode="hybrid"` entry, which renders as **Remove from History**. The check stops removing for accounts with multiple plays on, so removal needed a home; the overflow is where the other destructive actions already live. Accounts with multiple plays off now reach removal from either place - the check keeps it, and the overflow gains it.

**`MarkAsWatchedButtonIntlProvider`** - a bug found on the way. `label` ignored `isRewatching`, so the overflow's **Watch again** announced itself to a screen reader as *"Remove "X" from your History"*. `text` already had the right rule (`isWatched && !isRewatching`); `label` now uses it too. Without this the new check would have inherited the same wrong label.

This covers movies, shows and episodes in one change, since all three action bars share `TrackAction`. No API change, and no new translatable strings.

### Testing

Verified against my own account on `dev:contrib`, driving a real browser.

Exercised each of the three surfaces on both sides of the gate, with the button confirmed to be in its watched state first:

| | multiple plays on | multiple plays off |
| --- | --- | --- |
| movie | date drawer | removal confirmation |
| show | date drawer | removal confirmation |
| episode | (label flips) | (label flips) |

The button label is derived from the same value as the handler, so it moves with the branch taken: `Mark "…" as watched` when the check records a play, `Remove "…" from your History` when it removes. That flip was observed on all three surfaces; the drawer and the confirmation were additionally observed on the movie and show pages.

The overflow renders **Watch again…** and **Remove from History** together.

The account used has no `browsing` preferences at all, so `watch_only_once` is absent and the client defaults it to `true`. I injected it per-run in the browser to exercise both sides of the gate, rather than changing the account.

`MarkAsWatchedButtonIntlProvider.spec.ts` is new and covers the label/text pair, including that the re-watching label no longer mentions history. Confirmed the two label assertions fail if the `isRewatching` guard is reverted.

```
vitest             5 passed (1 file)
deno task check    0 errors, 0 warnings
eslint             clean on every changed file
```

### Screenshots

<img width="2800" height="1900" alt="01-check-opens-watch-again" src="https://github.com/user-attachments/assets/448e342f-39f7-4114-991d-47f434f6eaa4" />

**Multiple plays on: the check opens the date drawer**

<img width="2800" height="1900" alt="02-overflow" src="https://github.com/user-attachments/assets/0617f8f1-0d27-418e-a8e7-af9aa2158d2f" />


**The overflow carries Watch again and Remove from History**

<img width="2800" height="1900" alt="03-multiple-plays-off" src="https://github.com/user-attachments/assets/8dbb0051-a85b-4044-812b-c2218b317110" />


**Multiple plays off: the check still confirms removal**

### Not included

The Android issue this mirrors (trakt/trakt-android#355) also covers season context menus, clickable watched chips on season posters, and a season re-watch fix. None of those surfaces exist on web - there is no season action bar, and the only two `TrackAction` call sites are the media and episode bars - so this PR is the part that ports.

