### PR TITLE
refactor(rating): the star row loses its callout, its outsized star and its stroke bevel

### DIFF
--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
@@ -56,7 +56,13 @@
 
 {#if style === "action"}
   <QueuedIndicator {isQueued}>
-    <ActionButton {...commonProps} {...props} style="ghost" color="default">
+    <ActionButton
+      {...commonProps}
+      {...props}
+      style="ghost"
+      color="default"
+      classList="trakt-favorite-action-button"
+    >
       <FavoriteIcon {state} --icon-color="var(--color-background-red)" />
     </ActionButton>
   </QueuedIndicator>
@@ -71,3 +77,21 @@
     {/snippet}
   </DropdownItem>
 {/if}
+
+<style lang="scss">
+  /*
+    The heart wears the same treatment as the rating badge that opens the rate
+    popover beside it: a hover wash and a press, no glow. ActionButton draws
+    that glow from --color-background-action-button, a surface a ghost button
+    never paints, so here it reads as a shadow cast by nothing. The selector
+    repeats ActionButton's own disabled guards because it has to outrank the
+    rule it cancels.
+  */
+  :global(
+    .trakt-action-button.trakt-favorite-action-button:hover:not([disabled]):not(
+        [aria-disabled="true"]
+      )
+  ) {
+    box-shadow: none;
+  }
+</style>

--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
@@ -45,7 +45,7 @@
 </script>
 
 {#if style === "normal"}
-  <Button {...commonProps} {...props} style="ghost" color="orange">
+  <Button {...commonProps} {...props} style="ghost" color="red">
     {i18n.text({ isFavorited, title })}
     {#if isQueued}<QueuedTag />{/if}
     {#snippet icon()}
@@ -57,7 +57,7 @@
 {#if style === "action"}
   <QueuedIndicator {isQueued}>
     <ActionButton {...commonProps} {...props} style="ghost" color="default">
-      <FavoriteIcon {state} --icon-color="var(--color-background-orange)" />
+      <FavoriteIcon {state} --icon-color="var(--color-background-red)" />
     </ActionButton>
   </QueuedIndicator>
 {/if}

--- a/projects/client/src/lib/components/icons/StarIcon.svelte
+++ b/projects/client/src/lib/components/icons/StarIcon.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   const { fill }: { fill: "none" | "half" | "full" } = $props();
 
+  const STAR_PATH =
+    "M12 2L14.8214 8.11672L21.5106 8.90983L16.5651 13.4833L17.8779 20.0902L12 16.8L6.12215 20.0902L7.43493 13.4833L2.48944 8.90983L9.17863 8.11672L12 2Z";
+
   const fillWidth = $derived.by(() => {
     switch (fill) {
       case "none":
@@ -24,19 +27,16 @@
 >
   <defs>
     <clipPath id={clipId}>
-      <path
-        d="M12 2L14.8214 8.11672L21.5106 8.90983L16.5651 13.4833L17.8779 20.0902L12 16.8L6.12215 20.0902L7.43493 13.4833L2.48944 8.90983L9.17863 8.11672L12 2Z"
-      />
+      <path d={STAR_PATH} />
     </clipPath>
   </defs>
-  <path
-    class="trakt-star-path"
-    d="M12 2L14.8214 8.11672L21.5106 8.90983L16.5651 13.4833L17.8779 20.0902L12 16.8L6.12215 20.0902L7.43493 13.4833L2.48944 8.90983L9.17863 8.11672L12 2Z"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linejoin="bevel"
-    fill="transparent"
-  />
+  <!--
+    The unfilled part of the star is a dimmed fill, never a stroke. A stroked
+    outline has to bevel the star's five points, which reads as hard straight
+    edges the moment the fill slides over them - most visible on the active or
+    hovered star. Fill-only keeps the points sharp at every fill level.
+  -->
+  <path class="trakt-star-track" d={STAR_PATH} fill="currentColor" />
   <rect
     class="trakt-star-fill"
     x="0"
@@ -49,10 +49,9 @@
 </svg>
 
 <style>
-  .trakt-star-path {
-    transition:
-      fill,
-      stroke var(--transition-increment) ease-in-out;
+  .trakt-star-track {
+    opacity: var(--star-track-opacity, 0.3);
+    transition: opacity var(--transition-increment) ease-in-out;
   }
 
   .trakt-star-fill {

--- a/projects/client/src/lib/components/icons/StarIcon.svelte
+++ b/projects/client/src/lib/components/icons/StarIcon.svelte
@@ -31,12 +31,13 @@
     </clipPath>
   </defs>
   <!--
-    The unfilled part of the star is a dimmed fill, never a stroke. A stroked
-    outline has to bevel the star's five points, which reads as hard straight
-    edges the moment the fill slides over them - most visible on the active or
-    hovered star. Fill-only keeps the points sharp at every fill level.
+    The empty star is the outline; the fill is painted over it in the same
+    colour, so a fully rated star reads as one solid shape and both states
+    share an outer extent. The join is left to default (miter) rather than
+    bevel - bevel chops all five points flat, and those hard straight edges
+    are exactly what the fill exposes on the active or hovered star.
   -->
-  <path class="trakt-star-track" d={STAR_PATH} fill="currentColor" />
+  <path d={STAR_PATH} stroke="currentColor" stroke-width="2" fill="none" />
   <rect
     class="trakt-star-fill"
     x="0"
@@ -49,11 +50,6 @@
 </svg>
 
 <style>
-  .trakt-star-track {
-    opacity: var(--star-track-opacity, 0.3);
-    transition: opacity var(--transition-increment) ease-in-out;
-  }
-
   .trakt-star-fill {
     transition: width var(--transition-increment) ease-in-out;
   }

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -141,12 +141,5 @@
     background-color: var(--color-modal-background);
     box-shadow: var(--shadow-menu);
 
-    :global(svg) {
-      --icon-color: var(--color-text-primary);
-    }
-
-    :global(.is-current-rating svg) {
-      --icon-fill-color: var(--color-text-primary);
-    }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryRateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryRateNow.svelte
@@ -18,13 +18,6 @@
 
     width: 100%;
 
-    :global(svg) {
-      --icon-color: var(--color-text-primary);
-    }
-
-    :global(.is-current-rating svg) {
-      --icon-fill-color: var(--color-text-primary);
-    }
 
     :global(.trakt-action-button[disabled]) {
       background-color: transparent;

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import QueuedTag from "$lib/components/badge/QueuedTag.svelte";
-  import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import FavoriteAction from "$lib/sections/media-actions/favorite/FavoriteAction.svelte";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
@@ -15,7 +14,6 @@
   const {
     variant = "guard",
     onclick,
-    style = "default",
     ...props
   }: RateNowProps & { variant?: "allow" | "guard" } = $props();
 
@@ -66,9 +64,6 @@
     data-dpad-navigation={DpadNavigationType.List}
     transition:slide={{ duration: 150 }}
   >
-    {#if style !== "minimal"}
-      <span class="bold">{m.header_rate_now()}</span>
-    {/if}
     <div
       class="trakt-rate-actions"
       transition:fade={{ duration: 150, delay: 150 }}
@@ -96,7 +91,6 @@
         >
           <FavoriteAction
             style="action"
-            size="small"
             title={props.media.title}
             type={props.type}
             id={props.media.id}
@@ -125,8 +119,6 @@
     height: var(--ni-40);
 
     position: relative;
-
-    gap: var(--gap-m);
   }
 
   .trakt-rate-actions {

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
@@ -348,6 +348,9 @@
       gap: var(--gap-xs);
     }
 
+    // Every star keeps the same footprint at every state - the active one is
+    // called out with colour and opacity, never with size, so a selected row
+    // reads as one even sequence instead of one oversized trailing star.
     :global(.star-item) {
       display: inline-flex;
       cursor: pointer;
@@ -356,10 +359,6 @@
         transform var(--transition-increment) var(--ease-spring),
         color var(--transition-increment) var(--ease-glide),
         opacity var(--transition-increment) var(--ease-glide);
-    }
-
-    :global(.star-item[data-highlighted]) {
-      transform: scale(1.3);
     }
 
     // Tint the whole row while scrubbing, and gently recede the stars that
@@ -386,8 +385,9 @@
         bottom: calc(100% + var(--gap-l));
       }
 
+      // Lift only - no scale, so the star stays the size of its neighbours.
       :global(.star-item[data-highlighted]) {
-        transform: translateY(-0.75rem) scale(1.3);
+        transform: translateY(-0.75rem);
       }
     }
 

--- a/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
@@ -25,5 +25,4 @@ export type RateNowProps =
   & (RateableEpisode | RateableSeason | RateableMedia)
   & {
     onclick?: () => void;
-    style?: 'default' | 'minimal';
   };

--- a/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
@@ -72,7 +72,6 @@
       <RateNow
         {...lastWatched}
         variant="allow"
-        style="minimal"
         onclick={() => (interactionCounter += 1)}
       />
     </div>

--- a/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
@@ -118,12 +118,5 @@
       justify-content: flex-start;
     }
 
-    :global(svg) {
-      --icon-color: var(--color-foreground);
-    }
-
-    :global(.is-current-rating svg) {
-      --icon-fill-color: var(--color-foreground);
-    }
   }
 </style>


### PR DESCRIPTION
## What

The rate row carried three things that fought the shape it is built from, and
a heart that has never been the colour it was told to be.

| | Before | After |
| --- | --- | --- |
| Star points | `stroke-linejoin: bevel` chopped all five flat | default miter — sharp |
| Selected row | last star scaled to `1.3` | every star the same size |
| Unrated row | a bold **Rate** label to the left | the stars, which already say it |
| Heart | text-coloured, shrunk to `0.8`, glowing on hover | red, 24px like the stars, washes like the badge |

## Star points

`StarIcon` drew its unfilled half as a 2px bevelled stroke. Bevelling a
five-pointed star chops every tip flat, and those hard straight edges land
exactly where the eye does — the active or hovered star, where the fill slides
over them. The join is now the default miter, which holds at these angles
(1/sin 24.75° = 2.39, inside the miter limit of 4), so the points stay sharp.

The empty star is still the outline; the fill is painted over it in the same
colour, so a rated star reads as one solid shape and both states share an outer
extent. A dimmed-fill track was tried first and rejected — it reads as a
washed-out smudge rather than a star.

## Uniform stars

`[data-highlighted]` scaled to `1.3`, so a selected row ended in one oversized
star. Emphasis is colour and opacity now. The touch-scrub rule keeps its
`translateY` lift — that is about a thumb covering the target, not about size —
and drops the scale.

## The "Rate" label

The star row is self-explanatory, and it already carried `header_rate_now` as
the group's `aria-label`, so nothing is lost for assistive tech. Removing it
left `RateNow`'s `style: 'default' | 'minimal'` prop doing nothing at all; it
and its one call site go too.

## The heart was never red

Not orange either. Every surface that hosts `RateNow` — history popover,
summary row, now-playing toast — pinned `--icon-color` on `:global(svg)`:

```scss
:global(svg) { --icon-color: var(--color-text-primary); }
```

That sets the variable on the `<svg>` itself, deeper than the wrapper Svelte
creates for the value `FavoriteButton` hands down, so the host won every time
and the heart came out text-coloured. It swallowed the old orange the same way.
The overrides are gone: what colour the heart is belongs to `FavoriteButton`,
not to its host — `components.md` bans restyling a shared component from its
consumer. The `--icon-fill-color` rules beside them go too; nothing defines
`.is-current-rating` and nothing reads that property.

The heart also stopped shrinking. `size="small"` puts `scale: 0.8` on the whole
`ActionButton`, so a 24px heart rendered at 19px beside a 24px star.

## Hover

The heart glowed where the rating badge beside it only washes. `ActionButton`
draws that glow from `--color-background-action-button`, a surface a ghost
button never paints, so it hangs under nothing. Cancelled for this button only,
matching the badge treatment from #3229 — a wash and a `0.92` press.

That glow is wrong on every ghost `ActionButton`, not just this one, but ~50
files ship them and that sweep is its own PR.

## Verification

- `deno fmt` on `projects/client/src` (bare `deno fmt` rewrites the CrowdIn
  catalogs — reverted, zero catalog changes in this PR)
- `svelte-check`: 7739 files, 0 errors, 0 warnings
- `vitest`: 3131 passed, 10 skipped
- commitlint: both commits clean against `commitlint.config.js`
- Rendered through a throwaway `_design_system` route (since deleted): stars at
  none/half/full, the row at 8/10 · 7/10 · 0/10, the history popover's exact
  markup, and the heart hovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)