### PR TITLE
fix(errors): recovers stale chunks on iOS and polyfills Object.hasOwn

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -19,6 +19,17 @@ import type { ErrorEvent as SentryErrorEvent } from '@sentry/sveltekit';
 // the token.
 captureWebviewSession();
 
+// WebKit's wording for a dynamic import whose chunk no longer exists.
+const WEBKIT_MISSING_MODULE_PATTERN = /Importing module '.*' is not found\./;
+
+const DYNAMIC_IMPORT_ERROR_PATTERNS: ReadonlyArray<RegExp> = [
+  /Failed to fetch dynamically imported module/,
+  /error loading dynamically imported module/,
+  /Importing a module script failed/,
+  /Unable to preload CSS for/,
+  WEBKIT_MISSING_MODULE_PATTERN,
+];
+
 const SAMPLED_ERROR_PATTERNS = [
   /^Failed to fetch( \((app|media)\.trakt\.tv\))?$/,
   /^Load failed( \((app|media)\.trakt\.tv\))?$/,
@@ -72,10 +83,7 @@ Sentry.init({
     'Failed to register a ServiceWorker',
     'service-worker.js load failed',
     "type 'module' in RegistrationOptions is not implemented yet",
-    'Failed to fetch dynamically imported module',
-    'error loading dynamically imported module',
-    'Importing a module script failed',
-    'Unable to preload CSS for',
+    ...DYNAMIC_IMPORT_ERROR_PATTERNS,
     /^Module load timeout: m_\d+$/,
     // Cross-origin frames we cannot reach into: embedded players, plus frames
     // injected by ad-blockers / privacy extensions.
@@ -134,18 +142,9 @@ if (typeof document !== 'undefined') {
 
 const DYNAMIC_IMPORT_RELOAD_KEY = 'dynamic-import-reload';
 
-const DYNAMIC_IMPORT_ERROR_PATTERNS = [
-  'Failed to fetch dynamically imported module',
-  'error loading dynamically imported module',
-  'Importing a module script failed',
-  'Unable to preload CSS for',
-];
-
 function isDynamicImportError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return DYNAMIC_IMPORT_ERROR_PATTERNS.some((pattern) =>
-    message.includes(pattern)
-  );
+  return DYNAMIC_IMPORT_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 function hasChunkPath(path?: string): boolean {

--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,4 +1,5 @@
 import '$lib/polyfills/at.ts';
+import '$lib/polyfills/hasOwn.ts';
 import '$lib/polyfills/mapGroupBy.ts';
 import '$lib/polyfills/randomUUID.ts';
 import '$lib/polyfills/toReversed.ts';

--- a/projects/client/src/lib/polyfills/hasOwn.spec.ts
+++ b/projects/client/src/lib/polyfills/hasOwn.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import './hasOwn.ts';
+
+describe('Object.hasOwn polyfill', () => {
+  it('reports own properties', () => {
+    expect(Object.hasOwn({ a: 1 }, 'a')).toBe(true);
+  });
+
+  it('ignores inherited properties', () => {
+    expect(Object.hasOwn({}, 'toString')).toBe(false);
+  });
+
+  it('reports own properties holding undefined', () => {
+    expect(Object.hasOwn({ a: undefined }, 'a')).toBe(true);
+  });
+
+  it('reports array indices', () => {
+    expect(Object.hasOwn(['a'], 0)).toBe(true);
+    expect(Object.hasOwn(['a'], 1)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/polyfills/hasOwn.ts
+++ b/projects/client/src/lib/polyfills/hasOwn.ts
@@ -1,0 +1,12 @@
+// Polyfill for Object.hasOwn (ES2022).
+// Sentry: TRAKT-WEB-BXS. marked calls it while lexing reflinks, so older
+// browsers crash when comment and trivia markdown is rendered.
+if (typeof Object.hasOwn !== 'function') {
+  Object.defineProperty(Object, 'hasOwn', {
+    value(target: object, key: PropertyKey): boolean {
+      return Object.prototype.hasOwnProperty.call(target, key);
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes https://trakt-tv.sentry.io/issues/TRAKT-WEB-BYC
- Fixes https://trakt-tv.sentry.io/issues/TRAKT-WEB-BXS
- Two browser support gaps from last week's Sentry. Unrelated, both small.
- WebKit words a missing dynamic import chunk as `Importing module './X.js' is not found.`, which none of our Chrome/Firefox patterns matched. So on iOS a stale deploy never triggered the reload recovery, and the error got reported instead of ignored. 11 issues, ~37 events over 7 days, all Mobile Safari.
  - Message is the only hook we get: no stacktrace, no `filename`, no `reason.url` on these.
  - Also hoisted `DYNAMIC_IMPORT_ERROR_PATTERNS` above `Sentry.init` and spread it into `ignoreErrors`. The four wordings were already duplicated across both lists, now they live in one place.
  - No behaviour change for those four: they were substring matches, and unanchored regexes match the same thing.
- `marked` calls `Object.hasOwn` while lexing reflinks, so browsers predating ES2022 throw and take down the whole comments or trivia section. Polyfill sits next to the existing ones, same shape.
- Both are blind fixes in the sense that I can't reproduce on the affected browsers locally. Will keep an eye on the two issues after release.
