### PR TITLE
feat(rating): history ratings can be changed after the fact

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -9410,6 +9410,15 @@
         }
       }
     },
+    "button_label_change_rating": {
+      "default": "Change rating for \"{title}\"",
+      "description": "Aria label for the badge that shows the user's own rating and, when pressed, reopens the rating picker so they can change it.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "button_text_watch_until_here_anchor_start": {
       "default": "Start time",
       "description": "Toggle label that treats the picked date and time as when the user started binge-watching the selected episodes."

--- a/projects/client/src/lib/components/popover/Popover.svelte
+++ b/projects/client/src/lib/components/popover/Popover.svelte
@@ -5,6 +5,7 @@
 
   type PopoverProps = {
     content: Snippet;
+    label?: string;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
   } & (
@@ -12,7 +13,8 @@
     | { children: Snippet; customAnchor?: never }
   );
 
-  const { content, open, onOpenChange, ...rest }: PopoverProps = $props();
+  const { content, label, open, onOpenChange, ...rest }: PopoverProps =
+    $props();
 
   const isControlled = $derived(open !== undefined);
 
@@ -30,7 +32,7 @@
 
 <Popover.Root bind:open={getOpen, setOpen}>
   {#if rest.children}
-    <Popover.Trigger class="trakt-popover-trigger">
+    <Popover.Trigger class="trakt-popover-trigger" aria-label={label}>
       {@render rest.children()}
     </Popover.Trigger>
   {/if}
@@ -62,5 +64,12 @@
   :global(.trakt-popover-trigger) {
     all: unset;
     display: inline-flex;
+  }
+
+  /* `all: unset` above strips the UA focus ring, so put one back. */
+  :global(.trakt-popover-trigger:focus-visible) {
+    outline: var(--border-thickness-xs) solid var(--color-foreground);
+    outline-offset: var(--ni-2);
+    border-radius: var(--border-radius-m);
   }
 </style>

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import Popover from "$lib/components/popover/Popover.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
@@ -10,7 +9,6 @@
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
   import type { RateNowProps } from "$lib/sections/summary/components/rating/models/RateNowProps";
-  import { NOOP_FN } from "$lib/utils/constants";
   import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle";
   import ActivityItem from "../components/ActivityItem.svelte";
   import ActivitySummaryCard from "../components/ActivitySummaryCard.svelte";
@@ -61,6 +59,12 @@
 
     return activity.movie.title;
   });
+
+  const rateLabel = $derived(
+    userRating
+      ? m.button_label_change_rating({ title: targetTitle })
+      : m.button_label_rate({ title: targetTitle }),
+  );
 </script>
 
 {#snippet popupActions()}
@@ -93,23 +97,27 @@
   </div>
 {/snippet}
 
+<!--
+  Rated and unrated share one <Popover> and one trigger, so the element survives
+  a rating landing while the popover is open - the badge swaps in without the
+  popover unmounting under the user's cursor - and both states get the same
+  press affordance.
+-->
 {#snippet action()}
-  {#if userRating}
-    <UserRating rating={userRating} />
-  {:else}
-    <RenderFor audience="authenticated">
-      <Popover content={rateContent}>
-        <ActionButton
-          style="ghost"
-          size="small"
-          onclick={NOOP_FN}
-          label={m.button_label_rate({ title: targetTitle })}
-        >
+  <RenderFor audience="authenticated">
+    <Popover content={rateContent} label={rateLabel}>
+      <span
+        class="trakt-history-rating-badge"
+        class:is-rated={Boolean(userRating)}
+      >
+        {#if userRating}
+          <UserRating rating={userRating} />
+        {:else}
           <StarIcon fill="none" />
-        </ActionButton>
-      </Popover>
-    </RenderFor>
-  {/if}
+        {/if}
+      </span>
+    </Popover>
+  </RenderFor>
 {/snippet}
 
 {#if style === "cover"}
@@ -134,7 +142,52 @@
   />
 {/if}
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  /*
+    Negative margins cancel the hit-area padding so the badge keeps the exact
+    position it had as a read-only tag; only the wash grows.
+  */
+  .trakt-history-rating-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    color: var(--color-foreground);
+
+    padding: var(--ni-6);
+    margin: var(--ni-neg-6);
+    border-radius: var(--border-radius-m);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: background-color, transform;
+
+    /*
+      Unrated shows a lone star, so it is sized here rather than by UserRating.
+      Guarded on :not(.is-rated) so the rule can never reach the rated badge's
+      own icon, which UserRating sizes.
+    */
+    &:not(.is-rated) :global(svg) {
+      width: var(--ni-20);
+      height: var(--ni-20);
+    }
+
+    @include for-mouse() {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 10%,
+          transparent
+        );
+      }
+    }
+
+    &:active {
+      transform: scale(0.92);
+    }
+  }
+
   .trakt-history-rate-popover {
     padding: var(--ni-12) var(--ni-16);
     border-radius: var(--border-radius-l);

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import { m } from "$lib/features/i18n/messages";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -13,6 +14,10 @@
   };
 
   const { title, slug, mode }: RecentlyWatchedListProps = $props();
+
+  // Only my own history rows are actionable - a rating badge on someone else's
+  // activity would be showing my rating next to their watch.
+  const { isMe } = $derived(useIsMe(slug));
 </script>
 
 <DrillableMediaList
@@ -34,6 +39,6 @@
   urlBuilder={() => UrlBuilder.profile.history(slug)}
 >
   {#snippet item(media)}
-    <RecentlyWatchedItem {media} />
+    <RecentlyWatchedItem {media} isActionable={$isMe} />
   {/snippet}
 </DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+  import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { useRecentlyWatchedList } from "../stores/useRecentlyWatchedList";
   import RecentlyWatchedItem from "./RecentlyWatchedItem.svelte";
 
   const { slug, mode }: { slug: string; mode: DiscoverMode } = $props();
+
+  // Only my own history rows are actionable - a rating badge on someone else's
+  // activity would be showing my rating next to their watch.
+  const { isMe } = $derived(useIsMe(slug));
 </script>
 
 <DrilledMediaList
@@ -18,6 +23,6 @@
     })}
 >
   {#snippet item(media)}
-    <RecentlyWatchedItem {media} style="summary" />
+    <RecentlyWatchedItem {media} style="summary" isActionable={$isMe} />
   {/snippet}
 </DrilledMediaList>


### PR DESCRIPTION

##Visuals

You can now **change** ratings from the history section and drill-down. 
<img width="1423" height="858" alt="Screenshot 2026-09-08 at 13 46 54" src="https://github.com/user-attachments/assets/b5092cc7-e40a-40e1-9953-612e80c939ab" />
<img width="1423" height="858" alt="Screenshot 2026-09-08 at 13 46 43" src="https://github.com/user-attachments/assets/ebc72338-4adf-4e52-b634-29761b1084cf" />

## What

A rating shown in History was a dead end. Once an item was rated, the badge
sat there as a read-only tag, and the only way to change that rating was to
leave the list and open the title's summary page. Rating something and
changing that rating are the same decision, so they are now the same gesture:
the badge opens the same rate popover the empty star already opened.

Everywhere History is listed:

| Surface | Before | After |
| --- | --- | --- |
| Home / profile carousel (`PersonalHistoryList`) | star opens the popover, badge is dead | both open the popover |
| `/history` L2 (`PersonalHistoryPaginatedList`) | star opens the popover, badge is dead | both open the popover |
| `/profile/me/history` L2 (`RecentlyWatchedPaginatedList`) | no rating affordance at all | both open the popover |
| Another user's profile + L2 | read-only | unchanged, read-only |

## Screenshots

<!-- drop them here -->

## How it works

Rated and unrated share **one** `<Popover>` and **one** trigger:

```svelte
<Popover content={rateContent} label={rateLabel}>
  <span class="trakt-history-rating-badge" class:is-rated={Boolean(userRating)}>
    {#if userRating}<UserRating rating={userRating} />{:else}<StarIcon fill="none" />{/if}
  </span>
</Popover>
```

Two reasons for one trigger rather than two:

- **The popover survives a rating landing.** The trigger element does not
  unmount when the badge swaps in, so the stars stay open under the cursor
  and the rating can be adjusted again immediately.
- **It drops a `<button>` inside a `<button>`.** The old unrated trigger put
  an `ActionButton` inside `Popover.Trigger`, which nests two interactive
  controls and puts two stops in the tab order for one action.

Both states now carry the same hover wash and the same `:active` press. The
lone star lost `ActionButton`'s glow and gained the badge treatment - that
direction was picked from the two side by side. Negative margins cancel the
new hit-area padding, so the badge keeps the exact position it had as a tag;
only the wash grows outward.

## State invalidation

No new wiring - this already worked and is already covered. `useRatings`
fires `invalidate(InvalidateAction.Rated(type))` after both add and remove,
and `currentUserRatingsQuery` declares all four `Rated(...)` tokens in its
`invalidations`. `useUser().ratings` reads off that query, so a change made
in the carousel is reflected in the L2 view and vice versa without a reload.
Covered by `useRatings.spec.ts` ("should call invalidate after rating").

## Notes

- **`Popover` gained an optional `label`.** The rated badge's
  name-from-content is just the number - "3" - so the trigger needs an
  explicit accessible name (`button_label_change_rating`, one new key in
  `meta/en.json`; CrowdIn owns the translated catalogs). The same commit puts
  a `:focus-visible` ring back on the trigger, which `all: unset` had been
  stripping for all three consumers.
- **`isActionable` on the profile lists is a separate fix.** They passed no
  `isActionable` at all, so `/profile/me/history` offered neither a rating
  nor a row menu while `/history` offered both. They now gate on `useIsMe`,
  which keeps another user's activity read-only - a rating badge there would
  be showing *my* rating next to *their* watch. Side effect: my own profile
  L2 now also gets the row menu and the absolute date format, matching
  `/history`.
- **The rated state is auth-gated, so I could not screenshot it myself.** The
  hover and press feel were reviewed live instead.

## Verification

- `deno fmt` on the touched dirs
- `svelte-check`: 616 errors, all the pre-existing `unwasm/plugin` baseline noise, zero real
- `vitest`: 3131 passed, 10 skipped
- `i18n:check`: placeholders consistent with source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
