### PR TITLE
refactor(button): hover is a wash or a colour, never a glow

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -162,7 +162,7 @@
 
     transition: var(--transition-increment) cubic-bezier(0.22, 1, 0.36, 1);
     transition-property:
-      background-color, color, box-shadow, transform, outline, outline-offset;
+      background-color, color, transform, outline, outline-offset;
   }
 
   @each $color in "purple", "red", "blue", "orange", "default" {
@@ -188,20 +188,8 @@
     display: none;
   }
 
-  @include for-mouse {
-    :global(#{$b}:hover#{$on}) {
-      box-shadow: 0 var(--ni-2) var(--ni-8) var(--ni-neg-2)
-        color-mix(
-          in srgb,
-          var(--color-background-action-button) 50%,
-          transparent
-        );
-    }
-  }
-
   :global(#{$b}:active#{$on}) {
     transform: scale(0.92);
-    box-shadow: none;
   }
 
   :global(#{$b}:active[disabled]),

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -347,17 +347,8 @@
     outline: var(--border-thickness-xxs) solid var(--color-foreground);
   }
 
-  @include for-mouse {
-    :global(#{$b}[data-style=flat]:hover#{$on}) {
-      box-shadow: 0 var(--ni-4) var(--ni-12) var(--ni-neg-2)
-        color-mix(in srgb, var(--color-background-button) 45%, transparent);
-      transform: translateY(calc(var(--ni-1) * -1));
-    }
-  }
-
   :global(#{$b}[data-style=flat]:active#{$on}) {
     transform: scale(calc(var(--scale-factor-button) * 0.97));
-    box-shadow: none;
   }
 
   :global(#{$b}[data-style=underlined]) {
@@ -434,8 +425,8 @@
     }
   }
 
-  // Press feedback to match `flat`/`ghost`; keep the stroke (unlike `flat`,
-  // whose box-shadow is a hover lift, outline's box-shadow is the border).
+  // Press feedback to match `flat`/`ghost`; keep the stroke - outline's
+  // box-shadow IS the border, not decoration.
   :global(#{$b}[data-style=outline]:active#{$on}) {
     transform: scale(calc(var(--scale-factor-button) * 0.97));
   }

--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
@@ -56,13 +56,7 @@
 
 {#if style === "action"}
   <QueuedIndicator {isQueued}>
-    <ActionButton
-      {...commonProps}
-      {...props}
-      style="ghost"
-      color="default"
-      classList="trakt-favorite-action-button"
-    >
+    <ActionButton {...commonProps} {...props} style="ghost" color="default">
       <FavoriteIcon {state} --icon-color="var(--color-background-red)" />
     </ActionButton>
   </QueuedIndicator>
@@ -77,21 +71,3 @@
     {/snippet}
   </DropdownItem>
 {/if}
-
-<style lang="scss">
-  /*
-    The heart wears the same treatment as the rating badge that opens the rate
-    popover beside it: a hover wash and a press, no glow. ActionButton draws
-    that glow from --color-background-action-button, a surface a ghost button
-    never paints, so here it reads as a shadow cast by nothing. The selector
-    repeats ActionButton's own disabled guards because it has to outrank the
-    rule it cancels.
-  */
-  :global(
-    .trakt-action-button.trakt-favorite-action-button:hover:not([disabled]):not(
-        [aria-disabled="true"]
-      )
-  ) {
-    box-shadow: none;
-  }
-</style>

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -239,10 +239,6 @@
         }
       }
 
-      :global(.ratings-drilldown:hover) {
-        box-shadow: none;
-      }
-
       :global(.ratings-drilldown:active) {
         transform: scale(0.98);
       }

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -238,8 +238,6 @@
   @include for-mouse {
     :global(#{$selector}[data-style='flat']:hover:not([disabled]):not([aria-disabled='true'])),
     :global(#{$selector}[data-style='flat']:focus-visible:not([disabled]):not([aria-disabled='true'])) {
-      transform: none;
-      box-shadow: none;
       border-color: var(--color-card-border-hover);
     }
   }


### PR DESCRIPTION
Stacked on #3230 — **base is `feat/star-rating-cleanup`**, retarget to `main` once that lands.

## What

Two rules drew a coloured drop shadow on hover:

| Rule | Reach | Shadow |
| --- | --- | --- |
| `ActionButton :hover` | every icon button, ~50 files | `0 2px 8px -2px` from `--color-background-action-button` at 50% |
| `Button [data-style=flat]:hover` | every primary CTA | `0 4px 12px -2px` from `--color-background-button` at 45%, plus `translateY(-1px)` |

Both are mixed from the button's **own background colour**, which is why they
read as a glow rather than as elevation — a real drop shadow does not take the
hue of the thing casting it. And on a ghost button, which paints no background
at all, the glow hangs under nothing.

There is now one hover idiom everywhere, the one the favourite heart got in
#3230:

- **ghost** → washes to `--color-foreground` at 10%
- **filled** → inverts its foreground and background
- **press** → stays a `scale()`
- **nothing** casts a shadow

## Dead code that went with it

Three places existed only to cancel these shadows:

- `FavoriteButton` — the scoped `box-shadow: none` added in #3230, now covered
  by the global rule.
- `RatingList` — `:global(.ratings-drilldown:hover) { box-shadow: none }`,
  cancelling the ActionButton glow by hand.
- `card-outline-button` mixin — `transform: none` and `box-shadow: none` on
  `flat:hover`, undoing the lift and glow so a card-shaped button would sit
  still. Only the `border-color` swap was ever doing anything.

Net −51 lines.

## Not touched

The bespoke hover shadows on YIR headers, the profile all-time-review link and
a few one-off cards. They are surface decoration rather than a button idiom, and
sweeping them was explicitly out of scope.

`outline`'s `box-shadow` is untouched — that one **is** the border, not
decoration. The comment saying so has been corrected now that it no longer has
`flat`'s lift to contrast itself against.

## Verification

- `deno fmt` on `projects/client/src` (bare `deno fmt` rewrites the CrowdIn
  catalogs — zero catalog changes in this PR)
- `svelte-check`: 7739 files, 0 errors, 0 warnings
- `vitest`: 3131 passed, 10 skipped
- commitlint: clean
- Rendered all four states through a throwaway `_design_system` route (since
  deleted), forcing `:hover` via CDP: ghost + filled `ActionButton`, `flat` +
  ghost `Button`. Every hovered state is a flat wash or a colour inversion, no
  shadow anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)