### PR TITLE
VIP: PayPal switch card + re-signup mode

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6888,6 +6888,38 @@
       "default": "Billed every 2 years",
       "description": "Short billing frequency label for 2-year VIP plan displayed on the subscription card."
     },
+    "header_vip_paypal_switch": {
+      "default": "Switch to credit card",
+      "description": "Header for the card on the VIP manage page inviting PayPal subscribers to switch their payment method to credit card."
+    },
+    "text_vip_paypal_switch": {
+      "default": "Move your VIP subscription from PayPal to a credit card. You won't lose any VIP time, and your PayPal subscription is cancelled automatically once you pick a new plan.",
+      "description": "Description for the card on the VIP manage page inviting PayPal subscribers to switch their payment method to credit card."
+    },
+    "button_text_vip_paypal_switch": {
+      "default": "View plans",
+      "description": "Text for the button that opens the VIP plans page so a PayPal subscriber can switch to credit card. This should be as short as possible."
+    },
+    "button_label_vip_paypal_switch": {
+      "default": "View VIP plans and switch to credit card",
+      "description": "Aria-label for the button that opens the VIP plans page so a PayPal subscriber can switch to credit card."
+    },
+    "header_vip_two_year_deal": {
+      "default": "Pay for 1 year, get 2 years of VIP!",
+      "description": "Header for the banner on the VIP plans page announcing a first-term discount on the 2 year plan."
+    },
+    "text_vip_two_year_deal": {
+      "default": "You've unlocked the 2 year plan for {price}, then {renewalPrice} every 2 years. The discount is applied automatically at checkout.",
+      "description": "Description for the banner on the VIP plans page announcing a first-term discount on the 2 year plan.",
+      "variables": {
+        "price": {
+          "type": "string"
+        },
+        "renewalPrice": {
+          "type": "string"
+        }
+      }
+    },
     "usage_title_lists": {
       "default": "Lists",
       "description": "Title for the section that shows a user's lists usage, such as their list item counts and limits."

--- a/projects/client/src/lib/sections/vip/VipManage.svelte
+++ b/projects/client/src/lib/sections/vip/VipManage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import AccountDetails from "./_internal/AccountDetails.svelte";
+  import PaypalSwitchCard from "./_internal/PaypalSwitchCard.svelte";
   import UsageTabs from "./_internal/UsageTabs.svelte";
   import { useVip } from "./_internal/useVip";
   import VipContent from "./_internal/VipContent.svelte";
@@ -12,6 +13,7 @@
   {#if !$isLoading}
     <div class="trakt-vip-account-group">
       <AccountDetails subscription={$subscription} />
+      <PaypalSwitchCard subscription={$subscription} />
     </div>
 
     <UsageTabs subscription={$subscription} />

--- a/projects/client/src/lib/sections/vip/_internal/PaypalSwitchCard.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/PaypalSwitchCard.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import { m } from "$lib/features/i18n/messages";
+  import { type VipSubscription } from "$lib/requests/models/VipSubscription";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { useVip } from "./useVip";
+  import { isPaypalGateway } from "./utils/isPaypalGateway";
+  import { toVipPriceLabel } from "./utils/toVipPriceLabel";
+
+  const { subscription }: { subscription: VipSubscription | Nil } = $props();
+
+  const { plans } = useVip();
+
+  const isPaypal = $derived(isPaypalGateway(subscription?.gateway));
+
+  // On the manage page a discounted 2-year plan can only be the PayPal switch
+  // deal, so surface its pricing when the API returns one.
+  const dealPlan = $derived(
+    $plans.find((plan) => plan.type === "two_years" && plan.discount != null),
+  );
+</script>
+
+{#if isPaypal}
+  <div class="trakt-paypal-switch-card">
+    <div class="switch-copy">
+      <h2>{m.header_vip_paypal_switch()}</h2>
+      <p>{m.text_vip_paypal_switch()}</p>
+    </div>
+
+    <div class="switch-action">
+      {#if dealPlan?.discount}
+        <div class="switch-price">
+          <span class="price">
+            {toVipPriceLabel(dealPlan.discount.discountedAmountMonthly)}
+            <span class="per-month">/mo</span>
+          </span>
+          <span class="billed-text">{m.text_vip_billed_biyearly()}</span>
+        </div>
+      {/if}
+      <Button
+        size="small"
+        label={m.button_label_vip_paypal_switch()}
+        color="custom"
+        variant="primary"
+        style="flat"
+        text="uppercase"
+        href={UrlBuilder.renewVip()}
+      >
+        {m.button_text_vip_paypal_switch()}
+      </Button>
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-paypal-switch-card {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--gap-l);
+
+    width: 100%;
+    max-width: var(--ni-768);
+
+    @include vip-glow-card;
+
+    border: var(--ni-1) solid var(--color-vip-border-accent);
+    border-radius: var(--border-radius-xxl);
+
+    padding: var(--ni-24);
+    box-sizing: border-box;
+
+    @include for-tablet-sm-and-below {
+      padding: var(--ni-18);
+    }
+  }
+
+  .switch-copy {
+    flex: 1 1 var(--ni-280);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+
+    h2 {
+      font-size: var(--ni-20);
+    }
+
+    p {
+      margin: 0;
+      font-size: var(--ni-14);
+      color: var(--color-text-secondary);
+    }
+  }
+
+  .switch-action {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-s);
+
+    margin: 0 auto;
+
+    .switch-price {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .price {
+      font-size: var(--ni-28);
+      font-variant-numeric: tabular-nums;
+
+      .per-month {
+        font-size: 0.5em;
+      }
+    }
+
+    .billed-text {
+      font-size: var(--ni-12);
+      opacity: 0.7;
+    }
+
+    :global(.trakt-button) {
+      --color-background-custom: var(--purple-500);
+      --color-foreground-custom: var(--shade-10);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/vip/_internal/SubscriptionCard.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/SubscriptionCard.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import { languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { toHumanCurrency } from "$lib/utils/formatting/currency/toHumanCurrency";
   import type { VipPlan } from "./models/VipPlan";
   import MostPopularTag from "./MostPopularTag.svelte";
   import { useVip } from "./useVip";
+  import { toVipPriceLabel } from "./utils/toVipPriceLabel";
 
   const {
     plan,
@@ -21,12 +20,9 @@
     }
   };
 
-  const formatCurrency = (price: number) =>
-    toHumanCurrency({ price, currency: "usd", locale: languageTag() });
-
   const splitPrice = (price: number) => {
     const isWholeNumber = price % 1 === 0;
-    const formatted = formatCurrency(price);
+    const formatted = toVipPriceLabel(price);
 
     if (isWholeNumber) {
       return { whole: formatted, cents: null };

--- a/projects/client/src/lib/sections/vip/_internal/Subscriptions.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/Subscriptions.svelte
@@ -4,6 +4,7 @@
   import { VIP_PLANS } from "./constants";
   import TraktIcon from "./icons/TraktIcon.svelte";
   import SubscriptionCard from "./SubscriptionCard.svelte";
+  import TwoYearDealBanner from "./TwoYearDealBanner.svelte";
   import { useVip } from "./useVip";
   import VipContentContainer from "./VipContentContainer.svelte";
   import VipHeader from "./VipHeader.svelte";
@@ -35,6 +36,8 @@
       {/snippet}
     </VipHeader>
   {/snippet}
+
+  <TwoYearDealBanner />
 
   <div class="trakt-vip-subscription-plans">
     {#each activePlans as plan (plan.type)}

--- a/projects/client/src/lib/sections/vip/_internal/TwoYearDealBanner.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/TwoYearDealBanner.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { m } from "$lib/features/i18n/messages";
+  import { useVip } from "./useVip";
+  import { toVipPriceLabel } from "./utils/toVipPriceLabel";
+
+  const { plans } = useVip();
+
+  // A first-term-only discount on the 2 year plan is a deal (former VIP rejoin
+  // or PayPal switch); the always-on v3 Lite discount is not first-term-only.
+  const dealPlan = $derived(
+    $plans.find(
+      (plan) => plan.type === "two_years" && plan.discount?.firstTermOnly,
+    ),
+  );
+</script>
+
+{#if dealPlan?.discount}
+  <div class="trakt-two-year-deal-banner">
+    <h2>{m.header_vip_two_year_deal()}</h2>
+    <p>
+      {m.text_vip_two_year_deal({
+        price: toVipPriceLabel(dealPlan.discount.discountedAmount),
+        renewalPrice: toVipPriceLabel(dealPlan.totalPrice),
+      })}
+    </p>
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-two-year-deal-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    text-align: center;
+
+    width: 100%;
+    max-width: var(--ni-620);
+
+    @include vip-glow-card;
+
+    border: var(--ni-1) solid var(--color-vip-border-accent);
+    border-radius: var(--border-radius-xxl);
+
+    padding: var(--ni-18) var(--ni-24);
+    box-sizing: border-box;
+
+    margin-top: var(--ni-24);
+
+    h2 {
+      font-size: var(--ni-18);
+    }
+
+    p {
+      margin: 0;
+      font-size: var(--ni-14);
+      color: var(--color-text-secondary);
+    }
+
+    @include for-mobile {
+      max-width: var(--ni-280);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/vip/_internal/utils/isPaypalGateway.ts
+++ b/projects/client/src/lib/sections/vip/_internal/utils/isPaypalGateway.ts
@@ -1,0 +1,5 @@
+import type { VipGateway } from '$lib/requests/models/VipGateway.ts';
+
+export function isPaypalGateway(gateway: VipGateway | Nil): boolean {
+  return gateway === 'paypal' || gateway === 'paypal_api';
+}

--- a/projects/client/src/lib/sections/vip/_internal/utils/toVipPriceLabel.ts
+++ b/projects/client/src/lib/sections/vip/_internal/utils/toVipPriceLabel.ts
@@ -1,0 +1,6 @@
+import { languageTag } from '$lib/features/i18n/index.ts';
+import { toHumanCurrency } from '$lib/utils/formatting/currency/toHumanCurrency.ts';
+
+export function toVipPriceLabel(price: number): string {
+  return toHumanCurrency({ price, currency: 'usd', locale: languageTag() });
+}

--- a/projects/client/src/routes/vip/renew/+page.svelte
+++ b/projects/client/src/routes/vip/renew/+page.svelte
@@ -3,21 +3,30 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { useVip } from "$lib/sections/vip/_internal/useVip";
+  import { isPaypalGateway } from "$lib/sections/vip/_internal/utils/isPaypalGateway";
   import VipSubscribe from "$lib/sections/vip/VipSubscribe.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   const { subscription, isLoading } = useVip();
+
+  // Re-signup mode: cancelled subscriptions renew here, and PayPal VIPs pick a
+  // new plan here to switch to credit card (the API cancels PayPal after a
+  // successful Stripe checkout). Active subscriptions on other gateways are
+  // redirected so they can't double-subscribe.
+  const canResubscribe = $derived(
+    $subscription?.isCancelled || isPaypalGateway($subscription?.gateway),
+  );
 </script>
 
-{#if $subscription && !$subscription.isCancelled}
+{#if $subscription && !canResubscribe}
   <Redirect to={UrlBuilder.vip()} />
 {/if}
 
 <TraktPage audience="authenticated" image={DEFAULT_SHARE_COVER} title="VIP">
   <NavbarStateSetter mode="minimal" />
 
-  {#if !$isLoading && $subscription?.isCancelled}
+  {#if !$isLoading && canResubscribe}
     <VipSubscribe />
   {/if}
 </TraktPage>


### PR DESCRIPTION
# Summary

Gives active PayPal VIPs a path to the 2 Year Switch Deal. Companion to trakt/trakt-rails#2461: the API already returns the discounted 2-year plan and applies the coupon at checkout for eligible PayPal VIPs, but the manage page had no pricing or checkout path, so the deal was invisible to them.

# Changes

**PaypalSwitchCard** (new, on the VIP manage page): renders under the account details for `paypal` / `paypal_api` gateways with generic "Switch to credit card" copy, so it stays valid beyond this campaign. When `GET /vip/plans` returns a 2-year discount (which on the manage page can only be the switch deal), the card surfaces its monthly price. The View plans button links to `/vip/renew`.

<img width="760" height="324" alt="image" src="https://github.com/user-attachments/assets/970d04d7-4b7e-4f1f-adea-e1cb04441e66" />

**Re-signup mode** (`/vip/renew`): previously redirected anyone whose subscription wasn't cancelled. It now also opens for active PayPal VIPs so they can pick a plan; the switch-deal email links here directly. Active Stripe/Apple/Google subscribers are still redirected to the manage page so they can't double-subscribe.

<img width="834" height="430" alt="image" src="https://github.com/user-attachments/assets/fccafecd-5f10-4302-82f0-1d80c80b74bf" />

Server-side (already in the Rails PR): any plan a PayPal VIP checks out with cancels their PayPal subscription via `cancel_paypal` metadata, not just the 2-year plan, so re-signup mode can safely offer all three durations. The $36 coupon itself remains 2-years-only.

# Notes

- Four new i18n keys in `i18n/meta/en.json` only, pending the usual locale regeneration.
- The PayPal segment email (`vip:switch_deal_2026_paypal`) should not be sent until this is deployed. The former-VIP segment doesn't depend on this PR.