### PR TITLE
feat(filter): add parental guidance filters

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8528,7 +8528,7 @@
       "description": "Description for the Pantheon (follows watch-time ranking) preview feature."
     },
     "preview_feature_description_parental_guide": {
-      "default": "Show content risk levels in the details drawer for movies and shows.",
+      "default": "Show content risk levels in the details drawer for movies and shows, and filter by severity in advanced filters.",
       "description": "Description for the Parental Guidance preview feature."
     },
     "label_parental_guide_category_nudity": {
@@ -8566,6 +8566,21 @@
     "label_parental_guide_severity_severe": {
       "default": "Severe",
       "description": "Label for content with severe parental guide concerns."
+    },
+    "advanced_filter_label_parental_guide": {
+      "default": "{category}: {min} to {max}",
+      "description": "Selected parental guidance severity range for a category.",
+      "variables": {
+        "category": {
+          "type": "string"
+        },
+        "min": {
+          "type": "string"
+        },
+        "max": {
+          "type": "string"
+        }
+      }
     },
     "header_official_links": {
       "default": "Official Links",

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -107,7 +107,7 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     title: () => m.option_text_certification_parental_guidance(),
     addedAt: new Date('2026-06-30'),
     description: () => m.preview_feature_description_parental_guide(),
-    audience: 'director',
+    audience: 'vip',
   },
   [FeatureFlag.ActionConfirmations]: {
     icon: CheckIcon,

--- a/projects/client/src/lib/features/filters/_internal/constants.ts
+++ b/projects/client/src/lib/features/filters/_internal/constants.ts
@@ -4,6 +4,7 @@ import {
   generateDecadeRange,
 } from '$lib/features/filters/_internal/generateDecadeOptions.ts';
 import { type Filter, FilterKey } from '$lib/features/filters/models/Filter.ts';
+import { parentalGuideFilters } from '$lib/features/filters/parentalGuideFilters.ts';
 import { languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import { toTranslatedGenre } from '$lib/utils/formatting/string/toTranslatedGenre.ts';
@@ -236,6 +237,7 @@ export const FILTERS = [
   CERTIFICATION_FILTER,
   COUNTRY_FILTER,
   STATUS_FILTER,
+  ...parentalGuideFilters,
   IGNORE_WATCHED_FILTER,
   IGNORE_WATCHLISTED_FILTER,
 ] as const;

--- a/projects/client/src/lib/features/filters/models/Filter.ts
+++ b/projects/client/src/lib/features/filters/models/Filter.ts
@@ -20,10 +20,16 @@ export enum FilterKey {
   RtMeter = 'rt_meters',
   RtUserMeter = 'rt_user_meters',
   Status = 'statuses',
+  ParentalNudity = 'parental_nudity',
+  ParentalViolence = 'parental_violence',
+  ParentalProfanity = 'parental_profanity',
+  ParentalAlcohol = 'parental_alcohol',
+  ParentalFrightening = 'parental_frightening',
 }
 
 type BaseFilter = {
   key: FilterKey;
+  advancedOnly?: boolean;
   label: () => string;
   type: 'list' | 'toggle' | 'slider';
 };

--- a/projects/client/src/lib/features/filters/parentalGuideFilters.spec.ts
+++ b/projects/client/src/lib/features/filters/parentalGuideFilters.spec.ts
@@ -1,0 +1,43 @@
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
+import { getAppliedFilters } from './_internal/getAppliedFilters.ts';
+import { processFilterParams } from './_internal/processFilterParams.ts';
+import { parentalGuideFilters } from './parentalGuideFilters.ts';
+import { describe, expect, it } from 'vitest';
+
+const keys = [
+  'parental_nudity',
+  'parental_violence',
+  'parental_profanity',
+  'parental_alcohol',
+  'parental_frightening',
+];
+
+describe('parentalGuideFilters', () => {
+  it('should expose all five categories only in advanced filters with ordered severity labels', () => {
+    expect(parentalGuideFilters.map((filter) => filter.key)).toEqual(keys);
+    parentalGuideFilters.forEach((filter) => {
+      expect(filter.advancedOnly).toBe(true);
+      expect(filter.range).toEqual({ min: 0, max: 3 });
+      expect([0, 1, 2, 3].map((value) => filter.ticks?.formatter(value)))
+        .toEqual(['None', 'Mild', 'Moderate', 'Severe']);
+      expect(filter.formatLabel({ min: 0, max: 0 })).toContain('None to None');
+    });
+  });
+
+  it('should preserve none-only ranges when applying and saving filters', () => {
+    const params = new URLSearchParams(keys.map((key) => [key, '0-0']));
+    const saved: Record<string, unknown> = {};
+
+    processFilterParams(params.entries(), (key, value) => {
+      saved[key] = value;
+    });
+
+    expect(saved).toEqual(Object.fromEntries(params));
+    expect(getAppliedFilters(params).map((filter) => filter.key)).toEqual(keys);
+  });
+
+  it.each(keys)('should invalidate queries when %s changes', (key) => {
+    expect(getGlobalFilterDependencies({ [key]: '0-0' }))
+      .not.toEqual(getGlobalFilterDependencies({ [key]: '0-1' }));
+  });
+});

--- a/projects/client/src/lib/features/filters/parentalGuideFilters.ts
+++ b/projects/client/src/lib/features/filters/parentalGuideFilters.ts
@@ -1,0 +1,55 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import { FilterKey, type RatingsFilter } from './models/Filter.ts';
+import type { SliderOption } from './models/FilterOptions.ts';
+
+const severities = [
+  m.label_parental_guide_severity_none,
+  m.label_parental_guide_severity_mild,
+  m.label_parental_guide_severity_moderate,
+  m.label_parental_guide_severity_severe,
+];
+
+const formatSeverity = (value: number): string =>
+  severities.at(value)?.() ?? '';
+
+const categories = [
+  {
+    key: FilterKey.ParentalNudity,
+    label: m.label_parental_guide_category_nudity,
+  },
+  {
+    key: FilterKey.ParentalViolence,
+    label: m.label_parental_guide_category_violence,
+  },
+  {
+    key: FilterKey.ParentalProfanity,
+    label: m.label_parental_guide_category_profanity,
+  },
+  {
+    key: FilterKey.ParentalAlcohol,
+    label: m.label_parental_guide_category_alcohol,
+  },
+  {
+    key: FilterKey.ParentalFrightening,
+    label: m.label_parental_guide_category_frightening,
+  },
+];
+
+export const parentalGuideFilters: ReadonlyArray<RatingsFilter> = categories
+  .map(
+    ({ key, label }) => {
+      const slider: SliderOption = {
+        type: 'slider',
+        range: { min: 0, max: severities.length - 1 },
+        ticks: { count: severities.length, formatter: formatSeverity },
+        formatLabel: ({ min, max }) =>
+          m.advanced_filter_label_parental_guide({
+            category: label(),
+            min: formatSeverity(min),
+            max: formatSeverity(max),
+          }),
+      };
+
+      return { key, advancedOnly: true, ...slider, advanced: slider };
+    },
+  );

--- a/projects/client/src/lib/features/filters/useFilter.spec.ts
+++ b/projects/client/src/lib/features/filters/useFilter.spec.ts
@@ -1,0 +1,123 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
+import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
+import { useParameters } from '$lib/features/parameters/useParameters.ts';
+import { useNavbarState } from '$lib/sections/navbar/useNavbarState.ts';
+import { ExtendedUsersResponseMock } from '$mocks/data/users/response/ExtendedUserSettingsResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { waitFor } from '@testing-library/svelte';
+import { http, HttpResponse } from 'msw';
+import { combineLatest, filter, firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useFilter } from './useFilter.ts';
+import { useStoredFilters } from './useStoredFilters.ts';
+
+const ranges = {
+  parental_nudity: '0-0',
+  parental_violence: '0-1',
+  parental_profanity: '1-2',
+  parental_alcohol: '2-3',
+  parental_frightening: '3-3',
+};
+
+async function setup(isVip = true) {
+  server.use(
+    http.get('http://localhost/users/settings', () =>
+      HttpResponse.json({
+        ...ExtendedUsersResponseMock,
+        user: {
+          ...ExtendedUsersResponseMock.user,
+          vip: isVip,
+          vip_ep: false,
+          director: false,
+        },
+      })),
+  );
+  const stores = await renderStore(() => {
+    const parameters = useParameters();
+    const stored = useStoredFilters();
+    parameters.update({});
+    stored.saveFilters();
+    parameters.update(ranges);
+    return {
+      ...useFilter(),
+      ...useFeatureFlag(),
+      ...useUser(),
+      parameters,
+      stored,
+    };
+  });
+  await firstValueFrom(
+    stores.user.pipe(
+      filter((user) => Boolean(user.slug) && user.isVip === isVip),
+    ),
+  );
+  return stores;
+}
+
+describe('store: useFilter parental availability', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setAuthorization(true);
+    useNavbarState().set({ hasFilters: true });
+  });
+
+  afterEach(() => useNavbarState().reset());
+
+  it('should stop applying and counting ranges when disabled and restore them when enabled', async () => {
+    const stores = await setup();
+    const emissions: unknown[] = [];
+    const subscription = combineLatest([
+      stores.filterMap,
+      stores.activeFilterCount,
+      stores.hasActiveFilter,
+      stores.isFiltered,
+      stores.hasAnyAdvancedFilter,
+    ]).subscribe((value) => emissions.push(value));
+
+    try {
+      stores.setFlag(FeatureFlag.ParentalGuide, true);
+      await waitFor(() =>
+        expect(emissions.at(-1)).toEqual([ranges, 5, true, true, true])
+      );
+
+      stores.setFlag(FeatureFlag.ParentalGuide, false);
+      await waitFor(() =>
+        expect(emissions.at(-1)).toEqual([{}, 0, false, false, false])
+      );
+      expect(Object.fromEntries(await firstValueFrom(stores.parameters.search)))
+        .toEqual(ranges);
+
+      stores.setFlag(FeatureFlag.ParentalGuide, true);
+      await waitFor(() =>
+        expect(emissions.at(-1)).toEqual([ranges, 5, true, true, true])
+      );
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+
+  it('should ignore saved parental defaults while preserving ordinary filters', async () => {
+    const stores = await setup();
+    stores.setFlag(FeatureFlag.ParentalGuide, true);
+    stores.stored.saveFilters();
+    stores.parameters.update({ genres: 'action' });
+    stores.setFlag(FeatureFlag.ParentalGuide, false);
+
+    expect(await firstValueFrom(stores.filterMap)).toEqual({
+      genres: 'action',
+    });
+    expect(await firstValueFrom(stores.activeFilterCount)).toBe(1);
+    stores.parameters.update({});
+    expect(await firstValueFrom(stores.hasActiveFilter)).toBe(false);
+    expect(await firstValueFrom(stores.stored.storedFilters)).toEqual(ranges);
+  });
+
+  it('should ignore ranges for a non-VIP even when the flag is enabled', async () => {
+    const stores = await setup(false);
+    stores.setFlag(FeatureFlag.ParentalGuide, true);
+    expect(await firstValueFrom(stores.filterMap)).toEqual({});
+    expect(await firstValueFrom(stores.isFiltered)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/filters/useFilter.ts
+++ b/projects/client/src/lib/features/filters/useFilter.ts
@@ -1,3 +1,6 @@
+import { useAuth } from '$lib/features/auth/stores/useAuth.ts';
+import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
+import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
 import type { FilterKey } from '$lib/features/filters/models/Filter.ts';
 import { useParameters } from '$lib/features/parameters/useParameters.ts';
 import { combineLatest, distinctUntilChanged, map } from 'rxjs';
@@ -8,13 +11,47 @@ import { FILTERS } from './_internal/constants.ts';
 import { getAppliedFilters } from './_internal/getAppliedFilters.ts';
 import { isDifferentFilterSet } from './_internal/isDifferentFilterSet.ts';
 import { mapToSearchParamValue } from './_internal/mapToSearchParamValue.ts';
+import { parentalGuideFilters } from './parentalGuideFilters.ts';
 import { useStoredFilters } from './useStoredFilters.ts';
 
 export function useFilter() {
-  const { search } = useParameters();
+  const { search: rawSearch } = useParameters();
   const { user } = useUser();
-  const { storedFilters } = useStoredFilters();
+  const { storedFilters: rawStoredFilters } = useStoredFilters();
   const { state } = useNavbarState();
+
+  const { isAuthorized } = useAuth();
+  const { isEnabled } = useFeatureFlag();
+  const parentalKeys = new Set<string>(
+    parentalGuideFilters.map(({ key }) => key),
+  );
+  const canUseParentalFilters = combineLatest([
+    isEnabled(FeatureFlag.ParentalGuide),
+    isAuthorized,
+    user,
+  ]).pipe(
+    map(([enabled, authorized, currentUser]) =>
+      enabled && authorized && Boolean(currentUser?.isVip)
+    ),
+    distinctUntilChanged(),
+  );
+  const search = combineLatest([rawSearch, canUseParentalFilters]).pipe(
+    map(([params, available]) =>
+      available ? params : new URLSearchParams(
+        Array.from(params).filter(([key]) => !parentalKeys.has(key)),
+      )
+    ),
+  );
+  const storedFilters = combineLatest([rawStoredFilters, canUseParentalFilters])
+    .pipe(
+      map(([filters, available]) =>
+        available ? filters : Object.fromEntries(
+          Object.entries(filters ?? {}).filter(([key]) =>
+            !parentalKeys.has(key)
+          ),
+        )
+      ),
+    );
 
   return {
     filters: FILTERS,

--- a/projects/client/src/lib/requests/models/FilterParams.ts
+++ b/projects/client/src/lib/requests/models/FilterParams.ts
@@ -7,6 +7,11 @@ export type FilterParam = {
   genres: string;
   subgenres: string;
   years: string;
+  parental_nudity: string;
+  parental_violence: string;
+  parental_profanity: string;
+  parental_alcohol: string;
+  parental_frightening: string;
   ignore_watched: boolean;
   ignore_watchlisted: boolean;
   watch_window: number;

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.spec.ts
@@ -1,11 +1,37 @@
 import { MoviesTrendingMappedMock } from '$mocks/data/movies/mapped/MoviesTrendingMappedMock.ts';
+import { server } from '$mocks/server.ts';
 import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { mapToEntries } from '$test/utils/mapToEntries.ts';
+import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
-import { movieTrendingQuery } from './movieTrendingQuery.ts';
+import {
+  movieTrendingQuery,
+  movieTrendingRequest,
+} from './movieTrendingQuery.ts';
 
 describe('movieTrendingQuery', () => {
+  it('should send parental guidance ranges to the API unchanged', async () => {
+    const filter = {
+      parental_nudity: '0-0',
+      parental_violence: '0-1',
+      parental_profanity: '1-2',
+      parental_alcohol: '2-3',
+      parental_frightening: '3-3',
+    };
+    let requestedUrl: URL | undefined;
+    server.use(http.get('http://localhost/movies/trending', ({ request }) => {
+      requestedUrl = new URL(request.url);
+      return HttpResponse.json([]);
+    }));
+
+    await movieTrendingRequest({ filter, limit: 10 });
+
+    Object.entries(filter).forEach(([key, value]) => {
+      expect(requestedUrl?.searchParams.get(key)).toBe(value);
+    });
+  });
+
   it('should query trending movies', async () => {
     const result = await runQuery({
       factory: () =>

--- a/projects/client/src/lib/requests/queries/users/smartListQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/smartListQuery.spec.ts
@@ -1,4 +1,8 @@
-import { smartListQuery } from '$lib/requests/queries/users/smartListQuery.ts';
+import { getSmartListFilterSummary } from '$lib/sections/lists/smart/getSmartListFilterSummary.ts';
+import {
+  smartListQuery,
+  SmartListSchema,
+} from '$lib/requests/queries/users/smartListQuery.ts';
 import { SmartListDefinitionsMappedMock } from '$mocks/data/users/mapped/SmartListDefinitionsMappedMock.ts';
 import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
@@ -6,6 +10,24 @@ import { mapToEntries } from '$test/utils/mapToEntries.ts';
 import { describe, expect, it } from 'vitest';
 
 describe('smartListQuery', () => {
+  it('should retain parental ranges in saved lists and summarize their severities', () => {
+    const list = SmartListSchema.parse({
+      ...SmartListDefinitionsMappedMock.at(0),
+      filters: { parental_nudity: [0, 0], parental_violence: [0, 1] },
+    });
+
+    expect(list.filters).toEqual({
+      parental_nudity: [0, 0],
+      parental_violence: [0, 1],
+    });
+    expect(getSmartListFilterSummary(list)).toContain(
+      'Sex & Nudity: None to None',
+    );
+    expect(getSmartListFilterSummary(list)).toContain(
+      'Violence & Gore: None to Mild',
+    );
+  });
+
   it('should request smart lists', async () => {
     const result = await runQuery({
       factory: () =>

--- a/projects/client/src/lib/requests/queries/users/smartListQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/smartListQuery.ts
@@ -38,6 +38,11 @@ const SmartListFiltersSchema = z.object({
   imdb_ratings: range,
   rt_meters: range,
   rt_user_meters: range,
+  parental_nudity: range,
+  parental_violence: range,
+  parental_profanity: range,
+  parental_alcohol: range,
+  parental_frightening: range,
   ignore_watched: z.boolean().optional(),
   ignore_watchlisted: z.boolean().optional(),
 });

--- a/projects/client/src/lib/sections/lists/smart/getSmartListFilterSummary.ts
+++ b/projects/client/src/lib/sections/lists/smart/getSmartListFilterSummary.ts
@@ -1,3 +1,4 @@
+import { parentalGuideFilters } from '$lib/features/filters/parentalGuideFilters.ts';
 import { languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import type { SmartList } from '$lib/requests/queries/users/smartListQuery.ts';
@@ -114,6 +115,17 @@ function formatList(key: string, values: string[]): string[] {
 }
 
 function formatRange(key: string, range: number[]): string[] {
+  const parentalFilter = parentalGuideFilters.find((filter) =>
+    filter.key === key
+  );
+  if (parentalFilter) {
+    const [
+      min = parentalFilter.range.min,
+      max = parentalFilter.range.max,
+    ] = range;
+    return [parentalFilter.formatLabel({ min, max })];
+  }
+
   switch (key) {
     case 'years':
       return [formatNumberRange(range, m.advanced_filter_label_release_year)];

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/AdvancedFilters.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/AdvancedFilters.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import { FilterMode } from "$lib/features/filters/models/FilterMode";
   import { FilterKey } from "$lib/features/filters/models/Filter.ts";
+  import { parentalGuideFilters } from "$lib/features/filters/parentalGuideFilters.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { useFilter } from "$lib/features/filters/useFilter";
   import FilterGroup from "./_internal/FilterGroup.svelte";
+  import { isAutoRenderedFilter } from "./_internal/isAutoRenderedFilter";
   import { isMultiSelectFilter } from "./_internal/isMultiSelectFilter";
   import { isSliderFilter } from "./_internal/isSliderFilter";
   import MultiSelectFilter from "./_internal/MultiSelectFilter.svelte";
@@ -11,7 +16,9 @@
 
   const { filters } = useFilter();
 
-  const sliderFilters = $derived(filters.filter(isSliderFilter));
+  const sliderFilters = $derived(
+    filters.filter(isAutoRenderedFilter).filter(isSliderFilter),
+  );
   const multiSelectFilters = $derived(filters.filter(isMultiSelectFilter));
 </script>
 
@@ -33,3 +40,16 @@
     additionalKeys={filter.advanced.additionalKeys}
   />
 {/each}
+
+<RenderForFeature flag={FeatureFlag.ParentalGuide}>
+  {#snippet enabled()}
+    <p class="bold">{m.option_text_certification_parental_guidance()}</p>
+    {#each parentalGuideFilters as filter (filter.key)}
+      <SliderFilter
+        key={filter.key}
+        sliderOptions={filter.advanced}
+        mode={FilterMode.Advanced}
+      />
+    {/each}
+  {/snippet}
+</RenderForFeature>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/SimpleFilters.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/SimpleFilters.svelte
@@ -2,6 +2,7 @@
   import { FilterKey } from "$lib/features/filters/models/Filter.ts";
   import { FilterMode } from "$lib/features/filters/models/FilterMode";
   import { useFilter } from "$lib/features/filters/useFilter";
+  import { isAutoRenderedFilter } from "./_internal/isAutoRenderedFilter";
   import FilterGroup from "./_internal/FilterGroup.svelte";
   import StreamingAvailabilityFilter from "./_internal/StreamingAvailabilityFilter.svelte";
   import ListFilter from "./ListFilter.svelte";
@@ -13,7 +14,9 @@
     filters.filter((filter) => filter.type === "list"),
   );
   const ratingTypeFilters = $derived(
-    filters.filter((filter) => filter.type === "slider"),
+    filters
+      .filter(isAutoRenderedFilter)
+      .filter((filter) => filter.type === "slider"),
   );
 </script>
 

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/isAutoRenderedFilter.ts
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/isAutoRenderedFilter.ts
@@ -1,0 +1,5 @@
+import type { Filter } from '$lib/features/filters/models/Filter.ts';
+
+export const isAutoRenderedFilter = (filter: Filter): boolean => {
+  return !filter.advancedOnly;
+};

--- a/projects/client/src/lib/sections/smart-lists/toSmartListFilters.spec.ts
+++ b/projects/client/src/lib/sections/smart-lists/toSmartListFilters.spec.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { toSmartListFilters } from './toSmartListFilters.ts';
 
 describe('toSmartListFilters', () => {
+  it('should preserve all parental guidance ranges including none only', () => {
+    expect(toSmartListFilters({
+      parental_nudity: '0-0',
+      parental_violence: '0-1',
+      parental_profanity: '1-2',
+      parental_alcohol: '2-3',
+      parental_frightening: '3-3',
+    })).toEqual({
+      parental_nudity: [0, 0],
+      parental_violence: [0, 1],
+      parental_profanity: [1, 2],
+      parental_alcohol: [2, 3],
+      parental_frightening: [3, 3],
+    });
+  });
+
   it('splits list keys into trimmed string arrays', () => {
     expect(toSmartListFilters({ genres: 'adventure, comedy' })).to.deep.equal({
       genres: ['adventure', 'comedy'],

--- a/projects/client/src/lib/sections/smart-lists/toSmartListFilters.ts
+++ b/projects/client/src/lib/sections/smart-lists/toSmartListFilters.ts
@@ -19,6 +19,11 @@ const RANGE_KEYS = [
   'imdb_ratings',
   'rt_meters',
   'rt_user_meters',
+  'parental_nudity',
+  'parental_violence',
+  'parental_profanity',
+  'parental_alcohol',
+  'parental_frightening',
 ] as const;
 type RangeKey = (typeof RANGE_KEYS)[number];
 

--- a/projects/client/src/lib/sections/summary/components/_internal/useParentalGuideCategories.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useParentalGuideCategories.ts
@@ -14,25 +14,19 @@ type DisplayableCategory = {
   severityLabel: string;
   severityProgress: number;
   severityTone: SeverityTone;
-  signals: ReadonlyArray<{
-    key: SignalTone;
-    label: string;
-    count: number;
-  }>;
 };
 
 type GuideEntry = Guide['guide'][number];
 type GuideCategory = GuideEntry['category'];
 type GuideSeverity = GuideEntry['severity'];
-type SignalTone = Lowercase<GuideSeverity>;
-type SeverityTone = SignalTone | 'unknown';
+type SeverityTone = Lowercase<GuideSeverity> | 'unknown';
 
 type ParentalGuideTarget = {
   type: MediaType;
   slug: string;
 };
 
-// Declaration order is render order: category rows, then signal breakdown.
+// Declaration order is render order.
 const CATEGORY_LABEL = {
   NUDITY: m.label_parental_guide_category_nudity,
   VIOLENCE: m.label_parental_guide_category_violence,
@@ -60,11 +54,11 @@ const SEVERITY = {
   SEVERE: {
     tone: 'severe',
     label: m.label_parental_guide_severity_severe,
-    progress: 0.9,
+    progress: 1,
   },
 } as const satisfies Record<
   GuideSeverity,
-  { tone: SignalTone; label: () => string; progress: number }
+  { tone: SeverityTone; label: () => string; progress: number }
 >;
 
 function toDisplayableCategories(
@@ -82,7 +76,6 @@ function toDisplayableCategories(
         severityLabel: m.text_unknown(),
         severityProgress: 0,
         severityTone: 'unknown',
-        signals: [],
       };
     }
 
@@ -94,11 +87,6 @@ function toDisplayableCategories(
       severityLabel: severity.label(),
       severityProgress: severity.progress,
       severityTone: severity.tone,
-      signals: Object.values(SEVERITY).map(({ tone, label }) => ({
-        key: tone,
-        label: label(),
-        count: entry.signals[tone],
-      })),
     };
   });
 }

--- a/projects/client/src/lib/sections/summary/components/details/DetailsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/DetailsDrawer.svelte
@@ -33,7 +33,7 @@
       {#if props.type !== "episode"}
         <MediaLinks media={props.media} />
 
-        <RenderForFeature flag={FeatureFlag.ParentalGuide} audience="director">
+        <RenderForFeature flag={FeatureFlag.ParentalGuide}>
           {#snippet enabled()}
             <MediaParentalGuide type={props.type} slug={props.media.slug} />
           {/snippet}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaParentalGuide.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaParentalGuide.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
-  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
-  import { getLocale } from "$lib/features/i18n/index.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaType } from "$lib/requests/models/MediaType.ts";
-  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber.ts";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import { useParentalGuideCategories } from "../../_internal/useParentalGuideCategories.ts";
 
@@ -48,42 +45,23 @@
           class="guide-row"
           data-severity={isPending ? "unknown" : category.severityTone}
         >
-          <span class="guide-label bold" title={category.label}>
+          <span class="guide-label bold">
             {category.label}
           </span>
           <div class="guide-meter">
-            <Tooltip
-              variant="compact"
-              sideOffset={4}
-              disabled={isPending || category.signals.length === 0}
-              disableHoverableContent
-            >
-              {#snippet content()}
-                <dl class="signals-list">
-                  {#each category.signals as signal (signal.key)}
-                    <div class="signal-row">
-                      <dt>{signal.label}</dt>
-                      <dd>
-                        {toHumanNumber(signal.count, getLocale())}
-                      </dd>
-                    </div>
-                  {/each}
-                </dl>
-              {/snippet}
-              <span class="guide-accessible-label">
-                {category.label}: {severityLabel}
-              </span>
-              <div class="guide-bar" aria-hidden="true">
-                <DistributionBar
-                  fraction={isPending ? 0 : category.severityProgress}
-                  color="var(--guide-severity-color)"
-                  fillStyle="flat"
-                  animated={false}
-                  --distribution-bar-thickness="var(--ni-8)"
-                  --distribution-bar-track="var(--guide-track-color)"
-                />
-              </div>
-            </Tooltip>
+            <span class="guide-accessible-label">
+              {category.label}: {severityLabel}
+            </span>
+            <div class="guide-bar" aria-hidden="true">
+              <DistributionBar
+                fraction={isPending ? 0 : category.severityProgress}
+                color="var(--guide-severity-color)"
+                fillStyle="flat"
+                animated={false}
+                --distribution-bar-thickness="var(--ni-8)"
+                --distribution-bar-track="var(--guide-track-color)"
+              />
+            </div>
           </div>
           <span class="guide-severity secondary">
             {severityLabel}
@@ -172,10 +150,6 @@
   .trakt-media-parental-guide .guide-meter {
     display: block;
     width: 100%;
-
-    :global(.trakt-tooltip-trigger) {
-      width: 100%;
-    }
   }
 
   .trakt-media-parental-guide .guide-severity {
@@ -214,39 +188,6 @@
 
   .trakt-media-parental-guide .guide-row[data-severity="severe"] {
     --guide-severity-color: var(--red-500);
-  }
-
-  .signals-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ni-4);
-    min-width: var(--ni-120);
-    margin: 0;
-
-    line-height: 1.25;
-    font-weight: 400;
-  }
-
-  .signal-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: var(--gap-l);
-
-    white-space: nowrap;
-
-    dt,
-    dd {
-      margin: 0;
-    }
-
-    dt {
-      font-weight: 600;
-    }
-
-    dd {
-      font-weight: 400;
-      font-variant-numeric: tabular-nums;
-    }
   }
 
   @include for-mobile {


### PR DESCRIPTION
Add parental guidance severity ranges to Advanced Filters for VIP members who enable the Parental Guidance preview.

Reuse the existing low/high sliders for all five categories, from None to Severe. Preserve selected ranges in URLs, saved filters, and smart lists, including None-only selections.

Move the existing parental guide display from director-only to VIP access and gate the new controls behind the same flag. Keep the flag key to preserve saved preferences.

Also simplify the drawer display on top of the recent redesign: drop the per-severity signal breakdown tooltip and let Severe fill the distribution bar.
