### PR TITLE
feat(watched): show the play count on watched cards

### DIFF
--- a/projects/client/src/lib/components/media/tags/IndicatorTag.spec.ts
+++ b/projects/client/src/lib/components/media/tags/IndicatorTag.spec.ts
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import IndicatorTag from './IndicatorTag.svelte';
+
+describe('IndicatorTag', () => {
+  describe('watched', () => {
+    it('should stay a plain badge for a single play', () => {
+      const { container } = render(IndicatorTag, {
+        props: { indicator: 'watched', count: 1 },
+      });
+
+      expect(container.textContent?.trim()).toBe('');
+      expect(container.querySelector('.has-count')).toBeNull();
+    });
+
+    it('should stay a plain badge when the count is unknown', () => {
+      const { container } = render(IndicatorTag, {
+        props: { indicator: 'watched' },
+      });
+
+      expect(container.textContent?.trim()).toBe('');
+      expect(container.querySelector('.has-count')).toBeNull();
+    });
+
+    it('should show how many plays once a title was rewatched', () => {
+      const { container } = render(IndicatorTag, {
+        props: { indicator: 'watched', count: 3 },
+      });
+
+      expect(container.textContent).toContain('3');
+      expect(container.querySelector('.has-count')).not.toBeNull();
+    });
+  });
+
+  it('should never count a badge that is not about being watched', () => {
+    const { container } = render(IndicatorTag, {
+      props: { indicator: 'dropped', count: 4 },
+    });
+
+    expect(container.textContent?.trim()).toBe('');
+    expect(container.querySelector('.has-count')).toBeNull();
+  });
+});

--- a/projects/client/src/lib/components/media/tags/IndicatorTag.svelte
+++ b/projects/client/src/lib/components/media/tags/IndicatorTag.svelte
@@ -8,10 +8,18 @@
   const {
     variant = "full",
     indicator,
+    count = 0,
   }: {
     variant?: "partial" | "full";
     indicator: "watched" | "dropped" | "rewatching" | "watchlisted";
+    count?: number;
   } = $props();
+
+  /**
+   * A single play keeps the plain square badge, so the common case is pixel
+   * identical. Only a rewatch earns the extra width the number needs.
+   */
+  const hasCount = $derived(indicator === "watched" && count > 1);
 </script>
 
 {#snippet icon()}
@@ -26,13 +34,21 @@
   {/if}
 {/snippet}
 
-<trakt-indicator-tag data-variant={variant} data-indicator={indicator}>
+<trakt-indicator-tag
+  data-variant={variant}
+  data-indicator={indicator}
+  class:has-count={hasCount}
+>
   <StemTag
     --color-background-stem-tag="var(--color-background-indicator-tag)"
     --color-foreground-stem-tag="var(--color-text-indicator-tag)"
     --border-radius-tag="var(--border-radius-s)"
     {icon}
-  />
+  >
+    {#if hasCount}
+      <p class="bold count">{count}</p>
+    {/if}
+  </StemTag>
 </trakt-indicator-tag>
 
 <style>
@@ -51,6 +67,17 @@
 
     &[data-indicator="rewatching"] {
       --glyph-scale: 1.6;
+    }
+
+    &.has-count :global(.trakt-tag) {
+      width: auto;
+      gap: var(--ni-2);
+      padding-inline: var(--ni-3);
+
+      .count {
+        font-size: var(--ni-8);
+        line-height: var(--ni-10);
+      }
     }
 
     :global(.trakt-tag) {

--- a/projects/client/src/lib/components/media/tags/PosterTags.svelte
+++ b/projects/client/src/lib/components/media/tags/PosterTags.svelte
@@ -53,7 +53,7 @@
 {:else if active === "watched"}
   <WatchedTag
     {variant}
-    count={full?.watchCount}
+    count={props.watchCount}
     i18n={full?.i18n}
     link={full?.historyLink}
     onclick={full?.onWatchCountClick}

--- a/projects/client/src/lib/components/media/tags/WatchedTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchedTag.svelte
@@ -23,5 +23,5 @@
 {#if variant === "full"}
   <WatchCountTag {count} {i18n} {link} {onclick} />
 {:else}
-  <IndicatorTag variant="full" indicator="watched" />
+  <IndicatorTag variant="full" indicator="watched" {count} />
 {/if}

--- a/projects/client/src/lib/components/media/tags/_internal/PosterTagsProps.ts
+++ b/projects/client/src/lib/components/media/tags/_internal/PosterTagsProps.ts
@@ -7,6 +7,7 @@ type SharedPosterTagsProps = {
   isPartiallyWatched?: boolean;
   isDropped?: boolean;
   isWatchlisted?: boolean;
+  watchCount?: number;
 };
 
 type DefaultPosterTagsProps = SharedPosterTagsProps & {
@@ -16,7 +17,6 @@ type DefaultPosterTagsProps = SharedPosterTagsProps & {
 type FullPosterTagsProps = SharedPosterTagsProps & {
   variant: 'full';
   i18n: TagIntl;
-  watchCount: number;
   postCreditsCount: number;
   historyLink?: DrawerLinkProps;
   seasonsLink?: DrawerLinkProps;

--- a/projects/client/src/lib/components/media/tags/_internal/PosterTagsProps.ts
+++ b/projects/client/src/lib/components/media/tags/_internal/PosterTagsProps.ts
@@ -7,16 +7,19 @@ type SharedPosterTagsProps = {
   isPartiallyWatched?: boolean;
   isDropped?: boolean;
   isWatchlisted?: boolean;
-  watchCount?: number;
 };
 
 type DefaultPosterTagsProps = SharedPosterTagsProps & {
   variant?: 'default';
+  // Optional on a card: the badge only grows for a rewatch, so a caller that
+  // has no count to hand renders the same square badge as before.
+  watchCount?: number;
 };
 
 type FullPosterTagsProps = SharedPosterTagsProps & {
   variant: 'full';
   i18n: TagIntl;
+  watchCount: number;
   postCreditsCount: number;
   historyLink?: DrawerLinkProps;
   seasonsLink?: DrawerLinkProps;

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -13,6 +13,7 @@
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { useIsRewatching } from "$lib/sections/media-actions/rewatching/useIsRewatching";
+  import { useWatchCount } from "$lib/stores/useWatchCount";
   import { useIsWatchlisted } from "$lib/stores/useIsWatchlisted";
   import type { Snippet } from "svelte";
   import type { MediaCardProps } from "../components/models/MediaCardProps";
@@ -38,6 +39,7 @@
     useIsWatched({ type, media }),
   );
   const { isRewatching } = $derived(useIsRewatching({ type, media }));
+  const { watchCount } = $derived(useWatchCount({ type, media }));
   const { isWatchlisted } = $derived(useIsWatchlisted({ type, media }));
   const { isDropped } = $derived(useIsDropped(media));
 
@@ -73,6 +75,7 @@
   <PosterTags
     isRewatching={$isRewatching}
     isWatched={$isWatched}
+    watchCount={$watchCount}
     isPartiallyWatched={$isPartiallyWatched}
     isWatchlisted={$isWatchlisted}
     isDropped={$isDropped}

--- a/projects/client/src/lib/stores/useWatchCount.ts
+++ b/projects/client/src/lib/stores/useWatchCount.ts
@@ -1,14 +1,19 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
-import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 import { getShowWatchState } from '$lib/utils/media/getShowWatchState.ts';
 import { combineLatest, map } from 'rxjs';
 
 export type UseWatchCountProps =
   | { type: 'movie'; media: MediaEntry }
-  | { type: 'show'; media: ShowEntry }
-  | { type: 'episode'; show: ShowEntry; episode: EpisodeEntry };
+  // The episode count is optional so list cards, which carry a leaner entry,
+  // can ask too. Without it a show cannot read as fully watched, and
+  // `getShowWatchState` already returns no count in that case.
+  | {
+    type: 'show';
+    media: MediaEntry & Partial<{ episode: { count: number } }>;
+  }
+  | { type: 'episode'; show: { id: number }; episode: EpisodeEntry };
 
 export function useWatchCount(props: UseWatchCountProps) {
   const { history } = useUser();
@@ -27,7 +32,7 @@ export function useWatchCount(props: UseWatchCountProps) {
         case 'show': {
           const { isWatched, minPlays } = getShowWatchState({
             watchedShow: $history.shows.get(mediaId),
-            episodeCount: props.media.episode.count,
+            episodeCount: props.media.episode?.count,
           });
 
           return isWatched ? minPlays : 0;


### PR DESCRIPTION
Closes #3215

### Why

The watched badge on a list card is binary, so a title watched once looks exactly like a title watched five times - in search, discover, lists, watchlist, favourites, related and credits. The count already exists on the summary poster via `WatchCountTag`; list cards fall back to `IndicatorTag`, a plain square check.

### What changed

**`IndicatorTag`** takes an optional `count` and renders it for the watched badge when it is above one. A single play keeps the plain square badge, so the common case is pixel identical and only a rewatch pays for the extra width. Any other indicator ignores the count entirely.

**`useWatchCount`** already had the right semantics - plays for a movie, and for a show the lowest play count across its regular episodes, counted only once the show reads as fully watched. Its show branch now takes the episode count as optional, the way `MediaStoreProps` already does for `useIsWatched`, so the leaner entry a list card carries can ask too. Without the count a show simply cannot read as fully watched, and `getShowWatchState` already returns no count in that case.

**`watchCount` moved to the shared half of `PosterTagsProps`**, so both the `full` and `default` variants can carry it. It was required on `full`; it is now optional on both, which every existing `full` call site already satisfies.

`DefaultMediaItem` is the only call site wired up here.

### Why the minimum, not an average

`floor(total plays / episode count)` would lie about a partial rewatch: 61 episodes seen three times plus one seen once rounds to "3". The minimum is the only figure true of every episode, so a partial rewatch shows nothing rather than claiming a complete one. This is the rule `getShowWatchState.minPlays` already implements - this PR just surfaces it.

### Testing

Verified against my own account on `dev:contrib`, driving a real browser. The account has exactly one movie with more than one play.

| surface | watched badges | with a number |
| --- | --- | --- |
| `/search?query=spider-man` | 4 | 1 |
| `/movies/watched` | 1 | 1 |

The three plain badges on the search page are titles watched once, unchanged. The one carrying `2` is the only rewatched title in the account, so the badge is reading the real figure rather than a constant.

`IndicatorTag.spec.ts` is new: a single play and an absent count both stay plain, a count above one renders, and a non-watched indicator never counts. Confirmed the first assertion fails if the threshold is loosened to `count > 0`.

```
vitest             10 passed (2 files, incl. getShowWatchState)
deno task check    0 errors, 0 warnings
eslint             clean on every changed file
```

### Screenshots

**Search: only the rewatched title carries a number**

<img width="2800" height="1900" alt="01-cards-with-count" src="https://github.com/user-attachments/assets/6771a3d3-ce2a-4d20-8f7c-fe1794b7cc2d" />

**Watched movies**

<img width="2800" height="1900" alt="02-search" src="https://github.com/user-attachments/assets/9786aa3c-8b5d-4f49-bfaf-c631400f84fb" />

### Not included

The Android issue this mirrors (trakt/trakt-android#361) also covers season posters and the episode rows inside a season. `useWatchCount` has no season case - the per-season minimum would be new logic rather than a reuse - so those stay out of this PR and can follow separately.
