### PR TITLE
feat(watched): offer watched until here when a check skips episodes

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -472,6 +472,21 @@
       "default": "Watched until here",
       "description": "Text for the button that allows users to mark a show as watched until a specific point."
     },
+    "confirmation_title_watched_until_here": {
+      "default": "Fill in the episodes you skipped?",
+      "description": "Title of the prompt shown after marking an episode watched that left earlier episodes unwatched."
+    },
+    "warning_prompt_watched_until_here": {
+      "default": "Marking \"{title}\" as watched left earlier episodes unwatched. Mark everything up to it as watched too?",
+      "description": "Message of the prompt shown after marking an episode watched that left earlier episodes unwatched.",
+      "variables": {
+        "title": {
+          "type": "string",
+          "description": "Episode title",
+          "required": true
+        }
+      }
+    },
     "button_text_watch_again": {
       "default": "Watch again",
       "description": "Text for the button that allows users to mark a movie, episode, or show as re-watched."

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -26,6 +26,12 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     message: getWarningMessage(props.title, props.target),
     operation: 'destructive',
   }),
+  [ConfirmationType.WatchedUntilHere]: (props) => ({
+    title: m.confirmation_title_watched_until_here(),
+    buttonText: m.button_text_watched_until_here(),
+    message: m.warning_prompt_watched_until_here({ title: props.title }),
+    operation: 'affirmative',
+  }),
   [ConfirmationType.RemoveFromWatched]: (props) => ({
     title: m.confirmation_title_remove_from_watched(),
     buttonText: m.button_text_remove_from_history(),

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -24,6 +24,10 @@ interface ConfirmationParamsMap {
     type: ConfirmationType.BlockUser;
     username: string;
   };
+  [ConfirmationType.WatchedUntilHere]: {
+    type: ConfirmationType.WatchedUntilHere;
+    title: string;
+  };
   [ConfirmationType.RemoveFromWatched]: {
     type: ConfirmationType.RemoveFromWatched;
     title: string;

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
@@ -1,5 +1,6 @@
 export enum ConfirmationType {
   MarkAsWatched = 'mark-as-watched',
+  WatchedUntilHere = 'watched-until-here',
   RemoveFromWatched = 'remove-from-watched',
   RemoveFromHistory = 'remove-from-history',
   DropShow = 'drop-show',

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -13,7 +13,10 @@
   import type { EpisodeUrlOverride } from "$lib/sections/lists/components/models/EpisodeUrlOverride";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchedUntilHereDrawer from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/WatchedUntilHereDrawer.svelte";
+  import { countSkippedEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/countSkippedEpisodes.ts";
   import { useWatchUntilHereEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/useWatchUntilHereEpisodes.ts";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
+  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import { useMarkAsWatched } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
   import { scrollActiveItemIntoView } from "$lib/utils/actions/scrollActiveItemIntoView";
 
@@ -50,7 +53,7 @@
     hasUnseenEpisodes && episode.effectiveReleaseDate && !isFuture,
   );
 
-  const { isWatchable } = $derived(
+  const { isWatchable, isWatched } = $derived(
     useMarkAsWatched({ type: "episode", media: episode, show }),
   );
 
@@ -58,6 +61,15 @@
     !isFuture && (isWatchable || hasBulkMarkAsWatched),
   );
   const variant = $derived(isFuture ? "upcoming" : "default");
+
+  const skippedCount = $derived(
+    countSkippedEpisodes({
+      target: { season: episode.season, number: episode.number },
+      currentSeasonEpisodes,
+      previousSeasons,
+      watchedBySeason,
+    }),
+  );
 
   const src = $derived(
     useEpisodeSpoilerImage({
@@ -68,6 +80,35 @@
   );
 
   let isWatchUntilDrawerOpen = $state(false);
+
+  const { confirm } = useConfirm();
+  const confirmFillGap = $derived(
+    confirm({
+      type: ConfirmationType.WatchedUntilHere,
+      title: episode.title,
+      onConfirm: () => (isWatchUntilDrawerOpen = true),
+    }),
+  );
+
+  /**
+   * The prompt follows the episode becoming watched rather than the click, so
+   * it covers every route that marks it - the row check, the overflow, or the
+   * date drawer - and never fires on a re-watch, since the state was already
+   * true. `null` is the first read, before anything has been observed.
+   */
+  let wasWatched: boolean | null = $state(null);
+
+  $effect(() => {
+    const isNowWatched = $isWatched;
+    const previous = wasWatched;
+    wasWatched = isNowWatched;
+
+    if (previous !== false || !isNowWatched || skippedCount === 0) {
+      return;
+    }
+
+    confirmFillGap();
+  });
 
   const watchUntilResolver = $derived.by(() => {
     if (!isWatchUntilDrawerOpen) return null;

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -3,6 +3,7 @@
   import IconWrapper from "$lib/components/icons/IconWrapper.svelte";
   import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
@@ -14,6 +15,7 @@
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchedUntilHereDrawer from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/WatchedUntilHereDrawer.svelte";
   import { countSkippedEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/countSkippedEpisodes.ts";
+  import { toWatchedGapPrompt } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/toWatchedGapPrompt.ts";
   import { useWatchUntilHereEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/useWatchUntilHereEpisodes.ts";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -81,6 +83,7 @@
 
   let isWatchUntilDrawerOpen = $state(false);
 
+  const { history } = useUser();
   const { confirm } = useConfirm();
   const confirmFillGap = $derived(
     confirm({
@@ -91,19 +94,23 @@
   );
 
   /**
-   * The prompt follows the episode becoming watched rather than the click, so
-   * it covers every route that marks it - the row check, the overflow, or the
-   * date drawer - and never fires on a re-watch, since the state was already
-   * true. `null` is the first read, before anything has been observed.
+   * `toWatchedGapPrompt` holds the transition rule, including why an unsettled
+   * history cannot move the baseline. Plain `let`, not `$state`: nothing else
+   * reads it, and the effect must not re-run on its own write.
    */
-  let wasWatched: boolean | null = $state(null);
+  let watchedBaseline: boolean | null = null;
 
   $effect(() => {
-    const isNowWatched = $isWatched;
-    const previous = wasWatched;
-    wasWatched = isNowWatched;
+    const { baseline, shouldPrompt } = toWatchedGapPrompt({
+      baseline: watchedBaseline,
+      isHistorySettled: $history !== null,
+      isWatched: $isWatched,
+      skippedCount,
+    });
 
-    if (previous !== false || !isNowWatched || skippedCount === 0) {
+    watchedBaseline = baseline;
+
+    if (!shouldPrompt) {
       return;
     }
 

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/countSkippedEpisodes.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/countSkippedEpisodes.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { countSkippedEpisodes } from './countSkippedEpisodes.ts';
+
+const NOW = new Date('2026-01-01T00:00:00.000Z');
+const AIRED = new Date('2025-01-01T00:00:00.000Z');
+const UNAIRED = new Date('2027-01-01T00:00:00.000Z');
+
+const episode = (number: number, effectiveReleaseDate = AIRED) => ({
+  number,
+  effectiveReleaseDate,
+});
+
+const count = (
+  props: Partial<Parameters<typeof countSkippedEpisodes>[0]> = {},
+) =>
+  countSkippedEpisodes({
+    target: { season: 2, number: 10 },
+    currentSeasonEpisodes: [],
+    previousSeasons: [],
+    watchedBySeason: new Map(),
+    now: NOW,
+    ...props,
+  });
+
+describe('util: countSkippedEpisodes', () => {
+  it('should count nothing when there is no gap behind the target', () => {
+    expect(
+      count({
+        currentSeasonEpisodes: [episode(9), episode(10)],
+        watchedBySeason: new Map([[2, new Set([9])]]),
+      }),
+    ).toBe(0);
+  });
+
+  it('should count the unwatched episodes before the target', () => {
+    expect(
+      count({
+        currentSeasonEpisodes: [7, 8, 9, 10].map((n) => episode(n)),
+        watchedBySeason: new Map([[2, new Set<number>()]]),
+      }),
+    ).toBe(3);
+  });
+
+  it('should ignore episodes after the target', () => {
+    expect(
+      count({
+        currentSeasonEpisodes: [9, 10, 11, 12].map((n) => episode(n)),
+        watchedBySeason: new Map(),
+      }),
+    ).toBe(1);
+  });
+
+  it('should ignore episodes that have not aired', () => {
+    expect(
+      count({
+        currentSeasonEpisodes: [episode(8, UNAIRED), episode(9)],
+        watchedBySeason: new Map(),
+      }),
+    ).toBe(1);
+  });
+
+  it('should count gaps left in earlier seasons', () => {
+    expect(
+      count({
+        previousSeasons: [{ number: 1, episodes: { aired: 8 } }],
+        watchedBySeason: new Map([[1, new Set([1, 2, 3])]]),
+      }),
+    ).toBe(5);
+  });
+
+  it('should not count a season the target does not follow', () => {
+    expect(
+      count({
+        target: { season: 1, number: 5 },
+        previousSeasons: [{ number: 2, episodes: { aired: 8 } }],
+        watchedBySeason: new Map(),
+      }),
+    ).toBe(0);
+  });
+
+  it('should never report a negative gap for an over-watched season', () => {
+    expect(
+      count({
+        previousSeasons: [{ number: 1, episodes: { aired: 2 } }],
+        watchedBySeason: new Map([[1, new Set([1, 2, 3, 4])]]),
+      }),
+    ).toBe(0);
+  });
+});

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/countSkippedEpisodes.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/countSkippedEpisodes.ts
@@ -1,0 +1,48 @@
+type SeasonRef = { number: number; episodes: { aired: number } };
+type EpisodeRef = {
+  number: number;
+  effectiveReleaseDate: Date;
+};
+
+type CountSkippedEpisodesProps = {
+  target: { season: number; number: number };
+  currentSeasonEpisodes: ReadonlyArray<EpisodeRef>;
+  previousSeasons: ReadonlyArray<SeasonRef>;
+  watchedBySeason: ReadonlyMap<number, ReadonlySet<number>>;
+  now?: Date;
+};
+
+/**
+ * How many released episodes marking [target] as watched would leave behind.
+ *
+ * Counted from state the seasons row already holds, so a check that skips
+ * nothing costs no request. Earlier seasons count by their aired totals rather
+ * than by episode, since those lists are not loaded until the drawer asks for
+ * them - which is also why specials, absent from [previousSeasons], never
+ * count.
+ */
+export function countSkippedEpisodes({
+  target,
+  currentSeasonEpisodes,
+  previousSeasons,
+  watchedBySeason,
+  now = new Date(),
+}: CountSkippedEpisodesProps): number {
+  const watchedHere = watchedBySeason.get(target.season) ?? new Set<number>();
+
+  const inThisSeason =
+    currentSeasonEpisodes.filter((candidate) =>
+      candidate.number < target.number &&
+      !watchedHere.has(candidate.number) &&
+      candidate.effectiveReleaseDate <= now
+    ).length;
+
+  const inEarlierSeasons = previousSeasons
+    .filter((season) => season.number < target.season)
+    .reduce((total, season) => {
+      const watched = watchedBySeason.get(season.number)?.size ?? 0;
+      return total + Math.max(season.episodes.aired - watched, 0);
+    }, 0);
+
+  return inThisSeason + inEarlierSeasons;
+}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/toWatchedGapPrompt.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/toWatchedGapPrompt.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { toWatchedGapPrompt } from './toWatchedGapPrompt.ts';
+
+const prompt = (
+  props: Partial<Parameters<typeof toWatchedGapPrompt>[0]> = {},
+) =>
+  toWatchedGapPrompt({
+    baseline: false,
+    isHistorySettled: true,
+    isWatched: true,
+    skippedCount: 3,
+    ...props,
+  });
+
+describe('util: toWatchedGapPrompt', () => {
+  it('should prompt when a watched episode leaves a gap behind it', () => {
+    expect(prompt()).toEqual({ baseline: true, shouldPrompt: true });
+  });
+
+  it('should not prompt when nothing was skipped', () => {
+    expect(prompt({ skippedCount: 0 })).toEqual({
+      baseline: true,
+      shouldPrompt: false,
+    });
+  });
+
+  it('should not prompt on the first observed state', () => {
+    expect(prompt({ baseline: null })).toEqual({
+      baseline: true,
+      shouldPrompt: false,
+    });
+  });
+
+  it('should not prompt on a re-watch of an already watched episode', () => {
+    expect(prompt({ baseline: true })).toEqual({
+      baseline: true,
+      shouldPrompt: false,
+    });
+  });
+
+  it('should not prompt when the episode became unwatched', () => {
+    expect(prompt({ baseline: true, isWatched: false })).toEqual({
+      baseline: false,
+      shouldPrompt: false,
+    });
+  });
+
+  describe('while the history is unsettled', () => {
+    it('should not read an unsettled history as unwatched', () => {
+      expect(
+        prompt({
+          baseline: null,
+          isHistorySettled: false,
+          isWatched: false,
+        }),
+      ).toEqual({ baseline: null, shouldPrompt: false });
+    });
+
+    it('should not prompt when a settling history reveals a watched episode', () => {
+      const loading = prompt({
+        baseline: null,
+        isHistorySettled: false,
+        isWatched: false,
+      });
+
+      expect(prompt({ baseline: loading.baseline })).toEqual({
+        baseline: true,
+        shouldPrompt: false,
+      });
+    });
+
+    it('should keep the settled baseline across a refetch', () => {
+      const refetching = prompt({
+        isHistorySettled: false,
+        isWatched: false,
+      });
+
+      expect(refetching.baseline).toBe(false);
+      expect(prompt({ baseline: refetching.baseline })).toEqual({
+        baseline: true,
+        shouldPrompt: true,
+      });
+    });
+  });
+});

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/toWatchedGapPrompt.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/toWatchedGapPrompt.ts
@@ -1,0 +1,46 @@
+type ToWatchedGapPromptProps = {
+  /**
+   * The last watched state observed from a settled history, or `null` when
+   * none has been observed yet.
+   */
+  baseline: boolean | null;
+  isHistorySettled: boolean;
+  isWatched: boolean;
+  skippedCount: number;
+};
+
+type WatchedGapPrompt = {
+  baseline: boolean | null;
+  shouldPrompt: boolean;
+};
+
+/**
+ * Whether an episode just became watched over a gap, and the baseline to carry
+ * into the next read.
+ *
+ * The prompt follows the episode becoming watched rather than the click, so it
+ * covers every route that marks it - the row check, the overflow, or the date
+ * drawer - and stays quiet on a re-watch, since the state was already true.
+ *
+ * Only a settled history moves the baseline. `useIsWatched` reads an unsettled
+ * history as "not watched", so a baseline taken from it would turn the history
+ * arriving into a false -> true transition and prompt on an episode nobody
+ * touched. Skipping those reads rather than resetting keeps the last settled
+ * value in place, so a refetch passing back through an unsettled history still
+ * leaves the user's own check as a transition across it.
+ */
+export function toWatchedGapPrompt({
+  baseline,
+  isHistorySettled,
+  isWatched,
+  skippedCount,
+}: ToWatchedGapPromptProps): WatchedGapPrompt {
+  if (!isHistorySettled) {
+    return { baseline, shouldPrompt: false };
+  }
+
+  return {
+    baseline: isWatched,
+    shouldPrompt: baseline === false && isWatched && skippedCount > 0,
+  };
+}


### PR DESCRIPTION
Closes #3217

### Why

Marking an episode from the seasons list marks only that episode, so skipping ahead leaves everything in between unwatched and says nothing about it. Up next then points at the gap while the show carries a play past it.

`WatchedUntilHereDrawer` already fills exactly those gaps, but `SeasonEpisodeItem` only reaches it from the episode overflow, gated behind `hasBulkMarkAsWatched`. Someone using the check as their normal gesture never meets it.

### What changed

**`countSkippedEpisodes`** is a new pure helper next to the drawer it serves. It counts released episodes the target would leave behind, from state the row already holds - `currentSeasonEpisodes` for the current season, and `previousSeasons` aired totals against `watchedBySeason` for earlier ones. Nothing is fetched, so a check that skips nothing costs no request. Earlier seasons count by totals because their episode lists are not loaded until the drawer asks, which is also why specials, absent from `previousSeasons`, never count.

**`SeasonEpisodeItem`** prompts when the episode becomes watched with a gap behind it, and confirming opens the existing drawer untouched.

The prompt keys off the episode's watched state flipping, not off the click. That is deliberate: on web the check opens the mark-as-watched drawer rather than marking directly, and the episode can also be marked from the overflow. Watching the transition covers every route, and a re-watch never prompts because the state was already true. The first observation is `null` rather than `false`, so a row that renders already-watched stays quiet.

**A new `ConfirmationType`**, which is the one place this needs new copy - the enum entry, its params, and the title/message. The button reuses `button_text_watched_until_here`. Two new keys, English-only until the next Crowdin sync.

### Testing

`countSkippedEpisodes.spec.ts` covers the rule: no gap, a gap in the current season, episodes after the target ignored, unaired episodes ignored, gaps in earlier seasons, a season the target does not follow, and an over-watched season never going negative.

```
vitest             16 passed (3 files, incl. the existing watch-until-here specs)
deno task check    0 errors, 0 warnings
eslint             clean on every changed file
```

Loaded a real season page with the account signed in and writes to `/sync/history` blocked at the network layer: 13 episode rows render, no dialog opens on load, no new console errors.

**What I did not exercise:** the prompt firing end to end. Doing that means marking episodes as watched on a real Trakt account, and I did not want to write plays into mine to produce a screenshot. The rule behind it is unit tested and the surrounding drawer is unchanged, but the flow itself is untested at runtime - worth knowing before this is merged, and happy to run it against a throwaway account if that helps.

### Not included

The Android issue this mirrors (trakt/trakt-android#359) also describes the same prompt on the All seasons screen. On web both surfaces render through `SeasonEpisodeItem`, so they are covered by the same change.
