### PR TITLE
Discover: premiere/finale toggles for releases 

### DIFF
--- a/projects/client/src/lib/features/calendar/ReleasesCalendar.svelte
+++ b/projects/client/src/lib/features/calendar/ReleasesCalendar.svelte
@@ -8,6 +8,7 @@
   import { useCalendarPeriod } from "./context/useCalendarPeriod";
   import type { CalendarPeriod } from "./models/CalendarLayoutProps";
   import ReleasesCalendarItem from "./ReleasesCalendarItem.svelte";
+  import { useEpisodeType } from "./useEpisodeType";
 
   const order = "chronological" as const;
 
@@ -24,21 +25,25 @@
   const { mode } = useDiscover();
   const { filterMap } = useFilter();
 
+  const { episodeType } = useEpisodeType();
+
   const days = $derived(getDaysDifference($startDate, $endDate));
 
-  const { isLoading, calendar } = $derived(
+  const { isLoading, calendar, hasUpstreamItems } = $derived(
     useReleasesCalendar({
       start: $startDate,
       days,
       type: $mode,
       filter: $filterMap,
+      episodeType,
     }),
   );
 
   const periods: CalendarPeriod<ReleasesCalendarEntry>[] = $derived(
     accumulate({
       calendar: $calendar,
-      fingerprint: `releases:${$mode}:${JSON.stringify($filterMap)}`,
+      fingerprint: `releases:${$mode}:${JSON.stringify($filterMap)}:${$episodeType}`,
+      isEmpty: !$hasUpstreamItems,
     }),
   );
 

--- a/projects/client/src/lib/features/calendar/_internal/toCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/toCalendar.ts
@@ -1,0 +1,22 @@
+import { addDays } from '$lib/utils/date/addDays.ts';
+import { isSameDay } from 'date-fns/isSameDay';
+import type { Calendar } from '../models/Calendar.ts';
+
+type ToCalendarParams<T> = {
+  items: ReadonlyArray<T>;
+  start: Date;
+  days: number;
+};
+
+export function toCalendar<T extends { effectiveReleaseDate: Date }>(
+  { items, start, days }: ToCalendarParams<T>,
+): Calendar<T> {
+  return Array.from({ length: days }, (_, i) => {
+    const date = addDays(start, i);
+
+    return {
+      date,
+      items: items.filter((item) => isSameDay(item.effectiveReleaseDate, date)),
+    };
+  });
+}

--- a/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
@@ -12,13 +12,13 @@ import { upcomingMediaQuery } from '$lib/requests/queries/calendars/upcomingMedi
 import { upcomingMoviesQuery } from '$lib/requests/queries/calendars/upcomingMoviesQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { isSameDay } from 'date-fns/isSameDay';
 import { combineLatest, map, type Observable } from 'rxjs';
 import type { FilterParams } from '../../../requests/models/FilterParams.ts';
 import type { DiscoverMode } from '../../filters/models/DiscoverMode.ts';
+import { filterByEpisodeType } from '../filterByEpisodeType.ts';
 import type { Calendar } from '../models/Calendar.ts';
-import { matchesEpisodeTypeFilter } from '../matchesEpisodeTypeFilter.ts';
 import type { EpisodeTypeFilter } from '../models/EpisodeTypeFilter.ts';
+import { toCalendar } from './toCalendar.ts';
 
 export type CalendarItem = UpcomingEpisodeEntry | MediaEntry;
 type CalendarItems = CalendarItem[];
@@ -84,10 +84,8 @@ export function useCalendar(
     }),
   );
 
-  const allItems = combineLatest([sorted, props.episodeType]).pipe(
-    map(([$sorted, $episodeType]) =>
-      $sorted.filter((item) => matchesEpisodeTypeFilter(item, $episodeType))
-    ),
+  const allItems = sorted.pipe(
+    filterByEpisodeType(props.episodeType),
     overlay.operator,
   );
 
@@ -95,18 +93,13 @@ export function useCalendar(
     isLoading: withOverlayLoading(baseLoading, overlay.intlLoading$),
     hasUpstreamItems: sorted.pipe(map(($sorted) => $sorted.length > 0)),
     calendar: allItems.pipe(
-      map(($allItems) => {
-        return Array.from({ length: props.days }, (_, i) => {
-          const date = new Date(props.start);
-          date.setDate(props.start.getDate() + i);
-
-          const items = $allItems.filter(
-            (item) => isSameDay(item.effectiveReleaseDate, date),
-          );
-
-          return { date, items };
-        });
-      }),
+      map(($allItems) =>
+        toCalendar({
+          items: $allItems,
+          start: props.start,
+          days: props.days,
+        })
+      ),
     ),
   };
 }

--- a/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
@@ -8,21 +8,25 @@ import {
 } from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { isSameDay } from 'date-fns/isSameDay';
 import { map, type Observable } from 'rxjs';
 import type { FilterParams } from '../../../requests/models/FilterParams.ts';
 import type { DiscoverMode } from '../../filters/models/DiscoverMode.ts';
+import { filterByEpisodeType } from '../filterByEpisodeType.ts';
 import type { Calendar } from '../models/Calendar.ts';
+import type { EpisodeTypeFilter } from '../models/EpisodeTypeFilter.ts';
+import { toCalendar } from './toCalendar.ts';
 
 type UseReleasesCalendarParams = {
   start: Date;
   days: number;
   type: DiscoverMode;
+  episodeType: Observable<EpisodeTypeFilter>;
 } & FilterParams;
 
 type ReleasesCalendarResult = {
   isLoading: Observable<boolean>;
   calendar: Observable<Calendar<ReleasesCalendarEntry>>;
+  hasUpstreamItems: Observable<boolean>;
 };
 
 export function useReleasesCalendar(
@@ -52,21 +56,24 @@ export function useReleasesCalendar(
     getTargets: episodeWithShowOrMovieTargets,
   });
 
+  const items = query.pipe(
+    map(($query) => $query.data ?? []),
+  );
+
+  const filteredItems = items.pipe(
+    filterByEpisodeType(props.episodeType),
+    overlay.operator,
+  );
+
   return {
     isLoading: withOverlayLoading(baseLoading, overlay.intlLoading$),
-    calendar: query.pipe(
-      map(($query) => $query.data ?? []),
-      overlay.operator,
+    hasUpstreamItems: items.pipe(map(($items) => $items.length > 0)),
+    calendar: filteredItems.pipe(
       map(($items) =>
-        Array.from({ length: props.days }, (_, i) => {
-          const date = new Date(props.start);
-          date.setDate(props.start.getDate() + i);
-
-          const items = $items.filter(
-            (item) => isSameDay(item.effectiveReleaseDate, date),
-          );
-
-          return { date, items };
+        toCalendar({
+          items: $items,
+          start: props.start,
+          days: props.days,
         })
       ),
     ),

--- a/projects/client/src/lib/features/calendar/filterByEpisodeType.ts
+++ b/projects/client/src/lib/features/calendar/filterByEpisodeType.ts
@@ -1,0 +1,23 @@
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import {
+  combineLatest,
+  map,
+  type Observable,
+  type OperatorFunction,
+} from 'rxjs';
+import { matchesEpisodeTypeFilter } from './matchesEpisodeTypeFilter.ts';
+import type { EpisodeTypeFilter } from './models/EpisodeTypeFilter.ts';
+
+export function filterByEpisodeType<
+  T extends UpcomingEpisodeEntry | MediaEntry,
+>(
+  episodeType: Observable<EpisodeTypeFilter>,
+): OperatorFunction<T[], T[]> {
+  return (source) =>
+    combineLatest([source, episodeType]).pipe(
+      map(([$items, $episodeType]) =>
+        $items.filter((item) => matchesEpisodeTypeFilter(item, $episodeType))
+      ),
+    );
+}

--- a/projects/client/src/lib/features/query/_internal/createIdbPersister.spec.ts
+++ b/projects/client/src/lib/features/query/_internal/createIdbPersister.spec.ts
@@ -26,7 +26,7 @@ async function importPersister() {
   return createIdbPersister();
 }
 
-const DATA_UPDATED_AT = new Date('2026-09-09T00:00:00.000Z').getTime();
+const DATA_UPDATED_AT = Date.now();
 
 const persistedQuery = {
   buster: 'v3',

--- a/projects/client/src/lib/sections/lists/ReleasesList.svelte
+++ b/projects/client/src/lib/sections/lists/ReleasesList.svelte
@@ -1,15 +1,30 @@
 <script lang="ts">
+  import EpisodeTypeToggles from "$lib/features/calendar/EpisodeTypeToggles.svelte";
   import ReleasesCalendarItem from "$lib/features/calendar/ReleasesCalendarItem.svelte";
+  import { useEpisodeType } from "$lib/features/calendar/useEpisodeType";
+  import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import type { FilterParams } from "$lib/requests/models/FilterParams";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import EpisodeTypeMetaInfo from "./components/EpisodeTypeMetaInfo.svelte";
   import DrillableMediaList from "./drilldown/DrillableMediaList.svelte";
   import { useReleasesItems } from "./stores/useReleasesItems";
 
   const { mode } = useDiscover();
   const { filterMap } = useFilter();
+
+  const { episodeType } = useEpisodeType();
+
+  const useList = (
+    props: { type: DiscoverMode; limit: number } & FilterParams,
+  ) => useReleasesItems({ ...props, episodeType });
 </script>
+
+{#snippet metaInfo()}
+  <EpisodeTypeMetaInfo />
+{/snippet}
 
 <DrillableMediaList
   id={{
@@ -20,12 +35,17 @@
   type={$mode}
   variant="landscape"
   filter={$filterMap}
-  useList={useReleasesItems}
+  {useList}
+  {metaInfo}
   urlBuilder={({ type }) => UrlBuilder.releases({ mode: type })}
   drilldownLabel={m.button_label_view_releases()}
   title={m.list_title_releases()}
 >
   {#snippet item(entry)}
     <ReleasesCalendarItem item={entry} />
+  {/snippet}
+
+  {#snippet actions()}
+    <EpisodeTypeToggles />
   {/snippet}
 </DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/UpcomingList.svelte
+++ b/projects/client/src/lib/sections/lists/UpcomingList.svelte
@@ -7,9 +7,9 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { FilterParams } from "$lib/requests/models/FilterParams";
-  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CtaItem from "./components/cta/CtaItem.svelte";
+  import EpisodeTypeMetaInfo from "./components/EpisodeTypeMetaInfo.svelte";
   import DrillableMediaList from "./drilldown/DrillableMediaList.svelte";
   import { useUpcomingItems } from "./stores/useUpcomingItems";
 
@@ -17,7 +17,7 @@
 
   const { filterMap } = useFilter();
 
-  const { episodeType, current, isApplicable } = useEpisodeType();
+  const { episodeType } = useEpisodeType();
 
   const useList = (
     props: { type: DiscoverMode; limit: number } & FilterParams,
@@ -30,9 +30,7 @@
 </script>
 
 {#snippet metaInfo()}
-  {#if $isApplicable}
-    <ListMetaInfo text={$current.text()} />
-  {/if}
+  <EpisodeTypeMetaInfo />
 {/snippet}
 
 <DrillableMediaList

--- a/projects/client/src/lib/sections/lists/components/EpisodeTypeMetaInfo.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeTypeMetaInfo.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { useEpisodeType } from "$lib/features/calendar/useEpisodeType";
+  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
+
+  const { current, isApplicable } = useEpisodeType();
+</script>
+
+{#if $isApplicable}
+  <ListMetaInfo text={$current.text()} />
+{/if}

--- a/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
@@ -1,3 +1,5 @@
+import { filterByEpisodeType } from '$lib/features/calendar/filterByEpisodeType.ts';
+import type { EpisodeTypeFilter } from '$lib/features/calendar/models/EpisodeTypeFilter.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { episodeWithShowOrMovieTargets } from '$lib/features/intl-overlay/episodeWithShowOrMovieTargets.ts';
@@ -9,12 +11,13 @@ import {
   releasesCalendarQuery,
 } from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import { map } from 'rxjs';
+import { map, type Observable } from 'rxjs';
 import { filterReleasesItems } from './_internal/filterReleasesItems.ts';
 
 type UseReleasesItemsProps = {
   type: DiscoverMode;
   limit: number;
+  episodeType: Observable<EpisodeTypeFilter>;
 } & FilterParams;
 
 const daysToFetch = 30;
@@ -43,9 +46,11 @@ export function useReleasesItems(props: UseReleasesItemsProps) {
   const baseLoading = query.pipe(map(($query) => $query.isLoading));
 
   const list = query.pipe(
-    map(($query) =>
+    map(($query) => $query.data ?? []),
+    filterByEpisodeType(props.episodeType),
+    map((entries) =>
       filterReleasesItems({
-        entries: $query.data ?? [],
+        entries,
         limit: props.limit,
         now: new Date(),
       })

--- a/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
@@ -1,4 +1,4 @@
-import { matchesEpisodeTypeFilter } from '$lib/features/calendar/matchesEpisodeTypeFilter.ts';
+import { filterByEpisodeType } from '$lib/features/calendar/filterByEpisodeType.ts';
 import type { EpisodeTypeFilter } from '$lib/features/calendar/models/EpisodeTypeFilter.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
@@ -17,7 +17,7 @@ import { upcomingMoviesQuery } from '$lib/requests/queries/calendars/upcomingMov
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { getStartOfDay } from '$lib/utils/date/getStartOfDay.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { combineLatest, map, type Observable } from 'rxjs';
+import { map, type Observable } from 'rxjs';
 
 type UseUpcomingItemsProps = {
   type: DiscoverMode;
@@ -67,14 +67,14 @@ export function useUpcomingItems(props: UseUpcomingItemsProps) {
 
   const baseLoading = query.pipe(map(($query) => $query.isLoading));
 
-  const list = combineLatest([query, props.episodeType]).pipe(
-    map(([$query, $episodeType]) => {
+  const list = query.pipe(
+    map(($query) => {
       const startOfToday = getStartOfDay(new Date()).getTime();
       return ($query.data ?? [])
-        .filter((d) => d.effectiveReleaseDate.getTime() >= startOfToday)
-        .filter((d) => matchesEpisodeTypeFilter(d, $episodeType))
-        .slice(0, props.limit);
+        .filter((d) => d.effectiveReleaseDate.getTime() >= startOfToday);
     }),
+    filterByEpisodeType(props.episodeType),
+    map((items) => items.slice(0, props.limit)),
     overlay.operator,
   );
 

--- a/projects/client/src/routes/discover/releases/+page.svelte
+++ b/projects/client/src/routes/discover/releases/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import CalendarProvider from "$lib/features/calendar/CalendarProvider.svelte";
+  import EpisodeTypeToggles from "$lib/features/calendar/EpisodeTypeToggles.svelte";
   import ReleasesCalendar from "$lib/features/calendar/ReleasesCalendar.svelte";
+  import { useEpisodeType } from "$lib/features/calendar/useEpisodeType";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
@@ -9,7 +11,12 @@
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 
   const { current } = useDiscover();
+  const { current: episodeType, isApplicable } = useEpisodeType();
 </script>
+
+{#snippet episodeTypeToggles()}
+  <EpisodeTypeToggles />
+{/snippet}
 
 <TraktPage
   audience="authenticated"
@@ -22,7 +29,8 @@
       hasFilters
       header={{
         title: m.list_title_releases(),
-        metaInfo: $current.text(),
+        metaInfo: $isApplicable ? $episodeType.text() : $current.text(),
+        actions: episodeTypeToggles,
       }}
     />
 


### PR DESCRIPTION
# What

Adds the calendar's episode type toggles (All / Premieres / Finales) to the Discover surfaces: the Discover > Releases page and the Releases shelf on the main Discover page.

# Why

Requested on the forums in [Few questions about new Trakt and finding upcoming TV show premieres](https://forums.trakt.tv/t/few-questions-about-new-trakt-and-finding-upcoming-tv-show-premieres/114070/9): v2 had a way to browse every new series premiering in a given week, and v3's Releases page shows all episodes with no way to narrow to premieres. Adding the existing calendar toggles to Releases was the proposed fix, and the OP confirmed premiere-only filtering resolves "95% of the issue".

# How

- `useReleasesCalendar` and `useReleasesItems` now accept the `episodeType` observable and filter entries client-side, mirroring how `useCalendar` and `useUpcomingItems` already do it.
- The shared filtering plumbing was extracted into a new `filterByEpisodeType` RxJS operator in the calendar feature, now used by all four hooks.
- `useReleasesCalendar` also exposes `hasUpstreamItems` (computed pre-filter) so the accumulator's empty-period guard doesn't stop load-more pagination when a sparse filter like Premieres hides entire weeks.
- The Releases route wires `EpisodeTypeToggles` into the navbar actions and shows the active filter as meta text; the Discover shelf does the same via `DrillableMediaList`'s actions snippet plus `ListMetaInfo`, matching the Upcoming Schedule shelf.
- State is the existing shared `episodeType` toggler (localStorage-backed), so the selection stays in sync across Calendar, Releases, and the Discover shelf. Movie mode keeps its existing behavior: toggles hidden, filter forced to "all".

# Screenshots

<img width="765" height="323" alt="image" src="https://github.com/user-attachments/assets/68d50769-8033-48cd-902c-b3a055aee13f" />

<img width="869" height="544" alt="image" src="https://github.com/user-attachments/assets/bf002066-606f-40f2-9238-2567ec9de039" />

# Related

- Forum request: https://forums.trakt.tv/t/few-questions-about-new-trakt-and-finding-upcoming-tv-show-premieres/114070/9
- Related (not closed by this PR): #1891 (premiere/finale tags on more pages), #1842 (calendar views & filters epic)