### PR TITLE
feat(list): adds seasons and episodes to user lists

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2462,7 +2462,7 @@
     },
     "button_text_manage_lists": {
       "default": "Manage lists",
-      "description": "Text for the button that opens the lists drawer. This allows users to add or remove a movie or show from their lists."
+      "description": "Text for the button that opens the lists drawer. This allows users to add or remove a movie, show, season or episode from their lists."
     },
     "button_text_view_history": {
       "default": "View History",
@@ -2470,7 +2470,7 @@
     },
     "dropdown_label_add_remove_from_lists": {
       "default": "Add or remove \"{title}\" from lists",
-      "description": "Aria-label for the dropdown that allows users to add or remove a movie or show from lists.",
+      "description": "Aria-label for the dropdown that allows users to add or remove a movie, show, season or episode from lists.",
       "variables": {
         "title": {
           "type": "string"
@@ -2479,7 +2479,7 @@
     },
     "button_label_add_to_personal_list": {
       "default": "Add \"{title}\" to {list}",
-      "description": "Aria-label for the button that allows users to add a movie or show to a personal list.",
+      "description": "Aria-label for the button that allows users to add a movie, show, season or episode to a personal list.",
       "variables": {
         "title": {
           "type": "string"
@@ -2491,7 +2491,7 @@
     },
     "button_label_remove_from_personal_list": {
       "default": "Remove \"{title}\" from {list}",
-      "description": "Aria-label for the button that allows users to remove a movie or show from a personal list.",
+      "description": "Aria-label for the button that allows users to remove a movie, show, season or episode from a personal list.",
       "variables": {
         "title": {
           "type": "string"
@@ -5740,7 +5740,7 @@
     },
     "header_manage_lists": {
       "default": "Manage lists",
-      "description": "Header for the drawer that allows users to add/remove a movie or show to/from their lists."
+      "description": "Header for the drawer that allows users to add/remove a movie, show, season or episode to/from their lists."
     },
     "header_sentiment_highlight": {
       "default": "Highlight",

--- a/projects/client/src/lib/features/calendar/ReleasesCalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/ReleasesCalendarItem.svelte
@@ -52,11 +52,12 @@
 
     <ListAction
       style="dropdown-item"
-      media={listTarget}
+      target={{ type: listTarget.type, media: listTarget }}
       title={listTarget.title}
       onClick={() =>
         manageListsDrawerStore.open({
-          media: listTarget,
+          target: { type: listTarget.type, media: listTarget },
+          title: listTarget.title,
           metaInfo: listTarget.title,
         })}
     />

--- a/projects/client/src/lib/models/ListTarget.ts
+++ b/projects/client/src/lib/models/ListTarget.ts
@@ -1,0 +1,9 @@
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { Season } from '$lib/requests/models/Season.ts';
+
+export type ListTarget =
+  | { type: MediaType; media: MediaEntry }
+  | { type: 'season'; media: Season }
+  | { type: 'episode'; media: EpisodeEntry };

--- a/projects/client/src/lib/requests/models/InvalidateAction.spec.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { InvalidateAction } from './InvalidateAction.ts';
+
+describe('InvalidateAction', () => {
+  describe('Listed', () => {
+    it('should keep movies on their own token', () => {
+      expect(InvalidateAction.Listed('movie')).to.equal(
+        'invalidate:listed:movie',
+      );
+    });
+
+    it('should collapse seasons onto the show token', () => {
+      expect(InvalidateAction.Listed('season')).to.equal(
+        InvalidateAction.Listed('show'),
+      );
+    });
+
+    it('should collapse episodes onto the show token', () => {
+      expect(InvalidateAction.Listed('episode')).to.equal(
+        InvalidateAction.Listed('show'),
+      );
+    });
+  });
+});

--- a/projects/client/src/lib/requests/models/InvalidateAction.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.ts
@@ -3,6 +3,7 @@ import type { ExtendedMediaType } from './ExtendedMediaType.ts';
 import type { MediaType } from './MediaType.ts';
 
 export type RatedMediaType = ExtendedMediaType | 'season';
+export type ListedMediaType = ExtendedMediaType | 'season';
 
 type UserType = 'avatar' | 'settings' | 'follow' | 'cover' | 'block';
 type ListType = 'edited' | 'deleted' | 'created' | 'like';
@@ -73,6 +74,10 @@ type TypeDataMap = {
   'app_delete': null;
 };
 
+function toListedScope(type: ListedMediaType): MediaType {
+  return type === 'movie' ? 'movie' : 'show';
+}
+
 export function invalidationId(key?: string) {
   return `${INVALIDATION_ID}:${key ?? ''}` as const;
 }
@@ -101,7 +106,8 @@ export const InvalidateAction = {
     buildInvalidationKey('collected', type),
 
   Watchlisted: (type: MediaType) => buildInvalidationKey('watchlisted', type),
-  Listed: (type: MediaType) => buildInvalidationKey('listed', type),
+  Listed: (type: ListedMediaType) =>
+    buildInvalidationKey('listed', toListedScope(type)),
 
   Drop: (type: MediaType) => buildInvalidationKey('dropped', type),
 

--- a/projects/client/src/lib/requests/queries/users/userEpisodeListIdsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userEpisodeListIdsQuery.ts
@@ -1,0 +1,38 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { InvalidateAction } from '../../models/InvalidateAction.ts';
+import {
+  type ListIdResponse,
+  ListIdSchema,
+  mapToListId,
+} from './userMovieListIdsQuery.ts';
+
+type UserEpisodeListIdsParams = { id: number } & ApiParams;
+
+const userEpisodeListIdsRequest = async (
+  { fetch, id }: UserEpisodeListIdsParams,
+) => {
+  const response = await rawApiFetch(
+    { fetch, path: `/v3/episodes/${id}/me/lists` },
+  );
+
+  const body = response.ok ? await response.json() : [];
+
+  return {
+    body: body as ListIdResponse[],
+    status: response.status,
+  };
+};
+
+export const userEpisodeListIdsQuery = defineQuery({
+  key: 'userEpisodeListIds',
+  invalidations: [
+    InvalidateAction.Listed('episode'),
+  ],
+  dependencies: (params) => [params.id],
+  request: userEpisodeListIdsRequest,
+  mapper: (response) => response.body.map(mapToListId),
+  schema: ListIdSchema.array(),
+  ttl: time.hours(3),
+});

--- a/projects/client/src/lib/requests/queries/users/userSeasonListIdsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userSeasonListIdsQuery.ts
@@ -1,0 +1,38 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { InvalidateAction } from '../../models/InvalidateAction.ts';
+import {
+  type ListIdResponse,
+  ListIdSchema,
+  mapToListId,
+} from './userMovieListIdsQuery.ts';
+
+type UserSeasonListIdsParams = { id: number } & ApiParams;
+
+const userSeasonListIdsRequest = async (
+  { fetch, id }: UserSeasonListIdsParams,
+) => {
+  const response = await rawApiFetch(
+    { fetch, path: `/v3/seasons/${id}/me/lists` },
+  );
+
+  const body = response.ok ? await response.json() : [];
+
+  return {
+    body: body as ListIdResponse[],
+    status: response.status,
+  };
+};
+
+export const userSeasonListIdsQuery = defineQuery({
+  key: 'userSeasonListIds',
+  invalidations: [
+    InvalidateAction.Listed('season'),
+  ],
+  dependencies: (params) => [params.id],
+  request: userSeasonListIdsRequest,
+  mapper: (response) => response.body.map(mapToListId),
+  schema: ListIdSchema.array(),
+  ttl: time.hours(3),
+});

--- a/projects/client/src/lib/sections/components/lists-drawer/ListAction.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListAction.svelte
@@ -4,7 +4,7 @@
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
   import * as m from "$lib/features/i18n/messages";
-  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { ListTarget } from "$lib/models/ListTarget";
   import { useListedOnIds } from "$lib/stores/useListedOnIds";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
 
@@ -13,7 +13,7 @@
     style?: "normal" | "action" | "dropdown-item";
     variant?: "primary" | "secondary";
     title: string;
-    media: MediaEntry;
+    target: ListTarget;
     onClick: () => void;
     disabled?: boolean;
   };
@@ -23,13 +23,13 @@
     style = "normal",
     variant = "secondary",
     title,
-    media,
+    target,
     onClick,
     disabled,
   }: ListActionProps = $props();
 
-  const media$ = fromRune(() => media);
-  const { isLoading } = useListedOnIds({ media$ });
+  const target$ = fromRune(() => target);
+  const { isLoading } = useListedOnIds({ target$ });
 
   const isDisabled = $derived(disabled || $isLoading);
 </script>

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
@@ -6,7 +6,6 @@
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
-  import type { MediaType } from "$lib/requests/models/MediaType";
   import { onMount } from "svelte";
   import { ListDropdownItemIntlProvider } from "./ListDropdownItemIntlProvider";
   import type { ListDropdownItemProps } from "./ListDropdownItemProps";
@@ -17,18 +16,14 @@
     list,
     onLoading,
     i18n = ListDropdownItemIntlProvider,
-    media,
+    target,
     isListed,
   }: ListDropdownItemProps = $props();
 
   const { user } = useUser();
 
   const { addToList, removeFromList, isListUpdating } = $derived(
-    useList({
-      list,
-      type: media.type as MediaType,
-      media,
-    }),
+    useList({ list, ...target }),
   );
 
   const isBelowLimit = $derived(list.count < $user.limits.lists.itemLimit);

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemProps.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemProps.ts
@@ -1,12 +1,10 @@
+import type { ListTarget } from '$lib/models/ListTarget.ts';
 import type { UserList } from '$lib/requests/queries/users/userListsQuery.ts';
 import type { ListDropdownItemIntl } from './ListDropdownItemIntl.ts';
 
 export type ListDropdownItemProps = {
   list: UserList;
-  media: {
-    id: number;
-    type: string;
-  };
+  target: ListTarget;
   onLoading?: (isLoading: boolean) => void;
   title: string;
   isListed: boolean;

--- a/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.spec.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.spec.ts
@@ -1,0 +1,84 @@
+import type { ListTarget } from '$lib/models/ListTarget.ts';
+import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
+import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
+import { server } from '$mocks/server.ts';
+import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { setAuthorization } from '$test/beds/store/renderStore.ts';
+import { screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it } from 'vitest';
+import ListsDrawer from './ListsDrawer.svelte';
+
+const LIST_ID = 37_255_911;
+const LIST_NAME = 'Seasons and eps';
+const OWNER_ID = 14_360_847;
+
+const targets: [string, string, ListTarget][] = [
+  [
+    'episode',
+    `http://localhost/v3/episodes/${EpisodeSiloMappedMock.id}/me/lists`,
+    { type: 'episode', media: EpisodeSiloMappedMock },
+  ],
+  [
+    'movie',
+    `http://localhost/v3/movies/${MovieHereticMappedMock.slug}/me/lists`,
+    { type: 'movie', media: MovieHereticMappedMock },
+  ],
+];
+
+describe('ListsDrawer', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+  });
+
+  it.each(targets)(
+    'should mark the list as added after adding a %s to it',
+    async (_type, listIdsUrl, target) => {
+      const user = userEvent.setup();
+      let isAdded = false;
+
+      server.use(
+        http.get('http://localhost/v3/users/me/lists', () => {
+          return HttpResponse.json([{
+            id: LIST_ID,
+            name: LIST_NAME,
+            count: 3,
+            type: 'standard',
+            display_order: 1,
+            owner_id: OWNER_ID,
+          }]);
+        }),
+        http.post(
+          `http://localhost/users/${OWNER_ID}/lists/${LIST_ID}/items`,
+          () => {
+            isAdded = true;
+            return HttpResponse.json({}, { status: 201 });
+          },
+        ),
+        http.get(listIdsUrl, () => {
+          return HttpResponse.json(isAdded ? [LIST_ID] : []);
+        }),
+      );
+
+      const title = 'Freedom Day';
+      renderComponent(ListsDrawer, {
+        props: { onClose: () => {}, title, target },
+      });
+
+      const row = await screen.findByText(LIST_NAME);
+
+      const bookmarkFill = () =>
+        row
+          .closest('li')
+          ?.querySelector('.trakt-bookmark-path')
+          ?.getAttribute('fill');
+
+      await waitFor(() => expect(bookmarkFill()).toBe('transparent'));
+
+      await user.click(row);
+
+      await waitFor(() => expect(bookmarkFill()).toBe('currentColor'));
+    },
+  );
+});

--- a/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
@@ -1,35 +1,32 @@
 <script lang="ts">
-  import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import DropdownGroup from "$lib/components/dropdown/DropdownGroup.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
-  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
-  import { useWatchlist } from "$lib/sections/media-actions/watchlist/useWatchlist";
+  import type { ListTarget } from "$lib/models/ListTarget";
   import { useAllPersonalLists } from "$lib/stores/useAllPersonalLists";
   import { useListedOnIds } from "$lib/stores/useListedOnIds";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import ListDropdownItem from "./ListDropdownItem.svelte";
+  import WatchlistDropdownItem from "./_internal/WatchlistDropdownItem.svelte";
 
   const {
     onClose,
     metaInfo,
-    media,
+    target,
     title,
     onLoading,
   }: {
     onClose: () => void;
-    title?: string;
+    title: string;
     metaInfo?: string;
-    media: MediaEntry;
+    target: ListTarget;
     onLoading?: (isLoading: boolean) => void;
   } = $props();
 
   const { lists, isLoading: isLoadingLists } = useAllPersonalLists();
-  const media$ = fromRune(() => media);
-  const { listedOnIds, isLoading: isLoadingIds } = useListedOnIds({ media$ });
+  const target$ = fromRune(() => target);
+  const { listedOnIds, isLoading: isLoadingIds } = useListedOnIds({ target$ });
 
   const listedOnIdsSet = $derived(new Set($listedOnIds));
   const sortedLists = $derived(
@@ -41,54 +38,31 @@
     }),
   );
 
-  const {
-    addToWatchlist,
-    isWatchlistUpdating,
-    isWatchlisted,
-    removeFromWatchlist,
-  } = $derived(
-    useWatchlist({ media, type: media.type, isToastEnabled: false }),
-  );
-
-  const { confirm } = useConfirm();
-  const confirmRemove = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFromWatchList,
-      title: title ?? media.title,
-      onConfirm: removeFromWatchlist,
-    }),
-  );
-
   const isLoading = $derived($isLoadingIds || $isLoadingLists);
   const isEmpty = $derived($lists.length === 0);
-
-  $effect(() => {
-    onLoading?.($isWatchlistUpdating);
-  });
 </script>
 
 <Drawer {onClose} title={m.header_manage_lists()} {metaInfo}>
   <div class="lists-layout">
     <DropdownGroup>
-      <WatchlistButton
-        title={title ?? media.title}
-        type="dropdown-item"
-        size="normal"
-        isWatchlistUpdating={$isWatchlistUpdating}
-        isWatchlisted={$isWatchlisted}
-        onAdd={addToWatchlist}
-        onRemove={confirmRemove}
-      />
+      {#if target.type === "movie" || target.type === "show"}
+        <WatchlistDropdownItem
+          media={target.media}
+          type={target.type}
+          {title}
+          {onLoading}
+        />
+      {/if}
 
       {#if isEmpty && isLoading}
         <LoadingIndicator />
       {:else}
         {#each sortedLists as list (list.id)}
           <ListDropdownItem
-            title={title ?? media.title}
+            {title}
             {list}
             {onLoading}
-            {media}
+            {target}
             isListed={listedOnIdsSet.has(list.id)}
           />
         {/each}

--- a/projects/client/src/lib/sections/components/lists-drawer/ManageListsDrawerProvider.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ManageListsDrawerProvider.svelte
@@ -6,7 +6,7 @@
 {#if $manageListsDrawerStore?.isOpen}
   <ListsDrawer
     onClose={manageListsDrawerStore.close}
-    media={$manageListsDrawerStore.media}
+    target={$manageListsDrawerStore.target}
     title={$manageListsDrawerStore.title}
     metaInfo={$manageListsDrawerStore.metaInfo}
   />

--- a/projects/client/src/lib/sections/components/lists-drawer/_internal/WatchlistDropdownItem.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/_internal/WatchlistDropdownItem.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
+  import { useConfirm } from "$lib/features/confirmation/useConfirm";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useWatchlist } from "$lib/sections/media-actions/watchlist/useWatchlist";
+
+  const {
+    media,
+    type,
+    title,
+    onLoading,
+  }: {
+    media: MediaEntry;
+    type: MediaType;
+    title: string;
+    onLoading?: (isLoading: boolean) => void;
+  } = $props();
+
+  const {
+    addToWatchlist,
+    isWatchlistUpdating,
+    isWatchlisted,
+    removeFromWatchlist,
+  } = $derived(useWatchlist({ media, type, isToastEnabled: false }));
+
+  const { confirm } = useConfirm();
+  const confirmRemove = $derived(
+    confirm({
+      type: ConfirmationType.RemoveFromWatchList,
+      title,
+      onConfirm: removeFromWatchlist,
+    }),
+  );
+
+  $effect(() => {
+    onLoading?.($isWatchlistUpdating);
+  });
+</script>
+
+<WatchlistButton
+  {title}
+  type="dropdown-item"
+  size="normal"
+  isWatchlistUpdating={$isWatchlistUpdating}
+  isWatchlisted={$isWatchlisted}
+  onAdd={addToWatchlist}
+  onRemove={confirmRemove}
+/>

--- a/projects/client/src/lib/sections/components/lists-drawer/manageListsDrawerStore.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/manageListsDrawerStore.ts
@@ -1,9 +1,9 @@
-import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { ListTarget } from '$lib/models/ListTarget.ts';
 import { BehaviorSubject } from 'rxjs';
 
 type ManageListsDrawerProps = {
-  media: MediaEntry;
-  title?: string;
+  target: ListTarget;
+  title: string;
   metaInfo?: string;
 };
 

--- a/projects/client/src/lib/sections/components/lists-drawer/useList.spec.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/useList.spec.ts
@@ -1,0 +1,77 @@
+import type { ListTarget } from '$lib/models/ListTarget.ts';
+import type { UserList } from '$lib/requests/queries/users/userListsQuery.ts';
+import { useListedOnIds } from '$lib/stores/useListedOnIds.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
+import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
+import { server } from '$mocks/server.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { valueObservable } from '$test/beds/store/valueObservable.ts';
+import { http, HttpResponse } from 'msw';
+import { filter, firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useList } from './useList.ts';
+
+const LIST_ID = 37_255_911;
+
+const list: UserList = {
+  id: LIST_ID,
+  name: 'Seasons and eps',
+  count: 3,
+  ownerId: 14_360_847,
+};
+
+const season = assertDefined(ShowSiloSeasonsMappedMock.at(0));
+
+const targets: [string, string, ListTarget][] = [
+  ['season', `http://localhost/v3/seasons/${season.id}/me/lists`, {
+    type: 'season',
+    media: season,
+  }],
+  [
+    'episode',
+    `http://localhost/v3/episodes/${EpisodeSiloMappedMock.id}/me/lists`,
+    { type: 'episode', media: EpisodeSiloMappedMock },
+  ],
+];
+
+describe('store: useList', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+  });
+
+  it.each(targets)(
+    'should reflect a %s as listed after adding it',
+    async (_type, listedUrl, target) => {
+      let isAdded = false;
+
+      server.use(
+        http.post(
+          `http://localhost/users/${list.ownerId}/lists/${list.id}/items`,
+          () => {
+            isAdded = true;
+            return HttpResponse.json({}, { status: 201 });
+          },
+        ),
+        http.get(listedUrl, () => {
+          return HttpResponse.json(isAdded ? [LIST_ID] : []);
+        }),
+      );
+
+      const { listedOnIds, addToList } = await renderStore(() => ({
+        ...useListedOnIds({ target$: valueObservable(target) }),
+        ...useList({ list, ...target }),
+      }));
+
+      expect(await firstValueFrom(listedOnIds)).to.deep.equal([]);
+
+      await addToList();
+
+      const updated = await firstValueFrom(
+        listedOnIds.pipe(filter((ids) => ids.length > 0)),
+      );
+
+      expect(updated).to.deep.equal([LIST_ID]);
+    },
+  );
+});

--- a/projects/client/src/lib/sections/components/lists-drawer/useList.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/useList.ts
@@ -1,39 +1,30 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
-import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { ListTarget } from '$lib/models/ListTarget.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { addToListRequest } from '$lib/requests/queries/users/addToListRequest.ts';
 import { removeFromListRequest } from '$lib/requests/queries/users/removeFromListRequest.ts';
 import type { UserList } from '$lib/requests/queries/users/userListsQuery.ts';
-import {
-  toBulkPayload,
-} from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
+import { toBulkPayload } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { BehaviorSubject } from 'rxjs';
 
-type UseListProps = { list: UserList } & MediaStoreProps;
+type UseListProps = { list: UserList } & ListTarget;
 
-export function useList(props: UseListProps) {
-  const { type } = props;
-  const media = Array.isArray(props.media) ? props.media : [props.media];
+export function useList({ list, type, media }: UseListProps) {
   const isListUpdating = new BehaviorSubject(false);
   const { invalidate } = useInvalidator();
 
   const { track } = useTrack(AnalyticsEvent.List);
-  const ids = media.map(({ id }) => id);
-  const body = toBulkPayload(type, ids);
+  const body = toBulkPayload(type, [media.id]);
 
   const addToList = async () => {
-    if (type === 'episode') {
-      return;
-    }
-
     isListUpdating.next(true);
     track({ action: 'add' });
 
     await addToListRequest({
-      listId: props.list.id,
-      userId: props.list.ownerId,
+      listId: list.id,
+      userId: list.ownerId,
       body,
     });
     await invalidate(InvalidateAction.Listed(type));
@@ -42,16 +33,12 @@ export function useList(props: UseListProps) {
   };
 
   const removeFromList = async () => {
-    if (type === 'episode') {
-      return;
-    }
-
     isListUpdating.next(true);
     track({ action: 'remove' });
 
     await removeFromListRequest({
-      listId: props.list.id,
-      userId: props.list.ownerId,
+      listId: list.id,
+      userId: list.ownerId,
       body,
     });
     await invalidate(InvalidateAction.Listed(type));

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -108,7 +108,11 @@
     <DefaultMediaPopupActions
       {media}
       onListAction={() =>
-        manageListsDrawerStore.open({ media, metaInfo: media.title })}
+        manageListsDrawerStore.open({
+          target: { type: media.type, media },
+          title: media.title,
+          metaInfo: media.title,
+        })}
     />
   {/if}
 {/snippet}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaPopupActions.svelte
@@ -26,7 +26,7 @@
 />
 <ListAction
   style="dropdown-item"
-  {media}
+  target={{ type: media.type, media }}
   title={media.title}
   onClick={onListAction}
 />

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
@@ -40,7 +40,11 @@
     <DefaultMediaPopupActions
       {media}
       onListAction={() =>
-        manageListsDrawerStore.open({ media, metaInfo: media.title })}
+        manageListsDrawerStore.open({
+          target: { type: media.type, media },
+          title: media.title,
+          metaInfo: media.title,
+        })}
     />
     <HideRecommendationAction {media} />
   {/snippet}

--- a/projects/client/src/lib/sections/lists/season/SeasonActions.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonActions.svelte
@@ -3,6 +3,9 @@
   import ReportButton from "$lib/features/report/ReportButton.svelte";
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { ListTarget } from "$lib/models/ListTarget";
+  import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
+  import { manageListsDrawerStore } from "$lib/sections/components/lists-drawer/manageListsDrawerStore";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import type { SeasonActionsProps } from "./SeasonActionsProps.ts";
 
@@ -10,9 +13,11 @@
     title,
     episodes,
     show,
-    seasonId,
+    season,
     isLoading = false,
   }: SeasonActionsProps = $props();
+
+  const target = $derived<ListTarget>({ type: "season", media: season });
 </script>
 
 <MarkAsWatchedAction
@@ -24,11 +29,17 @@
   {isLoading}
 />
 
-{#if seasonId != null}
-  <RenderFor audience="authenticated">
-    <ReportButton
-      params={{ type: ReportableType.Season, id: seasonId, title }}
-      label={m.button_label_report_media({ title })}
-    />
-  </RenderFor>
-{/if}
+<ListAction
+  style="dropdown-item"
+  {target}
+  {title}
+  onClick={() =>
+    manageListsDrawerStore.open({ target, title, metaInfo: show.title })}
+/>
+
+<RenderFor audience="authenticated">
+  <ReportButton
+    params={{ type: ReportableType.Season, id: season.id, title }}
+    label={m.button_label_report_media({ title })}
+  />
+</RenderFor>

--- a/projects/client/src/lib/sections/lists/season/SeasonActionsProps.ts
+++ b/projects/client/src/lib/sections/lists/season/SeasonActionsProps.ts
@@ -1,10 +1,11 @@
 import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+import type { Season } from '$lib/requests/models/Season.ts';
 import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 
 export type SeasonActionsProps = {
   title: string;
   episodes: EpisodeEntry[];
   show: ShowEntry;
-  seasonId?: number;
+  season: Season;
   isLoading?: boolean;
 };

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -2,12 +2,17 @@
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import IconWrapper from "$lib/components/icons/IconWrapper.svelte";
   import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
+  import { useAuth } from "$lib/features/auth/stores/useAuth";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { ListTarget } from "$lib/models/ListTarget";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
+  import { manageListsDrawerStore } from "$lib/sections/components/lists-drawer/manageListsDrawerStore";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import type { BaseItemProps } from "$lib/sections/lists/components/models/BaseItemProps";
   import type { EpisodeUrlOverride } from "$lib/sections/lists/components/models/EpisodeUrlOverride";
@@ -16,6 +21,7 @@
   import { useWatchUntilHereEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/useWatchUntilHereEpisodes.ts";
   import { useMarkAsWatched } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
   import { scrollActiveItemIntoView } from "$lib/utils/actions/scrollActiveItemIntoView";
+  import { episodeMetaInfo } from "$lib/utils/intl/episodeMetaInfo";
 
   type SeasonEpisodeItemProps = {
     show: ShowEntry;
@@ -59,6 +65,14 @@
   );
   const variant = $derived(isFuture ? "upcoming" : "default");
 
+  const { isAuthorized } = useAuth();
+  const { user } = useUser();
+  const target = $derived<ListTarget>({ type: "episode", media: episode });
+  const listMetaInfo = $derived(episodeMetaInfo(episode, show.title));
+  const hasPopupActions = $derived(
+    isActionable || ($isAuthorized && $user != null),
+  );
+
   const src = $derived(
     useEpisodeSpoilerImage({
       episode,
@@ -85,14 +99,16 @@
 
 {#snippet popupActions()}
   <RenderFor audience="authenticated">
-    <MarkAsWatchedAction
-      style="dropdown-item"
-      type="episode"
-      title={episode.title}
-      {show}
-      media={episode}
-      mode="hybrid"
-    />
+    {#if isActionable}
+      <MarkAsWatchedAction
+        style="dropdown-item"
+        type="episode"
+        title={episode.title}
+        {show}
+        media={episode}
+        mode="hybrid"
+      />
+    {/if}
     {#if hasBulkMarkAsWatched}
       <DropdownItem
         onclick={() => (isWatchUntilDrawerOpen = true)}
@@ -110,6 +126,17 @@
         {/snippet}
       </DropdownItem>
     {/if}
+    <ListAction
+      style="dropdown-item"
+      {target}
+      title={episode.title}
+      onClick={() =>
+        manageListsDrawerStore.open({
+          target,
+          title: episode.title,
+          metaInfo: listMetaInfo,
+        })}
+    />
   </RenderFor>
 {/snippet}
 
@@ -118,7 +145,7 @@
     {episode}
     media={show}
     {style}
-    popupActions={isActionable ? popupActions : undefined}
+    popupActions={hasPopupActions ? popupActions : undefined}
     variant={isFuture ? "upcoming" : "default"}
     context="show"
     {source}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterItem.svelte
@@ -19,7 +19,7 @@
     {title}
     episodes={$episodes}
     {show}
-    seasonId={season.id}
+    {season}
     isLoading={$isLoading}
   />
 {/snippet}

--- a/projects/client/src/lib/sections/lists/user/_internal/PopupActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/PopupActions.svelte
@@ -4,6 +4,8 @@
   import type { ListItem } from "$lib/requests/models/ListItem";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
 
+  import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
+  import { manageListsDrawerStore } from "$lib/sections/components/lists-drawer/manageListsDrawerStore";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
@@ -53,6 +55,16 @@
 <RenderFor audience="authenticated">
   {#if isMyList && target}
     <RemoveFromListAction {list} {target} />
+  {/if}
+
+  {#if target && (listedItem.type === "season" || listedItem.type === "episode")}
+    <ListAction
+      style="dropdown-item"
+      {target}
+      title={target.title}
+      onClick={() =>
+        manageListsDrawerStore.open({ target, title: target.title })}
+    />
   {/if}
 
   {#if listedItem.type === "movie" || listedItem.type === "show"}

--- a/projects/client/src/lib/sections/lists/user/_internal/useRemoveFromList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useRemoveFromList.ts
@@ -35,10 +35,7 @@ export function useRemoveFromList(props: UseRemoveFromListProps) {
       listId: props.listId,
     });
 
-    const invalidationType = type === 'episode' || type === 'season'
-      ? 'show'
-      : type;
-    await invalidate(InvalidateAction.Listed(invalidationType));
+    await invalidate(InvalidateAction.Listed(type));
 
     isListUpdating.next(false);
   };

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
@@ -81,7 +81,7 @@ export function useWatchlist(props: UseWatchlistProps) {
           label: m.action_toast_label_change_list({ title: singleEntry.title }),
           onAction: () =>
             manageListsDrawerStore.open({
-              media: singleEntry,
+              target: { type: singleEntry.type, media: singleEntry },
               title: singleEntry.title,
             }),
         }

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as m from "$lib/features/i18n/messages";
+  import { episodeMetaInfo } from "$lib/utils/intl/episodeMetaInfo";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import TrackAction from "$lib/sections/media-actions/mark-as-watched/TrackAction.svelte";
@@ -29,7 +29,7 @@
   popup={{
     title,
     actions: popupActions,
-    metaInfo: `${showTitle} • ${m.text_season_episode_number(episode)}`,
+    metaInfo: episodeMetaInfo(episode, showTitle),
   }}
 >
   <TrackAction {title} type="episode" media={episode} {show} />

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
@@ -3,9 +3,13 @@
   import ReportButton from "$lib/features/report/ReportButton.svelte";
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { ListTarget } from "$lib/models/ListTarget";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import ModerateAction from "$lib/sections/components/admin/ModerateAction.svelte";
+  import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
+  import { manageListsDrawerStore } from "$lib/sections/components/lists-drawer/manageListsDrawerStore";
+  import { episodeMetaInfo } from "$lib/utils/intl/episodeMetaInfo";
   import SetCoverImageAction from "$lib/sections/media-actions/cover-image/SetCoverImageAction.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
@@ -29,6 +33,9 @@
   const { isWatched } = $derived(
     useIsWatched({ media: episode, show, type: "episode" }),
   );
+
+  const target = $derived<ListTarget>({ type: "episode", media: episode });
+  const metaInfo = $derived(episodeMetaInfo(episode, showTitle));
 </script>
 
 {#if $isWatched}
@@ -41,6 +48,14 @@
     {show}
   />
 {/if}
+
+<ListAction
+  style="dropdown-item"
+  {target}
+  {title}
+  onClick={() => manageListsDrawerStore.open({ target, title, metaInfo })}
+  variant="primary"
+/>
 
 <EpisodeSideActions
   {title}

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaActions.svelte
@@ -20,7 +20,11 @@
   <MediaPopupActions
     {media}
     {title}
-    onListAction={() => manageListsDrawerStore.open({ media, title })}
+    onListAction={() =>
+      manageListsDrawerStore.open({
+        target: { type: media.type, media },
+        title,
+      })}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -73,7 +73,7 @@
 
 <ListAction
   style="dropdown-item"
-  {media}
+  target={{ type: media.type, media }}
   {title}
   onClick={onListAction}
   variant="primary"

--- a/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonDrawerItem.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonDrawerItem.svelte
@@ -23,7 +23,7 @@
     {title}
     episodes={$episodes}
     {show}
-    seasonId={season.id}
+    {season}
     isLoading={$isLoading}
   />
 {/snippet}

--- a/projects/client/src/lib/stores/useListedOnIds.spec.ts
+++ b/projects/client/src/lib/stores/useListedOnIds.spec.ts
@@ -1,25 +1,45 @@
-import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
-import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { ListTarget } from '$lib/models/ListTarget.ts';
+import { UserEpisodeListIdsResponseMock } from '$mocks/data/lists/response/UserEpisodeListIdsResponseMock.ts';
 import { UserMovieListIdsResponseMock } from '$mocks/data/lists/response/UserMovieListIdsResponseMock.ts';
+import { UserSeasonListIdsResponseMock } from '$mocks/data/lists/response/UserSeasonListIdsResponseMock.ts';
 import { UserShowListIdsResponseMock } from '$mocks/data/lists/response/UserShowListIdsResponseMock.ts';
+import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
+import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { valueObservable } from '$test/beds/store/valueObservable.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { BehaviorSubject } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { useListedOnIds } from './useListedOnIds.ts';
 
+const movieTarget: ListTarget = {
+  type: 'movie',
+  media: MovieHereticMappedMock,
+};
+const showTarget: ListTarget = { type: 'show', media: ShowSiloMappedMock };
+const seasonTarget: ListTarget = {
+  type: 'season',
+  media: assertDefined(ShowSiloSeasonsMappedMock.at(0)),
+};
+const episodeTarget: ListTarget = {
+  type: 'episode',
+  media: EpisodeSiloMappedMock,
+};
+
 describe('store: useListedOnIds', () => {
-  it.each<[MediaType, MediaEntry, number[]]>([
-    ['movie', MovieHereticMappedMock, UserMovieListIdsResponseMock],
-    ['show', ShowSiloMappedMock, UserShowListIdsResponseMock],
+  it.each<[ListTarget['type'], ListTarget, number[]]>([
+    ['movie', movieTarget, UserMovieListIdsResponseMock],
+    ['show', showTarget, UserShowListIdsResponseMock],
+    ['season', seasonTarget, UserSeasonListIdsResponseMock],
+    ['episode', episodeTarget, UserEpisodeListIdsResponseMock],
   ])(
     'should resolve the list ids a %s is on',
-    async (_type, media, expected) => {
+    async (_type, target, expected) => {
       const listedOnIds = await runQuery({
         factory: () =>
-          useListedOnIds({ media$: valueObservable(media) }).listedOnIds,
+          useListedOnIds({ target$: valueObservable(target) }).listedOnIds,
         waitFor: (ids) => ids.length > 0,
       });
 
@@ -27,17 +47,17 @@ describe('store: useListedOnIds', () => {
     },
   );
 
-  it('should re-key the query when the media observable emits', async () => {
-    const media$ = new BehaviorSubject<MediaEntry>(MovieHereticMappedMock);
+  it('should re-key the query when the target observable emits', async () => {
+    const target$ = new BehaviorSubject<ListTarget>(movieTarget);
 
     const listedOnIds = runQuery({
-      factory: () => useListedOnIds({ media$ }).listedOnIds,
+      factory: () => useListedOnIds({ target$ }).listedOnIds,
       waitFor: (ids) =>
         ids.length > 0 &&
         ids.every((id) => UserShowListIdsResponseMock.includes(id)),
     });
 
-    media$.next(ShowSiloMappedMock);
+    target$.next(showTarget);
 
     expect(await listedOnIds).to.deep.equal(UserShowListIdsResponseMock);
   });

--- a/projects/client/src/lib/stores/useListedOnIds.ts
+++ b/projects/client/src/lib/stores/useListedOnIds.ts
@@ -1,25 +1,29 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
-import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { ListTarget } from '$lib/models/ListTarget.ts';
+import { userEpisodeListIdsQuery } from '$lib/requests/queries/users/userEpisodeListIdsQuery.ts';
 import { userMovieListIdsQuery } from '$lib/requests/queries/users/userMovieListIdsQuery.ts';
+import { userSeasonListIdsQuery } from '$lib/requests/queries/users/userSeasonListIdsQuery.ts';
 import { userShowListIdsQuery } from '$lib/requests/queries/users/userShowListIdsQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { map, type Observable } from 'rxjs';
 
-type UseListIdsProps = { media$: Observable<MediaEntry> };
+type UseListIdsProps = { target$: Observable<ListTarget> };
 
-function typeToQuery(media: MediaEntry) {
-  const params = { slug: media.slug };
-
-  switch (media.type) {
+function targetToQuery(target: ListTarget) {
+  switch (target.type) {
     case 'movie':
-      return userMovieListIdsQuery(params);
+      return userMovieListIdsQuery({ slug: target.media.slug });
     case 'show':
-      return userShowListIdsQuery(params);
+      return userShowListIdsQuery({ slug: target.media.slug });
+    case 'season':
+      return userSeasonListIdsQuery({ id: target.media.id });
+    case 'episode':
+      return userEpisodeListIdsQuery({ id: target.media.id });
   }
 }
 
-export function useListedOnIds({ media$ }: UseListIdsProps) {
-  const response = useQuery(media$.pipe(map(typeToQuery)));
+export function useListedOnIds({ target$ }: UseListIdsProps) {
+  const response = useQuery(target$.pipe(map(targetToQuery)));
 
   return {
     listedOnIds: response.pipe(map(($response) => $response.data ?? [])),

--- a/projects/client/src/lib/utils/intl/episodeMetaInfo.ts
+++ b/projects/client/src/lib/utils/intl/episodeMetaInfo.ts
@@ -1,0 +1,9 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+
+export function episodeMetaInfo(
+  episode: EpisodeEntry,
+  showTitle: string,
+): string {
+  return `${showTitle} • ${m.text_season_episode_number(episode)}`;
+}

--- a/projects/client/src/mocks/data/lists/response/UserEpisodeListIdsResponseMock.ts
+++ b/projects/client/src/mocks/data/lists/response/UserEpisodeListIdsResponseMock.ts
@@ -1,0 +1,5 @@
+import type { ListIdResponse } from '$lib/requests/queries/users/userMovieListIdsQuery.ts';
+
+export const UserEpisodeListIdsResponseMock: ListIdResponse[] = [
+  30_692_147,
+];

--- a/projects/client/src/mocks/data/lists/response/UserSeasonListIdsResponseMock.ts
+++ b/projects/client/src/mocks/data/lists/response/UserSeasonListIdsResponseMock.ts
@@ -1,0 +1,6 @@
+import type { ListIdResponse } from '$lib/requests/queries/users/userMovieListIdsQuery.ts';
+
+export const UserSeasonListIdsResponseMock: ListIdResponse[] = [
+  30_692_145,
+  30_692_146,
+];

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -2,6 +2,10 @@ import { http, HttpResponse } from 'msw';
 
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
+import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
+import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
+import { UserEpisodeListIdsResponseMock } from '$mocks/data/lists/response/UserEpisodeListIdsResponseMock.ts';
+import { UserSeasonListIdsResponseMock } from '$mocks/data/lists/response/UserSeasonListIdsResponseMock.ts';
 import { UserShowListIdsResponseMock } from '$mocks/data/lists/response/UserShowListIdsResponseMock.ts';
 import { EpisodeSiloCommentsResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloCommentsResponseMock.ts';
 import { EpisodeSiloPeopleResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloPeopleResponseMock.ts';
@@ -302,6 +306,20 @@ export const shows = [
     `http://localhost/v3/shows/${ShowSiloResponseMock.ids.slug}/me/lists`,
     () => {
       return HttpResponse.json(UserShowListIdsResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/v3/seasons/${
+      assertDefined(ShowSiloSeasonsMappedMock.at(0)).id
+    }/me/lists`,
+    () => {
+      return HttpResponse.json(UserSeasonListIdsResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/v3/episodes/${EpisodeSiloMappedMock.id}/me/lists`,
+    () => {
+      return HttpResponse.json(UserEpisodeListIdsResponseMock);
     },
   ),
 ];


### PR DESCRIPTION
## 🎶 Notes 🎶

- Lists could already contain seasons and episodes (added through the old rails app) and we already render those rows, but there was no way to add one from trakt-web. This adds it, same as movies and shows.
- Manage lists is now available on the episode summary popup, the season popup, episode rows inside season lists, and season/episode rows when viewing a list.
- The drawer hides the watchlist row for seasons and episodes, they can only go on user lists.
- Membership comes from `/v3/{seasons,episodes}/:id/me/lists`, added in trakt/trakt-workers#1518. Needs that deployed before the drawer can show what a season or episode is already on.
- New `ListTarget` model threaded through the drawer, replacing the movie/show only `media` prop. Season and episode invalidations collapse onto the show token, so the queries already subscribed to `listed:show` keep refreshing without each of them opting into two more tokens.
- Episode rows in a season list now show their popup even when the episode has not aired yet, so an upcoming episode can be added to a list. Mark as watched stays behind its own conditions.
- ⚠️ The shows toggle on a list page still leaves out seasons and episodes. The SDK only has `/items/show`, and there is no method for `show,season,episode`. Media shows everything, so it is only the shows filter. Will be tackled separately.

## 👀 Example 👀

https://github.com/user-attachments/assets/11bcd3bd-9b6c-4d9b-92a3-7907a08269f2


