### PR TITLE
fix: stop intermittent HTTP ERROR 503 on page load

### DIFF
--- a/projects/client/src/lib/features/auth/authMarker.spec.ts
+++ b/projects/client/src/lib/features/auth/authMarker.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const idb = vi.hoisted(() => ({
+  createStore: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock('idb-keyval', () => idb);
+
+// `indexedDB` only has to exist; `createStore` is mocked, so nothing opens it.
+vi.stubGlobal('indexedDB', {});
+
+// What a storage-partitioned or locked-down context throws. `createStore` is
+// lazy, so this surfaces synchronously out of `get`/`set` rather than as a
+// rejected promise.
+const blocked = () => {
+  throw new DOMException(
+    'IDBFactory.open() called in an invalid security context',
+    'SecurityError',
+  );
+};
+
+async function importAuthMarker() {
+  vi.resetModules();
+  return await import('./authMarker.ts');
+}
+
+describe('util: authMarker', () => {
+  beforeEach(() => {
+    idb.createStore.mockReturnValue(vi.fn());
+  });
+
+  describe('when storage is blocked', () => {
+    it('should read as signed out rather than reject', async () => {
+      idb.get.mockImplementation(blocked);
+
+      const { readAuthMarker } = await importAuthMarker();
+
+      await expect(readAuthMarker()).resolves.toBe(false);
+    });
+
+    it('should discard a write rather than reject', async () => {
+      idb.set.mockImplementation(blocked);
+
+      const { writeAuthMarker } = await importAuthMarker();
+
+      await expect(writeAuthMarker(true)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('when storage rejects asynchronously', () => {
+    it('should read as signed out', async () => {
+      idb.get.mockRejectedValue(new Error('transaction aborted'));
+
+      const { readAuthMarker } = await importAuthMarker();
+
+      await expect(readAuthMarker()).resolves.toBe(false);
+    });
+
+    it('should discard a write', async () => {
+      idb.set.mockRejectedValue(new Error('transaction aborted'));
+
+      const { writeAuthMarker } = await importAuthMarker();
+
+      await expect(writeAuthMarker(true)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('when storage is available', () => {
+    it('should read the stored marker', async () => {
+      idb.get.mockResolvedValue(true);
+
+      const { readAuthMarker } = await importAuthMarker();
+
+      await expect(readAuthMarker()).resolves.toBe(true);
+    });
+
+    it('should read an unset marker as signed out', async () => {
+      idb.get.mockResolvedValue(undefined);
+
+      const { readAuthMarker } = await importAuthMarker();
+
+      await expect(readAuthMarker()).resolves.toBe(false);
+    });
+
+    it('should write the marker', async () => {
+      idb.set.mockResolvedValue(undefined);
+
+      const { writeAuthMarker } = await importAuthMarker();
+      await writeAuthMarker(true);
+
+      expect(idb.set).toHaveBeenCalledWith(
+        'is-authorized',
+        true,
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/projects/client/src/lib/features/auth/authMarker.ts
+++ b/projects/client/src/lib/features/auth/authMarker.ts
@@ -21,13 +21,19 @@ function getStore(): UseStore | null {
   }
 }
 
+// `idb-keyval`'s lazy open throws synchronously, so a chained `.catch()` never
+// attaches.
 export async function readAuthMarker(): Promise<boolean> {
   const current = getStore();
   if (!current) {
     return false;
   }
 
-  return await get<boolean>(MARKER_KEY, current).catch(() => false) ?? false;
+  try {
+    return await get<boolean>(MARKER_KEY, current) ?? false;
+  } catch {
+    return false;
+  }
 }
 
 export async function writeAuthMarker(isAuthorized: boolean): Promise<void> {
@@ -36,5 +42,9 @@ export async function writeAuthMarker(isAuthorized: boolean): Promise<void> {
     return;
   }
 
-  await set(MARKER_KEY, isAuthorized, current).catch(() => {});
+  try {
+    await set(MARKER_KEY, isAuthorized, current);
+  } catch {
+    // SecurityError: storage is blocked.
+  }
 }

--- a/projects/client/src/lib/features/query/_internal/createIdbPersister.spec.ts
+++ b/projects/client/src/lib/features/query/_internal/createIdbPersister.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const idb = vi.hoisted(() => ({
+  createStore: vi.fn(),
+  del: vi.fn(),
+  entries: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock('idb-keyval', () => idb);
+
+// What a storage-partitioned or locked-down context throws. `createStore` is
+// lazy, so this surfaces synchronously out of the idb-keyval call rather than
+// as a rejected promise.
+const blocked = () => {
+  throw new DOMException(
+    'IDBFactory.open() called in an invalid security context',
+    'SecurityError',
+  );
+};
+
+async function importPersister() {
+  vi.resetModules();
+  const { createIdbPersister } = await import('./createIdbPersister.ts');
+  return createIdbPersister();
+}
+
+const DATA_UPDATED_AT = new Date('2026-09-09T00:00:00.000Z').getTime();
+
+const persistedQuery = {
+  buster: 'v3',
+  queryHash: '["movie"]',
+  queryKey: ['movie'],
+  state: { data: { title: 'Heretic' }, dataUpdatedAt: DATA_UPDATED_AT },
+};
+
+describe('util: createIdbPersister', () => {
+  beforeEach(() => {
+    idb.createStore.mockReturnValue(vi.fn());
+    idb.del.mockResolvedValue(undefined);
+    idb.entries.mockResolvedValue([]);
+    idb.get.mockResolvedValue(undefined);
+    idb.set.mockResolvedValue(undefined);
+  });
+
+  describe('when storage is blocked', () => {
+    it('should sweep as if storage were empty rather than reject', async () => {
+      idb.entries.mockImplementation(blocked);
+
+      const persister = await importPersister();
+
+      await expect(persister.persisterGc()).resolves.toBeUndefined();
+    });
+
+    it('should retrieve nothing rather than reject', async () => {
+      idb.get.mockImplementation(blocked);
+
+      const persister = await importPersister();
+
+      await expect(
+        persister.retrieveQuery('["movie"]'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should discard a removal rather than reject', async () => {
+      idb.entries.mockResolvedValue([
+        [`tanstack-query-${persistedQuery.queryHash}`, persistedQuery],
+      ]);
+      idb.del.mockImplementation(blocked);
+
+      const persister = await importPersister();
+
+      await expect(persister.removeQueries()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('when storage rejects asynchronously', () => {
+    it('should sweep as if storage were empty', async () => {
+      idb.entries.mockRejectedValue(new Error('transaction aborted'));
+
+      const persister = await importPersister();
+
+      await expect(persister.persisterGc()).resolves.toBeUndefined();
+    });
+
+    it('should retrieve nothing', async () => {
+      idb.get.mockRejectedValue(new Error('transaction aborted'));
+
+      const persister = await importPersister();
+
+      await expect(
+        persister.retrieveQuery('["movie"]'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('when storage is available', () => {
+    it('should retrieve a stored query', async () => {
+      idb.get.mockResolvedValue(persistedQuery);
+
+      const persister = await importPersister();
+
+      await expect(persister.retrieveQuery('["movie"]')).resolves.toEqual(
+        persistedQuery.state.data,
+      );
+    });
+
+    it('should sweep a busted entry', async () => {
+      const key = `tanstack-query-${persistedQuery.queryHash}`;
+      idb.entries.mockResolvedValue([[key, {
+        ...persistedQuery,
+        buster: 'v2',
+      }]]);
+
+      const persister = await importPersister();
+      await persister.persisterGc();
+
+      expect(idb.del).toHaveBeenCalledWith(key, expect.anything());
+    });
+  });
+});

--- a/projects/client/src/lib/features/query/_internal/createIdbPersister.ts
+++ b/projects/client/src/lib/features/query/_internal/createIdbPersister.ts
@@ -20,6 +20,19 @@ const handleError = (e: unknown) => {
   error('IDB Persister Error:', e);
 };
 
+// `idb-keyval`'s lazy open throws synchronously, so a chained `.catch()` never
+// attaches.
+async function orUndefined<T>(
+  operation: () => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await operation();
+  } catch (e) {
+    handleError(e);
+    return undefined;
+  }
+}
+
 // Storage round-trips PersistedQuery through IDB structured clone, so Dates,
 // Maps, Sets, and other built-ins survive rehydration. The default JSON
 // serializer would coerce them to plain strings/objects and break consumers
@@ -29,28 +42,20 @@ function createIdbStorage(): AsyncStorage<PersistedQuery> {
 
   return {
     getItem: monitor(
-      (key: string) =>
-        get<PersistedQuery>(key, store).catch((e) => {
-          handleError(e);
-          return undefined;
-        }),
+      (key: string) => orUndefined(() => get<PersistedQuery>(key, store)),
       'IDB Restorer',
     ),
     setItem: monitor(
       (key: string, value: PersistedQuery) =>
-        set(key, value, store).catch(handleError),
+        orUndefined(() => set(key, value, store)),
       'IDB Persister',
     ),
-    removeItem: (key: string) => del(key, store).catch(handleError),
-    entries: () =>
-      entries<string, PersistedQuery>(store)
-        .then((rows) =>
-          rows.map(([k, v]) => [String(k), v] as [string, PersistedQuery])
-        )
-        .catch((e) => {
-          handleError(e);
-          return [];
-        }),
+    removeItem: (key: string) => orUndefined(() => del(key, store)),
+    entries: async () =>
+      await orUndefined(async () => {
+        const rows = await entries<string, PersistedQuery>(store);
+        return rows.map(([k, v]) => [String(k), v] as [string, PersistedQuery]);
+      }) ?? [],
   };
 }
 

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -53,26 +53,33 @@ self.addEventListener('unhandledrejection', (event) => {
   console.error('Service Worker unhandledrejection:', event.reason);
 });
 
-// Global Workbox catch handler: log the failure and fall back to network
-setCatchHandler(async ({ event, request, url }) => {
-  console.error('Workbox route handler failed for:', {
-    url: request?.url ?? url?.toString(),
-    method: request?.method,
-    type: request?.destination,
-  });
+const RETRY_DELAY_MS = time.seconds(1);
 
-  // Try network as a safe fallback so the page still loads
-  try {
-    return await fetch(request || event.request);
-  } catch (err) {
-    console.error('Network fallback also failed:', err);
-    // Return a 503 response rather than letting respondWith reject.
-    return new Response('Service worker fetch failed', {
-      status: 503,
-      statusText: 'Service Worker Error',
-      headers: { 'Content-Type': 'text/plain' },
-    });
+const isIdempotentNavigation = (request: Request) =>
+  request.mode === 'navigate' && request.method === 'GET';
+
+// Workbox lands here when the network rejected and the cache missed. A
+// synthesised error status on a document renders as the browser's own "HTTP
+// ERROR" interstitial, so fail the way a fetch with no worker installed does.
+setCatchHandler(async ({ event, request }) => {
+  const failed = request ?? event.request;
+
+  const response = await fetch(failed).catch(() => null);
+
+  if (response) {
+    return response;
   }
+
+  if (!isIdempotentNavigation(failed)) {
+    return Response.error();
+  }
+
+  await delay(RETRY_DELAY_MS);
+
+  return await fetch(failed).catch(() => {
+    console.error('Service worker could not fetch:', failed.url);
+    return Response.error();
+  });
 });
 
 const toSeconds = (milliseconds: number) => milliseconds / time.seconds(1);
@@ -102,25 +109,35 @@ const navigationCacheName = `${CacheKey.navigation}-${buildSha}`;
 
 const CLEANUP_TIMEOUT_MS = time.seconds(3);
 
-async function deleteNavigationCaches() {
+async function deleteNavigationCaches(isDeletable: (key: string) => boolean) {
   const keys = await caches.keys().catch(() => []);
 
   await Promise.all(
-    keys
-      .filter((key) => key.startsWith(CacheKey.navigation))
-      .map((key) => deleteCache(key)),
+    keys.filter(isDeletable).map((key) => deleteCache(key)),
   );
 }
 
-// The cache name is keyed to the build, so this is garbage collection, not
-// correctness. Broken storage can hang instead of rejecting, and every caller
-// sits on something a user is waiting for: activation, a `_cb` navigation, or
-// a CacheBust round trip.
+const isNavigationCache = (key: string) => key.startsWith(CacheKey.navigation);
+
+// Broken storage can hang instead of rejecting, and every caller sits on
+// something a user is waiting for.
+const withCleanupTimeout = (cleanup: Promise<void>) =>
+  Promise.race([cleanup, delay(CLEANUP_TIMEOUT_MS)]);
+
+// Keeping this build's cache leaves a navigation that races a network blip
+// something to fall back on, and stops a lost race from deleting fresh
+// documents.
+function evictStaleNavigationCaches() {
+  return withCleanupTimeout(
+    deleteNavigationCaches((key) =>
+      isNavigationCache(key) && key !== navigationCacheName
+    ),
+  );
+}
+
+// `_cb` and CacheBust ask for fresh HTML, so they take this build's cache too.
 function removeNavigationCache() {
-  return Promise.race([
-    deleteNavigationCaches(),
-    delay(CLEANUP_TIMEOUT_MS),
-  ]);
+  return withCleanupTimeout(deleteNavigationCaches(isNavigationCache));
 }
 
 // Force immediate activation for new service worker
@@ -135,7 +152,7 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(
     Promise.all([
       self.clients.claim(),
-      removeNavigationCache(),
+      evictStaleNavigationCaches(),
     ]).catch(() => undefined),
   );
 });


### PR DESCRIPTION
## What's happening

The app intermittently showed Chrome's `HTTP ERROR 503` page. A refresh always fixed it, and it had been getting more frequent.

The 503 was **not** coming from Cloudflare. The service worker was manufacturing it:

```ts
return new Response('Service worker fetch failed', { status: 503, ... });
```

Browsers substitute their own error interstitial for a short-bodied error status on a document request, so this read as a server outage the origin was never having.

## Why it fired

Sentry pointed at the root cause: `SecurityError: IDBFactory.open() called in an invalid security context`, 566 events across [TRAKT-WEB-B9S](https://trakt-tv.sentry.io/issues/TRAKT-WEB-B9S) and [TRAKT-WEB-9Z6](https://trakt-tv.sentry.io/issues/TRAKT-WEB-9Z6), still firing, overwhelmingly iOS.

`authMarker.ts` looked defensive but wasn't. `idb-keyval`'s `createStore` is **lazy** — it never calls `indexedDB.open()`. The open happens on first use, *synchronously*, inside `get`/`set`:

```js
const getDB = () => { ...; const request = indexedDB.open(dbName); ... };
return (txMode, callback) => getDB().then(...);   // getDB() runs synchronously
```

So in a blocked-storage context they throw **before returning a promise**, and the chained `.catch()` never attaches. `getStore()`'s try/catch was guarding a call that cannot throw.

That rejection propagates into the service worker, which reads the marker to key cached documents. A rejected cache key fails `fetchAndCachePut` and then `cacheMatch` — which Workbox does **not** wrap in a try/catch — so the strategy throws and *every* navigation falls through to the catch handler. Affected users were one network blip away from an error page on any page load. Hence: intermittent, refresh fixes it, skewed mobile.

## Changes

**`fix(auth)`** — `try`/`catch` around the `await`, which catches the synchronous throw and an async rejection alike.

**`fix(pwa)`** — two service-worker fixes:
- Fail with `Response.error()` (what the browser does with no worker installed) instead of a synthesised status. The retry is now delayed rather than running in the same tick as the fetch that just failed, so transient blips self-recover. Only GET navigations retry, so a form submission is never resent.
- Activation keeps the current build's cache. The sweep matched every name prefixed with the navigation key — its own included — and races a 3s timeout that can leave it running detached, long enough to delete documents the new build had just cached. So the fallback never survived to be used. `_cb`/CacheBust still clear everything.

Replaying another build's HTML was considered and rejected: it references `_app/immutable` chunks the deploy no longer serves, which is exactly what 8f50d7832 fixed.

## Testing

New `authMarker.spec.ts`. I verified the two "storage is blocked" cases **fail** against the old `.catch()` implementation and pass against the fix, while the async-rejection cases pass against both — so they pin the actual regression rather than passing vacuously.

Full suite: 3150 passed, 0 failures. `deno task check` and `deno task lint` show no new issues.

## Note

Production is still on `6de102491b` (2026-09-08). The `build` job in `ci_cd.yml` shares a concurrency group with `files-changed`, so rapid pushes cancel each other before the deploy step. Worth fixing separately, or this won't ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)