### PR TITLE
fix(pwa): stop caching error responses as documents

### DIFF
--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -1,5 +1,6 @@
 import { AssetPattern } from '$worker/AssetPattern.ts';
 import { Domain } from '$worker/Domain.ts';
+import { isCacheableDocument } from '$worker/isCacheableDocument.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { CacheExpiration, ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute } from 'workbox-precaching';
@@ -189,16 +190,18 @@ const documentCacheKey = {
   },
 };
 
-const skipRedirectedDocuments = {
+// Declaring `cacheWillUpdate` replaces Workbox's own status check, so the
+// predicate has to do the rejecting itself.
+const skipUncacheableDocuments = {
   cacheWillUpdate: ({ response }: { response: Response }) =>
-    Promise.resolve(response.redirected ? null : response),
+    Promise.resolve(isCacheableDocument(response) ? response : null),
 };
 
 const navigationOptions = {
   cacheName: navigationCacheName,
   plugins: [
     documentCacheKey,
-    skipRedirectedDocuments,
+    skipUncacheableDocuments,
     expiration(time.hours(12)),
   ],
 };

--- a/projects/client/src/worker/isCacheableDocument.spec.ts
+++ b/projects/client/src/worker/isCacheableDocument.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCacheableDocument } from './isCacheableDocument.ts';
+
+describe('util: isCacheableDocument', () => {
+  it('should cache a plain document', () => {
+    expect(isCacheableDocument({ status: 200, redirected: false })).toBe(true);
+  });
+
+  it('should not cache a redirected document', () => {
+    expect(isCacheableDocument({ status: 200, redirected: true })).toBe(false);
+  });
+
+  // A cached error is replayed as the page, so the visitor keeps seeing it
+  // after the origin recovers.
+  describe('when the origin errors', () => {
+    it.each([500, 502, 503, 504])(
+      'should not cache a %i',
+      (status) => {
+        expect(isCacheableDocument({ status, redirected: false })).toBe(false);
+      },
+    );
+
+    it.each([401, 403, 404, 429])(
+      'should not cache a %i',
+      (status) => {
+        expect(isCacheableDocument({ status, redirected: false })).toBe(false);
+      },
+    );
+  });
+
+  it('should not cache an opaque response', () => {
+    expect(isCacheableDocument({ status: 0, redirected: false })).toBe(false);
+  });
+
+  it('should not cache a partial response', () => {
+    expect(isCacheableDocument({ status: 206, redirected: false })).toBe(false);
+  });
+});

--- a/projects/client/src/worker/isCacheableDocument.ts
+++ b/projects/client/src/worker/isCacheableDocument.ts
@@ -1,0 +1,5 @@
+export function isCacheableDocument(
+  response: { status: number; redirected: boolean },
+): boolean {
+  return response.status === 200 && !response.redirected;
+}


### PR DESCRIPTION
## The 503 was cached, not generated

Follow-up to #3234, which did not fix the reported symptom. A HAR from a failing load shows why:

```json
"status": 503,
"_fetchedViaServiceWorker": true,
"_serviceWorkerResponseSource": "cache-storage",
"_responseCacheStorageCacheName": "trakt-web-navigation-97aba47"
```

The document was served **out of the navigation cache**. It carries `cf-ray`, `server: cloudflare` and `cf-speculation-refused: prefetch refused: disabled for worker requests`, so it is a real edge 503 that we stored. In the same HAR the revalidation fetch running beside it returns a clean `200`.

The cache name pins the build to `97aba47`, i.e. the reporter was already running the fixes from #3234.

## Why we cached it

Workbox installs `cacheOkAndOpaquePlugin` — the only status check its strategies apply — **only if no plugin already declares `cacheWillUpdate`**:

```js
// NetworkFirst + StaleWhileRevalidate constructors
if (!this.plugins.some((p) => 'cacheWillUpdate' in p)) {
    this.plugins.unshift(cacheOkAndOpaquePlugin);
}
```

`skipRedirectedDocuments` declared one to drop redirects, which silently replaced that default. Both navigation strategies share `navigationOptions`, so from then on they stored whatever came back — including a 503 — and replayed it as the page for the 12 hours the entry lived.

That explains the shape of the bug: intermittent (only a URL that caught a 503), self-healing on reload (StaleWhileRevalidate overwrites the entry in the background), and more frequent lately as speculation prefetch traffic grew.

## Changes

The predicate now rejects everything the Workbox default would have, and moves to `$worker` so those statuses are covered by tests.

The navigation cache is keyed to the build, so deploying this abandons the poisoned entries rather than waiting out their expiry.

## Testing

`isCacheableDocument.spec.ts` covers 5xx (including the observed 503), 4xx, opaque, partial, and redirected responses.

## Note on CI

`createIdbPersister.spec.ts > when storage is available > should retrieve a stored query` fails on **clean `origin/main`** (verified at `7664fac65`, detached, without my change). It came in with 97aba4727 and is unrelated to this PR, but it will show red here until fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)