### PR TITLE
fix(drawer): slides on transform instead of width

### DIFF
--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -7,8 +7,8 @@
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { appendClassList } from "$lib/utils/actions/appendClassList";
   import { writable } from "$lib/utils/store/WritableSubject";
+  import { slideEdge } from "$lib/utils/transitions/slideEdge.ts";
   import { onMount, type Snippet } from "svelte";
-  import { slide } from "svelte/transition";
   import ActionButton from "../buttons/ActionButton.svelte";
   import CloseIcon from "../icons/CloseIcon.svelte";
   import ListTitle from "../lists/_internal/ListTitle.svelte";
@@ -128,7 +128,7 @@
   data-elevated={elevated}
   data-header-variant={headerVariant}
   style:--drawer-header-overlay-opacity={headerOverlayOpacity}
-  transition:slide={{ duration: 150, axis: slideAxis }}
+  transition:slideEdge={{ duration: 150, axis: slideAxis }}
   use:portal
   use:trap
   use:appendClassList={classList}

--- a/projects/client/src/lib/utils/transitions/slideEdge.ts
+++ b/projects/client/src/lib/utils/transitions/slideEdge.ts
@@ -1,0 +1,23 @@
+import { cubicOut } from 'svelte/easing';
+import { slide, type TransitionConfig } from 'svelte/transition';
+
+type SlideEdgeProps = {
+  duration?: number;
+  axis?: 'x' | 'y';
+};
+
+export function slideEdge(
+  node: Element,
+  { duration = 150, axis = 'x' }: SlideEdgeProps = {},
+): TransitionConfig {
+  if (axis === 'y') {
+    return slide(node, { duration, axis });
+  }
+
+  return {
+    duration,
+    easing: cubicOut,
+    css: (t) =>
+      `transform: translateX(calc(var(--rtl-sign, 1) * ${(1 - t) * 100}%));`,
+  };
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- On desktop the drawer's `transition:slide` (axis `x`) animates `width` + inline padding, so the content reflowed on every frame. Looked like the content was shrinking as the drawer slid in.
- Added `slideEdge` to `lib/utils/transitions`, next to `slideFade`. Translates instead of resizing, so the drawer keeps its full width for the whole animation.
  - RTL-safe, mirrors via the existing `--rtl-sign`.
  - `cubicOut` + 150ms to match what `slide` was doing.
- Mobile is untouched: axis `y` still delegates to Svelte's `slide`, so the height-driven drag/fullscreen behaviour stays as is.

## 👀 Examples 👀
Before/after:

https://github.com/user-attachments/assets/f5065464-23f6-4f11-98dc-905c75d5d7eb


https://github.com/user-attachments/assets/5d595e66-9699-494f-9b4b-91d836034d4a

