### PR TITLE
feat(toggle): let the progress filters be reordered by holding a chip

### DIFF
--- a/projects/client/src/lib/components/select/SegmentedSelect.svelte
+++ b/projects/client/src/lib/components/select/SegmentedSelect.svelte
@@ -6,6 +6,8 @@
   import { appendGlobalParameters } from "$lib/features/parameters/appendGlobalParameters.ts";
   import type { SegmentedSelectOption } from "./models/SegmentedSelectOption.ts";
   import type { SegmentedSelectProps } from "./models/SegmentedSelectProps.ts";
+  import { moveItem } from "$lib/utils/array/moveItem.ts";
+  import { holdToReorder } from "./_internal/holdToReorder.ts";
   import {
     trackSelector,
     type TrackSelectorParams,
@@ -24,8 +26,14 @@
     collapsedCount = 0,
     expanded = false,
     extension,
+    reorderable = false,
+    onReorder,
     onChange,
   }: SegmentedSelectProps<TValue> = $props();
+
+  let heldIndex = $state<number | null>(null);
+  let previewIndex = $state<number | null>(null);
+  const isReordering = $derived(heldIndex !== null);
 
   const selectedIndex = $derived(
     Math.max(
@@ -53,7 +61,19 @@
     collapsed: boolean;
   };
 
+  const reorderTo = (from: number, to: number) => {
+    if (from === to) return;
+    onReorder?.(
+      moveItem({ items: options.map((option) => option.value), from, to }),
+    );
+  };
+
   const segmentProps = ({ option, index, collapsed }: SegmentPropsParams) => ({
+    "data-segment-index": index,
+    "data-held": heldIndex === index ? "true" : undefined,
+    "data-preview": previewIndex === index && heldIndex !== index
+      ? "true"
+      : undefined,
     class: [
       "segment",
       !collapsed && index === selectedIndex && "is-selected",
@@ -153,6 +173,20 @@
 >
   <div
     class="segment-row"
+    class:is-reordering={isReordering}
+    use:holdToReorder={{
+      isEnabled: reorderable,
+      onHold: (index) => {
+        heldIndex = index;
+        previewIndex = index;
+      },
+      onPreview: (index) => (previewIndex = index),
+      onCommit: reorderTo,
+      onRelease: () => {
+        heldIndex = null;
+        previewIndex = null;
+      },
+    }}
     use:trackSelector={selectorParams}
     data-dpad-navigation={DpadNavigationType.List}
   >
@@ -185,6 +219,38 @@
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
+
+  /* Reorder mode: the row rocks so it reads as editable, the held chip lifts
+     out of the rocking, and the slot it would land in makes room. */
+  @keyframes segment-rock {
+    0%, 100% { rotate: -0.8deg; }
+    50% { rotate: 0.8deg; }
+  }
+
+  .segment-row.is-reordering {
+    touch-action: none;
+    cursor: grabbing;
+
+    :global([data-segment-index]) {
+      animation: segment-rock 240ms ease-in-out infinite;
+    }
+
+    :global([data-held="true"]) {
+      animation: none;
+      scale: 1.06;
+      z-index: 1;
+    }
+
+    :global([data-preview="true"]) {
+      opacity: 0.55;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .segment-row.is-reordering :global([data-segment-index]) {
+      animation: none;
+    }
+  }
 
   .trakt-segmented-select {
     --segment-height: var(--segmented-select-segment-height);

--- a/projects/client/src/lib/components/select/_internal/holdToReorder.ts
+++ b/projects/client/src/lib/components/select/_internal/holdToReorder.ts
@@ -60,12 +60,23 @@ export function holdToReorder(node: HTMLElement, params: HoldToReorderParams) {
     const index = segmentAt(event.target);
     if (index === null) return;
 
+    // A pointer released outside the row never reaches `pointerup` here, so
+    // clear whatever the previous gesture left behind before starting.
+    reset();
+
     startX = event.clientX;
     fromIndex = index;
     holdTimer = setTimeout(() => {
+      try {
+        node.setPointerCapture?.(event.pointerId);
+      } catch {
+        // The pointer is already gone, so there is no gesture left to claim.
+        reset();
+        return;
+      }
+
       isHolding = true;
       toIndex = index;
-      node.setPointerCapture?.(event.pointerId);
       current.onHold(index);
     }, HOLD_MS);
   };

--- a/projects/client/src/lib/components/select/_internal/holdToReorder.ts
+++ b/projects/client/src/lib/components/select/_internal/holdToReorder.ts
@@ -1,0 +1,112 @@
+import { toReorderIndex } from './toReorderIndex.ts';
+
+export type HoldToReorderParams = {
+  /** Attribute carrying each segment's index, set on the segment element. */
+  indexAttribute?: string;
+  isEnabled: boolean;
+  onHold: (index: number) => void;
+  onPreview: (index: number) => void;
+  onCommit: (from: number, to: number) => void;
+  onRelease: () => void;
+};
+
+/** Long enough not to fight a tap, short enough to feel like a hold. */
+const HOLD_MS = 400;
+/** Movement before the hold lands reads as a scroll, not a reorder. */
+const CANCEL_DISTANCE_PX = 10;
+
+export function holdToReorder(node: HTMLElement, params: HoldToReorderParams) {
+  let current = params;
+  let holdTimer: ReturnType<typeof setTimeout> | null = null;
+  let startX = 0;
+  let fromIndex: number | null = null;
+  let toIndex: number | null = null;
+  let isHolding = false;
+
+  const attribute = () => current.indexAttribute ?? 'data-segment-index';
+
+  const segmentAt = (target: EventTarget | null) => {
+    if (!(target instanceof Element)) return null;
+    const segment = target.closest(`[${attribute()}]`);
+    if (!(segment instanceof HTMLElement)) return null;
+    const index = Number(segment.getAttribute(attribute()));
+    return Number.isFinite(index) ? index : null;
+  };
+
+  const bounds = () =>
+    [...node.querySelectorAll(`[${attribute()}]`)].map((segment) => {
+      const rect = segment.getBoundingClientRect();
+      return { left: rect.left, width: rect.width };
+    });
+
+  const stopHold = () => {
+    if (holdTimer !== null) {
+      clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+  };
+
+  const reset = () => {
+    stopHold();
+    isHolding = false;
+    fromIndex = null;
+    toIndex = null;
+    current.onRelease();
+  };
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (!current.isEnabled || event.button !== 0) return;
+
+    const index = segmentAt(event.target);
+    if (index === null) return;
+
+    startX = event.clientX;
+    fromIndex = index;
+    holdTimer = setTimeout(() => {
+      isHolding = true;
+      toIndex = index;
+      node.setPointerCapture?.(event.pointerId);
+      current.onHold(index);
+    }, HOLD_MS);
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (fromIndex === null) return;
+
+    if (!isHolding) {
+      if (Math.abs(event.clientX - startX) > CANCEL_DISTANCE_PX) stopHold();
+      return;
+    }
+
+    // Holding owns the gesture, so the row must not scroll under it.
+    event.preventDefault();
+    toIndex = toReorderIndex({ segments: bounds(), pointerX: event.clientX });
+    current.onPreview(toIndex);
+  };
+
+  const onPointerUp = () => {
+    if (isHolding && fromIndex !== null && toIndex !== null) {
+      current.onCommit(fromIndex, toIndex);
+    }
+    reset();
+  };
+
+  node.addEventListener('pointerdown', onPointerDown);
+  node.addEventListener('pointermove', onPointerMove);
+  node.addEventListener('pointerup', onPointerUp);
+  node.addEventListener('pointercancel', reset);
+
+  return {
+    update(next: HoldToReorderParams) {
+      current = next;
+      if (!next.isEnabled) reset();
+    },
+    destroy() {
+      stopHold();
+      node.removeEventListener('pointerdown', onPointerDown);
+      node.removeEventListener('pointermove', onPointerMove);
+      node.removeEventListener('pointerup', onPointerUp);
+      node.removeEventListener('pointercancel', reset);
+    },
+  };
+}

--- a/projects/client/src/lib/components/select/_internal/toReorderIndex.spec.ts
+++ b/projects/client/src/lib/components/select/_internal/toReorderIndex.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { toReorderIndex } from './toReorderIndex.ts';
+
+// Three 100px segments starting at x=0.
+const segments = [
+  { left: 0, width: 100 },
+  { left: 100, width: 100 },
+  { left: 200, width: 100 },
+];
+
+describe('util: toReorderIndex', () => {
+  it('should report the slot the pointer sits in', () => {
+    expect(toReorderIndex({ segments, pointerX: 10 })).toBe(0);
+    expect(toReorderIndex({ segments, pointerX: 140 })).toBe(1);
+    expect(toReorderIndex({ segments, pointerX: 240 })).toBe(2);
+  });
+
+  it('should switch slot at the midpoint, not at the edge', () => {
+    expect(toReorderIndex({ segments, pointerX: 49 })).toBe(0);
+    expect(toReorderIndex({ segments, pointerX: 51 })).toBe(1);
+  });
+
+  it('should park at the first slot when dragged off the start', () => {
+    expect(toReorderIndex({ segments, pointerX: -500 })).toBe(0);
+  });
+
+  it('should park at the last slot when dragged off the end', () => {
+    expect(toReorderIndex({ segments, pointerX: 5000 })).toBe(2);
+  });
+
+  it('should stay at zero without segments to measure', () => {
+    expect(toReorderIndex({ segments: [], pointerX: 42 })).toBe(0);
+  });
+});

--- a/projects/client/src/lib/components/select/_internal/toReorderIndex.spec.ts
+++ b/projects/client/src/lib/components/select/_internal/toReorderIndex.spec.ts
@@ -31,4 +31,27 @@ describe('util: toReorderIndex', () => {
   it('should stay at zero without segments to measure', () => {
     expect(toReorderIndex({ segments: [], pointerX: 42 })).toBe(0);
   });
+
+  describe('right to left', () => {
+    // The same three segments, laid out with the first option on the right.
+    const rtlSegments = [
+      { left: 200, width: 100 },
+      { left: 100, width: 100 },
+      { left: 0, width: 100 },
+    ];
+
+    it('should report the option sitting under the pointer', () => {
+      expect(toReorderIndex({ segments: rtlSegments, pointerX: 240 })).toBe(0);
+      expect(toReorderIndex({ segments: rtlSegments, pointerX: 140 })).toBe(1);
+      expect(toReorderIndex({ segments: rtlSegments, pointerX: 10 })).toBe(2);
+    });
+
+    it('should park at the last option when dragged off the start', () => {
+      expect(toReorderIndex({ segments: rtlSegments, pointerX: -500 })).toBe(2);
+    });
+
+    it('should park at the first option when dragged off the end', () => {
+      expect(toReorderIndex({ segments: rtlSegments, pointerX: 5000 })).toBe(0);
+    });
+  });
 });

--- a/projects/client/src/lib/components/select/_internal/toReorderIndex.ts
+++ b/projects/client/src/lib/components/select/_internal/toReorderIndex.ts
@@ -12,6 +12,10 @@ type ToReorderIndexProps = {
  * Which slot the pointer is currently over, by comparing against each
  * segment's midpoint. Past the last midpoint the answer is the end of the row,
  * so dragging a chip off either edge parks it there rather than doing nothing.
+ *
+ * Segments arrive in option order, which only matches the order on screen while
+ * the row reads left to right. Reading the slot off the visual order and
+ * mapping it back keeps the answer an option index in either direction.
  */
 export function toReorderIndex(
   { segments, pointerX }: ToReorderIndexProps,
@@ -20,9 +24,14 @@ export function toReorderIndex(
     return 0;
   }
 
-  const crossed = segments.findIndex(
+  const onScreen = segments
+    .map((segment, index) => ({ ...segment, index }))
+    .sort((left, right) => left.left - right.left);
+
+  const crossed = onScreen.findIndex(
     (segment) => pointerX < segment.left + segment.width / 2,
   );
+  const slot = crossed === -1 ? onScreen.length - 1 : crossed;
 
-  return crossed === -1 ? segments.length - 1 : crossed;
+  return onScreen.at(slot)?.index ?? 0;
 }

--- a/projects/client/src/lib/components/select/_internal/toReorderIndex.ts
+++ b/projects/client/src/lib/components/select/_internal/toReorderIndex.ts
@@ -1,0 +1,28 @@
+export type SegmentBounds = {
+  left: number;
+  width: number;
+};
+
+type ToReorderIndexProps = {
+  segments: ReadonlyArray<SegmentBounds>;
+  pointerX: number;
+};
+
+/**
+ * Which slot the pointer is currently over, by comparing against each
+ * segment's midpoint. Past the last midpoint the answer is the end of the row,
+ * so dragging a chip off either edge parks it there rather than doing nothing.
+ */
+export function toReorderIndex(
+  { segments, pointerX }: ToReorderIndexProps,
+): number {
+  if (segments.length === 0) {
+    return 0;
+  }
+
+  const crossed = segments.findIndex(
+    (segment) => pointerX < segment.left + segment.width / 2,
+  );
+
+  return crossed === -1 ? segments.length - 1 : crossed;
+}

--- a/projects/client/src/lib/components/select/models/SegmentedSelectProps.ts
+++ b/projects/client/src/lib/components/select/models/SegmentedSelectProps.ts
@@ -13,5 +13,8 @@ export type SegmentedSelectProps<TValue extends string = string> = {
   collapsedCount?: number;
   expanded?: boolean;
   extension?: Snippet;
+  /** Opt in to holding a segment to drag it into another position. */
+  reorderable?: boolean;
+  onReorder?: (values: TValue[]) => void;
   onChange: (value: TValue) => void;
 };

--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -10,6 +10,8 @@
     options: ToggleOption<T>[];
     variant?: "icon" | "text";
     ariaLabel?: string;
+    reorderable?: boolean;
+    onReorder?: (values: T[]) => void;
   }
 
   const {
@@ -18,6 +20,8 @@
     options,
     variant = "icon",
     ariaLabel,
+    reorderable = false,
+    onReorder,
   }: TogglerProps = $props();
 
   const segmentedOptions = $derived<SegmentedSelectOption<T>[]>(
@@ -48,5 +52,7 @@
   options={segmentedOptions}
   {ariaLabel}
   icon={variant === "icon" ? iconSnippet : undefined}
+  {reorderable}
+  {onReorder}
   {onChange}
 />

--- a/projects/client/src/lib/components/toggles/useToggler.ts
+++ b/projects/client/src/lib/components/toggles/useToggler.ts
@@ -9,6 +9,7 @@ import {
 } from './_internal/constants.ts';
 
 const TOGGLER_PREFIX = 'trakt_toggler';
+const ORDER_SUFFIX = 'order';
 
 const globalStores = new Map<string, BehaviorSubject<unknown>>();
 
@@ -16,9 +17,37 @@ export function resetGlobalStore() {
   globalStores.clear();
 }
 
+/**
+ * Reads a stored order, dropping anything that is no longer an option and
+ * appending anything new, so an order saved before a filter was added or
+ * removed still applies instead of being thrown away.
+ */
+function readOrder(
+  storageKey: string,
+  options: ReadonlyArray<{ value: unknown }>,
+): ReadonlyArray<{ value: unknown }> {
+  try {
+    const stored = safeLocalStorage.getItem(storageKey);
+    if (!stored) return options;
+
+    const order = JSON.parse(stored) as unknown;
+    if (!Array.isArray(order)) return options;
+
+    const known = order
+      .map((value) => options.find((option) => option.value === value))
+      .filter((option) => option != null);
+    const rest = options.filter((option) => !known.includes(option));
+
+    return [...known, ...rest];
+  } catch {
+    return options;
+  }
+}
+
 export function useToggler<T extends TogglerId, K = TogglerValueMap[T]>(id: T) {
   const toggler = TOGGLERS[id];
   const storageKey = `${TOGGLER_PREFIX}_${toggler.id}`;
+  const orderKey = `${storageKey}_${ORDER_SUFFIX}`;
 
   if (!globalStores.has(storageKey)) {
     const initialValue = (() => {
@@ -41,8 +70,30 @@ export function useToggler<T extends TogglerId, K = TogglerValueMap[T]>(id: T) {
 
   const current = globalStores.get(storageKey) as BehaviorSubject<K>;
 
+  if (!globalStores.has(orderKey)) {
+    globalStores.set(
+      orderKey,
+      new BehaviorSubject<unknown>(readOrder(orderKey, toggler.options)),
+    );
+  }
+
+  const order = globalStores.get(orderKey) as BehaviorSubject<
+    typeof toggler.options
+  >;
+
   return {
     options: toggler.options,
+    orderedOptions: order.asObservable(),
+    setOrder: (values: K[]) => {
+      const next = values
+        .map((value) => toggler.options.find((o) => o.value === value))
+        .filter((option) => option != null);
+
+      if (next.length !== toggler.options.length) return;
+
+      order.next(next as typeof toggler.options);
+      safeLocalStorage.setItem(orderKey, JSON.stringify(values));
+    },
     default: toggler.default as K,
     current: current.pipe(
       map(($current) => {

--- a/projects/client/src/lib/sections/profile/components/ProgressList.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProgressList.svelte
@@ -13,7 +13,8 @@
 
   const { mode }: { mode: DiscoverMode } = $props();
 
-  const { current, set, options } = useToggler("progress");
+  const { current, set, options, orderedOptions, setOrder } =
+    useToggler("progress");
 
   const cta = $derived(
     $current.value !== "dropped"
@@ -54,7 +55,9 @@
         <Toggler
           value={$current.value}
           onChange={set}
-          {options}
+          options={$orderedOptions ?? options}
+          reorderable
+          onReorder={setOrder}
           ariaLabel={m.list_title_progress()}
         />
       {/snippet}

--- a/projects/client/src/lib/utils/array/moveItem.spec.ts
+++ b/projects/client/src/lib/utils/array/moveItem.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { moveItem } from './moveItem.ts';
+
+const items = ['a', 'b', 'c', 'd'];
+
+describe('util: moveItem', () => {
+  it('should move an entry forward', () => {
+    expect(moveItem({ items, from: 0, to: 2 })).toEqual(['b', 'c', 'a', 'd']);
+  });
+
+  it('should move an entry backward', () => {
+    expect(moveItem({ items, from: 3, to: 0 })).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  it('should leave the order alone when it does not move', () => {
+    expect(moveItem({ items, from: 1, to: 1 })).toEqual(items);
+  });
+
+  it('should settle at the nearest end when dropped past the row', () => {
+    expect(moveItem({ items, from: 0, to: 99 })).toEqual(['b', 'c', 'd', 'a']);
+    expect(moveItem({ items, from: 3, to: -5 })).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  it('should never drop an entry', () => {
+    expect(moveItem({ items, from: 99, to: 0 })).toHaveLength(items.length);
+  });
+
+  it('should handle an empty row', () => {
+    expect(moveItem({ items: [], from: 0, to: 1 })).toEqual([]);
+  });
+});

--- a/projects/client/src/lib/utils/array/moveItem.ts
+++ b/projects/client/src/lib/utils/array/moveItem.ts
@@ -1,0 +1,26 @@
+import { clamp } from '$lib/utils/number/clamp.ts';
+
+type MoveItemProps<T> = {
+  items: ReadonlyArray<T>;
+  from: number;
+  to: number;
+};
+
+/**
+ * Moves one entry to another position, keeping every other entry in order.
+ * Both indexes are clamped, so a drag that ends outside the row settles at the
+ * nearest end rather than dropping the entry.
+ */
+export function moveItem<T>({ items, from, to }: MoveItemProps<T>): T[] {
+  const source = clamp({ value: from, min: 0, max: items.length - 1 });
+
+  if (items.length === 0) {
+    return [];
+  }
+
+  const moved = items[source] as T;
+  const rest = items.filter((_, index) => index !== source);
+  const target = clamp({ value: to, min: 0, max: rest.length });
+
+  return [...rest.slice(0, target), moved, ...rest.slice(target)];
+}

--- a/projects/client/src/routes/profile/[slug]/progress/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/progress/+page.svelte
@@ -16,7 +16,8 @@
 
   const { params }: PageProps = $props();
 
-  const { current, set, options } = useToggler("progress");
+  const { current, set, options, orderedOptions, setOrder } =
+    useToggler("progress");
 
   const { isMe } = $derived(useIsMe(params.slug));
 
@@ -32,7 +33,13 @@
 </script>
 
 {#snippet actions()}
-  <Toggler value={$current.value} onChange={set} {options} />
+  <Toggler
+    value={$current.value}
+    onChange={set}
+    options={$orderedOptions ?? options}
+    reorderable
+    onReorder={setOrder}
+  />
 {/snippet}
 
 {#if !$isMe}


### PR DESCRIPTION
Closes #3220

### Why

The progress filters render in a fixed order, so `In progress` always sits behind `Up to date` even for someone who only ever consults it. `useToggler` already persists the selected filter, so the toggler was willing to remember a preference here - the order simply was not one of them.

### What changed

**`holdToReorder`**, a new action on the segment row. A press starts a hold; moving more than 10px before it lands reads as a scroll and cancels, so a tap and a swipe both still behave. Once the hold lands the gesture owns the pointer, `pointermove` picks the slot, and the release commits. It works with a mouse and with touch, and matches the gesture the Android app uses.

**`toReorderIndex`** and **`moveItem`** are the pure halves, kept out of the DOM so they can be tested - which slot the pointer is over, and the resulting order. `moveItem` clamps both ends, so a drag that finishes outside the row parks the chip at the nearest end rather than dropping it.

**`useToggler`** persists the order beside the selection, in the same store and the same shape. A stored order is reconciled against the current options on read: values that no longer exist are dropped and new ones appended, so an order saved before a filter was added or removed still applies.

**Reordering is opt in.** `SegmentedSelect` takes `reorderable` and `onReorder`, and only the progress toggler passes them. Every other toggler - social, discover, activity, library - is untouched and keeps its fixed order.

While a chip is held the row rocks and the target slot dims, so it reads as editable. Both are dropped under `prefers-reduced-motion`.

### Testing

Verified in a browser against my own account, on Profile > Progress:

```
initial      completed → in-progress → dropped
after drag   in-progress → dropped → completed
persisted    ["in-progress","dropped","completed"]
after reload in-progress → dropped → completed
```

The drag was a real hold-and-move: press, wait past the hold threshold, move to the far end, release. The other togglers on the same page (media/shows/movies, people/lists) did not move, which is the check that `reorderable` is actually scoped.

```
vitest             21 passed (3 files, incl. the existing useToggler spec)
deno task check    0 errors, 0 warnings
eslint             clean on every changed file
```

`moveItem.spec.ts` covers forward, backward, no-op, both clamped ends, never dropping an entry and an empty row. `toReorderIndex.spec.ts` covers the slot under the pointer, switching at the midpoint rather than the edge, and parking past either end.

### Screenshots

**Before: the default order**

<img width="2800" height="1900" alt="01-before" src="https://github.com/user-attachments/assets/a0ed5659-249e-4d3d-a8e4-d8042f950e94" />

**A chip held, the row in reorder mode**

<img width="2800" height="1900" alt="02-holding" src="https://github.com/user-attachments/assets/2205e7d4-2d0f-40ae-80a7-5f761ad2ee1b" />

**After: `In progress` first, and it survives a reload**

<img width="2800" height="1900" alt="03-after" src="https://github.com/user-attachments/assets/145ca33f-9879-49b9-ae6b-0c635a80405d" />

### Worth a second opinion

This is the one of these where the interaction is a judgement call rather than a mechanical port. Hold-to-drag is a touch idiom first; on desktop it is less conventional than a drag handle. I went with it so the two platforms feel the same, and because a handle on a small pill is awkward - but if you would rather have a different affordance on web, the pure parts and the persistence stay as they are and only the action changes.

Keyboard reordering is not included. It would need an interaction of its own rather than falling out of this one, and I did not want to guess at it here.
