### PR TITLE
feat(summary): redesigns the parental guide

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8528,8 +8528,44 @@
       "description": "Description for the Pantheon (follows watch-time ranking) preview feature."
     },
     "preview_feature_description_parental_guide": {
-      "default": "Show content risk levels in the details drawer for movies, shows, and episodes.",
+      "default": "Show content risk levels in the details drawer for movies and shows.",
       "description": "Description for the Parental Guidance preview feature."
+    },
+    "label_parental_guide_category_nudity": {
+      "default": "Sex & Nudity",
+      "description": "Label for the sex and nudity category in the parental guide."
+    },
+    "label_parental_guide_category_violence": {
+      "default": "Violence & Gore",
+      "description": "Label for the violence and gore category in the parental guide."
+    },
+    "label_parental_guide_category_profanity": {
+      "default": "Profanity",
+      "description": "Label for the profanity category in the parental guide."
+    },
+    "label_parental_guide_category_alcohol": {
+      "default": "Alcohol, Drugs & Smoking",
+      "description": "Label for the alcohol, drugs, and smoking category in the parental guide."
+    },
+    "label_parental_guide_category_frightening": {
+      "default": "Frightening & Intense Scenes",
+      "description": "Label for the frightening and intense scenes category in the parental guide."
+    },
+    "label_parental_guide_severity_none": {
+      "default": "None",
+      "description": "Label for content with no reported parental guide concerns."
+    },
+    "label_parental_guide_severity_mild": {
+      "default": "Mild",
+      "description": "Label for content with mild parental guide concerns."
+    },
+    "label_parental_guide_severity_moderate": {
+      "default": "Moderate",
+      "description": "Label for content with moderate parental guide concerns."
+    },
+    "label_parental_guide_severity_severe": {
+      "default": "Severe",
+      "description": "Label for content with severe parental guide concerns."
     },
     "header_official_links": {
       "default": "Official Links",

--- a/projects/client/src/lib/components/charts/DistributionBar.svelte
+++ b/projects/client/src/lib/components/charts/DistributionBar.svelte
@@ -12,6 +12,8 @@
     orientation = "horizontal",
     seriesIndex = 0,
     color,
+    fillStyle = "gradient",
+    animated = true,
     active = false,
     track = true,
     rounded = true,
@@ -35,8 +37,10 @@
   class="trakt-distribution-bar"
   data-orientation={orientation}
   class:is-active={active}
+  class:is-animated={animated}
   class:has-track={track}
   class:is-rounded={rounded}
+  data-fill-style={fillStyle}
   role="progressbar"
   aria-valuenow={Math.round(clamped * 100)}
   aria-valuemin={0}
@@ -92,6 +96,10 @@
     );
   }
 
+  .trakt-distribution-bar[data-fill-style="flat"] .distribution-bar-fill {
+    background: var(--viz-series);
+  }
+
   // High-contrast hatch overlay (shape encoding); invisible until a HC mode
   // sets --viz-pattern-opacity to 1.
   .distribution-bar-fill::after {
@@ -119,6 +127,10 @@
     // transform-origin has no logical keyword; physical left only affects the
     // brief one-shot entrance scale, so RTL impact is negligible.
     transform-origin: left center;
+  }
+
+  .trakt-distribution-bar.is-animated[data-orientation="horizontal"]
+    .distribution-bar-fill {
     transition:
       width var(--viz-morph-duration) ease,
       filter var(--transition-increment) ease;
@@ -134,6 +146,10 @@
     bottom: 0;
     height: var(--viz-fill);
     transform-origin: center bottom;
+  }
+
+  .trakt-distribution-bar.is-animated[data-orientation="vertical"]
+    .distribution-bar-fill {
     transition:
       height var(--viz-morph-duration) ease,
       filter var(--transition-increment) ease;

--- a/projects/client/src/lib/components/charts/models/DistributionBarProps.ts
+++ b/projects/client/src/lib/components/charts/models/DistributionBarProps.ts
@@ -7,6 +7,10 @@ export type DistributionBarProps = {
   seriesIndex?: number;
   /** Explicit CSS color override; defaults to the `seriesIndex` viz token. */
   color?: string;
+  /** Fill treatment. Defaults to the shared gradient treatment. */
+  fillStyle?: 'gradient' | 'flat';
+  /** Animate fill changes and the initial reveal. Defaults to true. */
+  animated?: boolean;
   /** Spotlight this bar (full strength + glow) - e.g. hovered/selected row. */
   active?: boolean;
   /** Render the muted track behind the fill. Defaults to true. */

--- a/projects/client/src/lib/requests/models/MediaParentalGuide.ts
+++ b/projects/client/src/lib/requests/models/MediaParentalGuide.ts
@@ -1,25 +1,28 @@
 import { z } from 'zod';
 
-const MediaParentalGuideVotesSchema = z.object({
-  none: z.number(),
-  mild: z.number(),
-  moderate: z.number(),
-  severe: z.number(),
+const signals = z.number().int().nonnegative();
+
+const MediaParentalGuideSignalsSchema = z.object({
+  none: signals,
+  mild: signals,
+  moderate: signals,
+  severe: signals,
 });
 
 const MediaParentalGuideCategorySchema = z.object({
-  categoryId: z.string().nullish(),
-  label: z.string(),
-  severity: z.string(),
-  severityLabel: z.string().nullish(),
-  votes: MediaParentalGuideVotesSchema,
-  totalVotes: z.number(),
+  category: z.enum([
+    'NUDITY',
+    'VIOLENCE',
+    'PROFANITY',
+    'ALCOHOL',
+    'FRIGHTENING',
+  ]),
+  severity: z.enum(['NONE', 'MILD', 'MODERATE', 'SEVERE']),
+  signals: MediaParentalGuideSignalsSchema,
 });
 
 export const MediaParentalGuideSchema = z.object({
-  id: z.string(),
-  title: z.string().nullish(),
-  categories: z.record(MediaParentalGuideCategorySchema),
+  guide: z.array(MediaParentalGuideCategorySchema),
 });
 
 export type MediaParentalGuide = z.infer<typeof MediaParentalGuideSchema>;

--- a/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.spec.ts
@@ -1,86 +1,86 @@
+import { mediaParentalGuideQuery } from '$lib/requests/queries/media/mediaParentalGuideQuery.ts';
+import { MediaParentalGuideResponseMock } from '$mocks/data/summary/common/response/MediaParentalGuideResponseMock.ts';
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import { server } from '$mocks/server.ts';
 import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
-import { server } from '$mocks/server.ts';
-import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { mediaParentalGuideQuery } from './mediaParentalGuideQuery.ts';
+import { describe, expect, it } from 'vitest';
 
-const MediaParentalGuideMock = {
-  id: 'tt14693272',
-  title: 'Freedom Day',
-  categories: {
-    sex_nudity: {
-      categoryId: 'NUDITY',
-      label: 'Sex & Nudity',
-      severity: 'NONE',
-      severityLabel: 'None',
-      votes: {
-        none: 10,
-        mild: 1,
-        moderate: 0,
-        severe: 0,
-      },
-      totalVotes: 11,
-    },
-    violence_gore: {
-      categoryId: 'VIOLENCE',
-      label: 'Violence & Gore',
-      severity: 'MODERATE',
-      severityLabel: 'Moderate',
-      votes: {
-        none: 1,
-        mild: 4,
-        moderate: 12,
-        severe: 2,
-      },
-      totalVotes: 19,
-    },
-  },
-};
+const MOVIE_SLUG = MovieHereticResponseMock.ids.slug;
+const PARENTAL_GUIDE_PATH =
+  `http://localhost/v3/media/movie/${MOVIE_SLUG}/info/16/version/1`;
 
 describe('mediaParentalGuideQuery', () => {
-  it('should be disabled without an IMDb id', () => {
-    const query = mediaParentalGuideQuery({ imdbId: null });
-
-    expect(query.enabled).to.equal(false);
-  });
-
-  it('should query for a media parental guide by IMDb id', async () => {
+  it('should query for a movie parental guide by slug', async () => {
     server.use(
       http.get(
-        `http://localhost/v3/media/imdb/${MediaParentalGuideMock.id}/parental-guide`,
-        () => HttpResponse.json(MediaParentalGuideMock),
+        PARENTAL_GUIDE_PATH,
+        () => HttpResponse.json(MediaParentalGuideResponseMock),
       ),
     );
 
     const result = await runQuery({
       factory: () =>
         createTestBedQuery(
-          mediaParentalGuideQuery({ imdbId: MediaParentalGuideMock.id }),
+          mediaParentalGuideQuery({
+            type: 'movie',
+            slug: MOVIE_SLUG,
+            locale: 'en',
+          }),
         ),
       mapper: (response) => response?.data,
     });
 
-    expect(result).to.deep.equal(MediaParentalGuideMock);
+    expect(result).to.deep.equal(MediaParentalGuideResponseMock);
   });
 
   it('should return null when a media parental guide is unavailable', async () => {
     server.use(
       http.get(
-        `http://localhost/v3/media/imdb/${MediaParentalGuideMock.id}/parental-guide`,
-        () => new HttpResponse(null, { status: 204 }),
+        PARENTAL_GUIDE_PATH,
+        () => new HttpResponse(null, { status: 404 }),
       ),
     );
 
     const result = await runQuery({
       factory: () =>
         createTestBedQuery(
-          mediaParentalGuideQuery({ imdbId: MediaParentalGuideMock.id }),
+          mediaParentalGuideQuery({
+            type: 'movie',
+            slug: MOVIE_SLUG,
+            locale: 'en',
+          }),
         ),
       mapper: (response) => response?.data,
       waitFor: (response) => response === null,
     });
 
     expect(result).to.equal(null);
+  });
+
+  it('should request the given locale', async () => {
+    const requestedLocales: Array<string | null> = [];
+
+    server.use(
+      http.get(PARENTAL_GUIDE_PATH, ({ request }) => {
+        requestedLocales.push(new URL(request.url).searchParams.get('locale'));
+        return HttpResponse.json(MediaParentalGuideResponseMock);
+      }),
+    );
+
+    await runQuery({
+      factory: () =>
+        createTestBedQuery(
+          mediaParentalGuideQuery({
+            type: 'movie',
+            slug: MOVIE_SLUG,
+            locale: 'pt-BR',
+          }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(requestedLocales).to.deep.equal(['pt-BR']);
   });
 });

--- a/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.ts
@@ -1,31 +1,31 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
 import {
   type MediaParentalGuide,
   MediaParentalGuideSchema,
 } from '$lib/requests/models/MediaParentalGuide.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { time } from '$lib/utils/timing/time.ts';
+import { toMediaInfoPath } from '../../_internal/toMediaInfoPath.ts';
 
 type MediaParentalGuideParams = {
-  imdbId?: string | null;
+  type: MediaType;
+  slug: string;
+  locale: AvailableLocale;
 } & ApiParams;
 
 const mediaParentalGuideRequest = async (
-  { fetch, imdbId }: MediaParentalGuideParams,
+  { fetch, type, slug, locale }: MediaParentalGuideParams,
 ) => {
-  if (!imdbId) {
-    return {
-      body: undefined,
-      status: 204,
-    };
-  }
-
   const response = await rawApiFetch({
     fetch,
-    path: `/v3/media/imdb/${encodeURIComponent(imdbId)}/parental-guide`,
+    path: toMediaInfoPath({ type, slug, infoType: 16, locale }),
   });
 
-  if (response.status === 204) {
+  // A missing guide 404s upstream; fold it into no-content so the query
+  // resolves to null instead of throwing.
+  if (response.status === 204 || response.status === 404) {
     return {
       body: undefined,
       status: 204,
@@ -48,10 +48,9 @@ const mediaParentalGuideRequest = async (
 export const mediaParentalGuideQuery = defineQuery({
   key: 'mediaParentalGuide',
   invalidations: [],
-  dependencies: (params) => [params.imdbId ?? ''],
+  dependencies: (params) => [params.type, params.slug, params.locale],
   request: mediaParentalGuideRequest,
   mapper: (response): MediaParentalGuide | null => response.body ?? null,
   schema: MediaParentalGuideSchema.nullish(),
   ttl: time.hours(3),
-  enabled: (params) => Boolean(params.imdbId),
 });

--- a/projects/client/src/lib/sections/summary/components/_internal/useParentalGuideCategories.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useParentalGuideCategories.ts
@@ -1,75 +1,117 @@
+import { getLocale } from '$lib/features/i18n/index.ts';
+import * as m from '$lib/features/i18n/messages.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaParentalGuide as Guide } from '$lib/requests/models/MediaParentalGuide.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { mediaParentalGuideQuery } from '$lib/requests/queries/media/mediaParentalGuideQuery.ts';
+import { isShallowEqual } from '$lib/utils/object/isShallowEqual.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { distinctUntilChanged, map, type Observable } from 'rxjs';
-
-type SeverityTone = 'none' | 'mild' | 'moderate' | 'severe' | 'unknown';
 
 type DisplayableCategory = {
   key: string;
   label: string;
   severityLabel: string;
+  severityProgress: number;
   severityTone: SeverityTone;
+  signals: ReadonlyArray<{
+    key: SignalTone;
+    label: string;
+    count: number;
+  }>;
 };
 
-const CATEGORY_ORDER = [
-  'sex_nudity',
-  'violence_gore',
-  'profanity',
-  'alcohol_drugs_smoking',
-  'frightening_intense_scenes',
-];
+type GuideEntry = Guide['guide'][number];
+type GuideCategory = GuideEntry['category'];
+type GuideSeverity = GuideEntry['severity'];
+type SignalTone = Lowercase<GuideSeverity>;
+type SeverityTone = SignalTone | 'unknown';
 
-function toSeverityTone(severity: string): SeverityTone {
-  switch (severity.toUpperCase()) {
-    case 'NONE':
-      return 'none';
-    case 'MILD':
-      return 'mild';
-    case 'MODERATE':
-      return 'moderate';
-    case 'SEVERE':
-      return 'severe';
-    default:
-      return 'unknown';
-  }
-}
+type ParentalGuideTarget = {
+  type: MediaType;
+  slug: string;
+};
 
-function toDisplayableSeverity(severity: string): string {
-  return severity
-    .toLowerCase()
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (character) => character.toUpperCase());
-}
+// Declaration order is render order: category rows, then signal breakdown.
+const CATEGORY_LABEL = {
+  NUDITY: m.label_parental_guide_category_nudity,
+  VIOLENCE: m.label_parental_guide_category_violence,
+  PROFANITY: m.label_parental_guide_category_profanity,
+  ALCOHOL: m.label_parental_guide_category_alcohol,
+  FRIGHTENING: m.label_parental_guide_category_frightening,
+} as const satisfies Record<GuideCategory, () => string>;
 
-function categoryRank(key: string): number {
-  const index = CATEGORY_ORDER.indexOf(key);
-  return index === -1 ? CATEGORY_ORDER.length : index;
-}
+const SEVERITY = {
+  NONE: {
+    tone: 'none',
+    label: m.label_parental_guide_severity_none,
+    progress: 0.1,
+  },
+  MILD: {
+    tone: 'mild',
+    label: m.label_parental_guide_severity_mild,
+    progress: 0.3,
+  },
+  MODERATE: {
+    tone: 'moderate',
+    label: m.label_parental_guide_severity_moderate,
+    progress: 0.6,
+  },
+  SEVERE: {
+    tone: 'severe',
+    label: m.label_parental_guide_severity_severe,
+    progress: 0.9,
+  },
+} as const satisfies Record<
+  GuideSeverity,
+  { tone: SignalTone; label: () => string; progress: number }
+>;
 
 function toDisplayableCategories(
   parentalGuide: Guide | null | undefined,
 ): DisplayableCategory[] {
-  return Object.entries(parentalGuide?.categories ?? {})
-    .filter(([, category]) => category.label.length > 0)
-    .sort(([keyA], [keyB]) => categoryRank(keyA) - categoryRank(keyB))
-    .map(([key, category]) => ({
-      key,
-      label: category.label,
-      severityLabel: category.severityLabel ??
-        toDisplayableSeverity(category.severity),
-      severityTone: toSeverityTone(category.severity),
-    }));
+  return Object.entries(CATEGORY_LABEL).map(([category, toCategoryLabel]) => {
+    const entry = parentalGuide?.guide.find((item) =>
+      item.category === category
+    );
+
+    if (!entry) {
+      return {
+        key: category,
+        label: toCategoryLabel(),
+        severityLabel: m.text_unknown(),
+        severityProgress: 0,
+        severityTone: 'unknown',
+        signals: [],
+      };
+    }
+
+    const severity = SEVERITY[entry.severity];
+
+    return {
+      key: category,
+      label: toCategoryLabel(),
+      severityLabel: severity.label(),
+      severityProgress: severity.progress,
+      severityTone: severity.tone,
+      signals: Object.values(SEVERITY).map(({ tone, label }) => ({
+        key: tone,
+        label: label(),
+        count: entry.signals[tone],
+      })),
+    };
+  });
 }
 
 export function useParentalGuideCategories(
-  { imdbId$ }: { imdbId$: Observable<string | null | undefined> },
+  { target$ }: { target$: Observable<ParentalGuideTarget> },
 ) {
   const query = useQuery(
-    imdbId$.pipe(
-      distinctUntilChanged(),
-      map((imdbId) => mediaParentalGuideQuery({ imdbId })),
+    target$.pipe(
+      distinctUntilChanged(isShallowEqual),
+      map(({ type, slug }) =>
+        mediaParentalGuideQuery({ type, slug, locale: getLocale() })
+      ),
     ),
   );
 

--- a/projects/client/src/lib/sections/summary/components/details/DetailsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/DetailsDrawer.svelte
@@ -14,10 +14,6 @@
     $props();
 
   let isOpen = $state(false);
-
-  const imdbId = $derived(
-    props.type === "episode" ? props.episode.imdbId : props.media.imdbId,
-  );
 </script>
 
 <Drawer
@@ -36,13 +32,13 @@
 
       {#if props.type !== "episode"}
         <MediaLinks media={props.media} />
-      {/if}
 
-      <RenderForFeature flag={FeatureFlag.ParentalGuide} audience="director">
-        {#snippet enabled()}
-          <MediaParentalGuide {imdbId} />
-        {/snippet}
-      </RenderForFeature>
+        <RenderForFeature flag={FeatureFlag.ParentalGuide} audience="director">
+          {#snippet enabled()}
+            <MediaParentalGuide type={props.type} slug={props.media.slug} />
+          {/snippet}
+        </RenderForFeature>
+      {/if}
     </div>
   {/if}
 </Drawer>

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaParentalGuide.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaParentalGuide.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { getLocale } from "$lib/features/i18n/index.ts";
   import * as m from "$lib/features/i18n/messages.ts";
+  import type { MediaType } from "$lib/requests/models/MediaType.ts";
+  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber.ts";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import { useParentalGuideCategories } from "../../_internal/useParentalGuideCategories.ts";
 
-  const LOADING_ROWS = Array.from({ length: 5 });
-
-  const { imdbId }: { imdbId?: string | null } = $props();
+  const { type, slug }: { type: MediaType; slug: string } = $props();
 
   const { categories, isError, isLoading } = useParentalGuideCategories({
-    imdbId$: fromRune(() => imdbId),
+    target$: fromRune(() => ({ type, slug })),
   });
 
   const guideState = $derived.by(() => {
@@ -20,88 +23,112 @@
       return "error";
     }
 
-    return $categories.length > 0 ? "ready" : "empty";
+    return "ready";
   });
 
-  const guideNotice = $derived.by(() => {
-    if (guideState === "error") {
-      return {
-        label: m.error_text_parental_guide_load_failed(),
-        severityTone: "severe",
-      };
-    }
-
-    if (guideState === "empty") {
-      return {
-        label: m.text_unavailable(),
-        severityTone: "none",
-      };
-    }
-
-    return null;
-  });
+  const isPending = $derived(guideState === "loading");
 </script>
 
 <section
   class="trakt-media-parental-guide"
-  aria-busy={guideState === "loading"}
+  aria-busy={isPending}
   data-state={guideState}
 >
-  <p class="bold secondary">
+  <p class="guide-heading bold secondary">
     {m.option_text_certification_parental_guidance()}
   </p>
 
-  {#if guideState === "ready"}
+  {#if guideState !== "error"}
     <ul class="guide-list">
       {#each $categories as category (category.key)}
-        <li class="guide-row" data-severity={category.severityTone}>
-          <span class="severity-rail" aria-hidden="true"></span>
-          <span class="guide-copy">
-            <span class="guide-label bold">{category.label}</span>
-            <span class="guide-severity secondary">{category.severityLabel}</span>
+        {@const severityLabel = isPending
+          ? m.yir_state_loading()
+          : category.severityLabel}
+        <li
+          class="guide-row"
+          data-severity={isPending ? "unknown" : category.severityTone}
+        >
+          <span class="guide-label bold" title={category.label}>
+            {category.label}
+          </span>
+          <div class="guide-meter">
+            <Tooltip
+              variant="compact"
+              sideOffset={4}
+              disabled={isPending || category.signals.length === 0}
+              disableHoverableContent
+            >
+              {#snippet content()}
+                <dl class="signals-list">
+                  {#each category.signals as signal (signal.key)}
+                    <div class="signal-row">
+                      <dt>{signal.label}</dt>
+                      <dd>
+                        {toHumanNumber(signal.count, getLocale())}
+                      </dd>
+                    </div>
+                  {/each}
+                </dl>
+              {/snippet}
+              <span class="guide-accessible-label">
+                {category.label}: {severityLabel}
+              </span>
+              <div class="guide-bar" aria-hidden="true">
+                <DistributionBar
+                  fraction={isPending ? 0 : category.severityProgress}
+                  color="var(--guide-severity-color)"
+                  fillStyle="flat"
+                  animated={false}
+                  --distribution-bar-thickness="var(--ni-8)"
+                  --distribution-bar-track="var(--guide-track-color)"
+                />
+              </div>
+            </Tooltip>
+          </div>
+          <span class="guide-severity secondary">
+            {severityLabel}
           </span>
         </li>
       {/each}
     </ul>
-  {:else if guideState === "loading"}
-    <div class="guide-list" aria-hidden="true">
-      {#each LOADING_ROWS as _, index (index)}
-        <div class="guide-row is-loading">
-          <span class="severity-rail"></span>
-          <span class="guide-copy">
-            <span class="guide-label"></span>
-            <span class="guide-severity"></span>
-          </span>
-        </div>
-      {/each}
-    </div>
-  {:else if guideNotice}
+  {:else}
     <div class="guide-list">
-      <div class="guide-row" data-severity={guideNotice.severityTone}>
-        <span class="severity-rail" aria-hidden="true"></span>
-        <span class="guide-copy">
-          <span class="guide-label bold secondary">{guideNotice.label}</span>
+      <div class="guide-row" data-severity="severe">
+        <span class="guide-notice bold secondary">
+          {m.error_text_parental_guide_load_failed()}
         </span>
       </div>
     </div>
   {/if}
 </section>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-media-parental-guide {
+    --guide-track-color: color-mix(
+      in srgb,
+      var(--color-text-secondary) 22%,
+      transparent
+    );
+
     display: flex;
     flex-direction: column;
-    gap: var(--gap-s);
+    gap: var(--gap-xs);
 
     padding-top: var(--gap-l);
 
     border-top: var(--ni-1) solid var(--color-border);
   }
 
+  .trakt-media-parental-guide .guide-heading {
+    max-width: 100%;
+  }
+
   .trakt-media-parental-guide .guide-list {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-xs);
+    gap: 0;
 
     padding: 0;
     margin: 0;
@@ -111,35 +138,70 @@
 
   .trakt-media-parental-guide .guide-row {
     display: grid;
-    grid-template-columns: var(--ni-6) minmax(0, 1fr);
+    grid-template-columns:
+      minmax(0, 1fr)
+      minmax(var(--ni-80), 0.72fr)
+      var(--ni-96);
     align-items: center;
-    gap: var(--gap-s);
-    min-height: var(--ni-32);
+    gap: var(--gap-l);
+    height: var(--ni-52);
+
+    border-bottom: var(--ni-1) solid var(--color-border);
   }
 
-  .trakt-media-parental-guide .severity-rail {
-    width: var(--ni-6);
-    height: var(--ni-28);
-
-    border-radius: var(--border-radius-xs);
-    background: var(--guide-severity-color, var(--shade-500));
+  .trakt-media-parental-guide .guide-row:last-child {
+    border-bottom: none;
   }
 
-  .trakt-media-parental-guide .guide-copy {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: var(--gap-xs);
+  .trakt-media-parental-guide .guide-label,
+  .trakt-media-parental-guide .guide-meter,
+  .trakt-media-parental-guide .guide-severity {
     min-width: 0;
   }
 
   .trakt-media-parental-guide .guide-label,
   .trakt-media-parental-guide .guide-severity {
-    overflow-wrap: anywhere;
+    display: -webkit-box;
+    overflow: hidden;
+
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .trakt-media-parental-guide .guide-meter {
+    display: block;
+    width: 100%;
+
+    :global(.trakt-tooltip-trigger) {
+      width: 100%;
+    }
+  }
+
+  .trakt-media-parental-guide .guide-severity {
+    color: var(--guide-severity-color);
+
+    text-align: end;
+  }
+
+  .trakt-media-parental-guide .guide-bar {
+    width: 100%;
+  }
+
+  .trakt-media-parental-guide .guide-accessible-label {
+    @include visually-hidden;
+  }
+
+  .trakt-media-parental-guide .guide-notice {
+    grid-column: 1 / -1;
   }
 
   .trakt-media-parental-guide .guide-row[data-severity="none"] {
     --guide-severity-color: var(--shade-300);
+  }
+
+  .trakt-media-parental-guide .guide-row[data-severity="unknown"] {
+    --guide-severity-color: var(--color-text-secondary);
   }
 
   .trakt-media-parental-guide .guide-row[data-severity="mild"] {
@@ -154,29 +216,51 @@
     --guide-severity-color: var(--red-500);
   }
 
-  .trakt-media-parental-guide .guide-row.is-loading .severity-rail,
-  .trakt-media-parental-guide .guide-row.is-loading .guide-label,
-  .trakt-media-parental-guide .guide-row.is-loading .guide-severity {
-    background: color-mix(
-      in srgb,
-      var(--color-text-secondary) 18%,
-      transparent
-    );
+  .signals-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-4);
+    min-width: var(--ni-120);
+    margin: 0;
+
+    line-height: 1.25;
+    font-weight: 400;
   }
 
-  .trakt-media-parental-guide .guide-row.is-loading .guide-label,
-  .trakt-media-parental-guide .guide-row.is-loading .guide-severity {
-    display: block;
-    height: var(--ni-14);
+  .signal-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--gap-l);
 
-    border-radius: var(--border-radius-xs);
+    white-space: nowrap;
+
+    dt,
+    dd {
+      margin: 0;
+    }
+
+    dt {
+      font-weight: 600;
+    }
+
+    dd {
+      font-weight: 400;
+      font-variant-numeric: tabular-nums;
+    }
   }
 
-  .trakt-media-parental-guide .guide-row.is-loading .guide-label {
-    width: min(var(--ni-192), 60%);
-  }
+  @include for-mobile {
+    .trakt-media-parental-guide .guide-row {
+      grid-template-columns: minmax(0, 1fr) var(--ni-96);
+      gap: var(--gap-xs) var(--gap-m);
+      height: var(--ni-64);
+      box-sizing: border-box;
+      padding-block: var(--gap-xs);
+    }
 
-  .trakt-media-parental-guide .guide-row.is-loading .guide-severity {
-    width: var(--ni-72);
+    .trakt-media-parental-guide .guide-meter {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
   }
 </style>

--- a/projects/client/src/mocks/data/summary/common/response/MediaParentalGuideResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/common/response/MediaParentalGuideResponseMock.ts
@@ -1,0 +1,24 @@
+export const MediaParentalGuideResponseMock = {
+  guide: [
+    {
+      category: 'NUDITY',
+      severity: 'NONE',
+      signals: {
+        none: 10,
+        mild: 1,
+        moderate: 0,
+        severe: 0,
+      },
+    },
+    {
+      category: 'VIOLENCE',
+      severity: 'MODERATE',
+      signals: {
+        none: 1,
+        mild: 4,
+        moderate: 12,
+        severe: 2,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Refreshes parental guidance in the details drawer so content-risk information is easier to scan across screen sizes and languages.

## Changes

- Uses a fixed three-column layout with category, severity bar, and rating
- Limits category labels to two lines while preserving consistent row dimensions
- Uses flat, unanimated severity bars sized off the `--ni-8` token
- Shows signal counts in compact tooltips
- Displays the complete empty layout with “Loading…” while loading
- Displays “Unknown” and empty bars when guidance is unavailable
- Limits parental guidance to movies and shows

## Validation

- Parental-guide query tests pass
- Svelte type checking passes with no errors or warnings
- Localization placeholders are consistent
- Formatting and focused lint checks pass
