### PR TITLE
feat(list): add featured people with a searchable drilldown

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -11,6 +11,10 @@
     }
   },
   "messages": {
+    "list_title_featured_people": {
+      "default": "Featured People",
+      "description": "Heading for the row of recurring cast, directors, and creators featured in a list."
+    },
     "link_text_streaming_sync_settings": {
       "default": "Streaming",
       "description": "Text for the link to the streaming services settings page."

--- a/projects/client/src/lib/requests/queries/lists/listFeaturedPeopleQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/lists/listFeaturedPeopleQuery.spec.ts
@@ -1,0 +1,72 @@
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/assets.ts';
+import { server } from '$mocks/server.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { listFeaturedPeopleQuery } from './listFeaturedPeopleQuery.ts';
+
+const listId = 42;
+const readFeaturedPeople = () =>
+  runQuery({
+    factory: () => createTestBedQuery(listFeaturedPeopleQuery({ listId })),
+    waitFor: (response) => response.isSuccess,
+  }).then((response) => response.data);
+
+describe('listFeaturedPeopleQuery', () => {
+  it('should request the extension and preserve ranking with minimal person data', async () => {
+    let requestedUrl: URL | undefined;
+    server.use(
+      http.get(`http://localhost/lists/${listId}`, ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return HttpResponse.json({
+          featured: [
+            {
+              name: 'Rebecca Ferguson',
+              ids: { trakt: 2, slug: 'rebecca-ferguson' },
+            },
+            { name: 'Hugh Grant', ids: { trakt: 1, slug: 'hugh-grant' } },
+          ],
+        });
+      }),
+    );
+
+    const result = await readFeaturedPeople();
+
+    expect(requestedUrl?.searchParams.get('extended')).toBe('featured');
+    expect(result?.map((person) => person.slug)).toEqual([
+      'rebecca-ferguson',
+      'hugh-grant',
+    ]);
+    expect(result?.map((person) => person.headshot.url.thumb)).toEqual([
+      MEDIA_POSTER_PLACEHOLDER,
+      MEDIA_POSTER_PLACEHOLDER,
+    ]);
+  });
+
+  it.each([[], null, undefined])(
+    'should return no people for an empty or unavailable extension (%s)',
+    async (featured) => {
+      server.use(
+        http.get(
+          `http://localhost/lists/${listId}`,
+          () => HttpResponse.json({ featured }),
+        ),
+      );
+
+      expect(await readFeaturedPeople()).toEqual([]);
+    },
+  );
+
+  it('should reject failed requests instead of caching them as an empty list', async () => {
+    server.use(
+      http.get(
+        `http://localhost/lists/${listId}`,
+        () => new HttpResponse(null, { status: 503 }),
+      ),
+    );
+
+    await expect(listFeaturedPeopleQuery({ listId }).execute()).rejects
+      .toThrow();
+  });
+});

--- a/projects/client/src/lib/requests/queries/lists/listFeaturedPeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listFeaturedPeopleQuery.ts
@@ -1,0 +1,45 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToPersonSummary } from '$lib/requests/_internal/mapToPersonSummary.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { PersonSummarySchema } from '$lib/requests/models/PersonSummary.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { personResponseSchema } from '@trakt/api';
+import { z } from 'zod';
+
+const FeaturedResponseSchema = z.object({
+  featured: personResponseSchema.array().nullish(),
+});
+
+type ListFeaturedPeopleParams = { listId: number } & ApiParams;
+
+const listFeaturedPeopleRequest = async (
+  { fetch, listId }: ListFeaturedPeopleParams,
+) => {
+  // The SDK list schema does not expose the featured extension yet.
+  const response = await rawApiFetch({
+    fetch,
+    path: `/lists/${listId}?extended=featured`,
+  });
+
+  return {
+    status: response.status,
+    body: response.ok
+      ? FeaturedResponseSchema.parse(await response.json())
+      : undefined,
+  };
+};
+
+export const listFeaturedPeopleQuery = defineQuery({
+  key: 'listFeaturedPeople',
+  invalidations: [
+    InvalidateAction.List.Edited,
+    InvalidateAction.Listed('movie'),
+    InvalidateAction.Listed('show'),
+  ],
+  dependencies: (params) => [params.listId],
+  request: listFeaturedPeopleRequest,
+  mapper: (response) => (response.body?.featured ?? []).map(mapToPersonSummary),
+  schema: PersonSummarySchema.array(),
+  ttl: time.minutes(30),
+});

--- a/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
@@ -14,7 +14,7 @@
 
   type CreditMemberItemProps = {
     member: CreditMember;
-    type: ExtendedMediaType;
+    type?: ExtendedMediaType;
   };
 
   const { member, type }: CreditMemberItemProps = $props();

--- a/projects/client/src/lib/sections/lists/user/FeaturedPeopleList.svelte
+++ b/projects/client/src/lib/sections/lists/user/FeaturedPeopleList.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { DRAWER_VIEW_PARAM } from "$lib/components/drawer/constants/index.ts";
+  import { drawerNavigation } from "$lib/components/drawer/drawerNavigation.ts";
+  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import PersonCard from "$lib/components/people/card/PersonCard.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useQuery } from "$lib/features/query/useQuery.ts";
+  import { listFeaturedPeopleQuery } from "$lib/requests/queries/lists/listFeaturedPeopleQuery.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { map } from "rxjs";
+  import FeaturedPeopleDrawer from "./_internal/FeaturedPeopleDrawer.svelte";
+  import FeaturedPersonItem from "./_internal/FeaturedPersonItem.svelte";
+
+  const { listId }: { listId: number } = $props();
+
+  const query = useQuery(
+    fromRune(() => listId).pipe(map((listId) => listFeaturedPeopleQuery({ listId }))),
+  );
+  const people = $derived($query.data ?? []);
+  const { buildDrawerLink, close } = drawerNavigation<"featured-people">();
+  const drilldown = $derived(buildDrawerLink("featured-people"));
+  const isDrawerOpen = $derived(
+    page.url.searchParams.get(DRAWER_VIEW_PARAM) === "featured-people",
+  );
+</script>
+
+{#if people.length > 0}
+  <div class="trakt-featured-people-list">
+    <SectionList
+      id={{ scope: "featured-people", key: `${listId}` }}
+      title={m.list_title_featured_people()}
+      items={people}
+      drilldown={{
+        ...drilldown,
+        source: { id: "featured-people" },
+        label: m.button_text_view_all(),
+      }}
+      --height-list="var(--height-person-list)"
+    >
+      {#snippet item(person)}
+        <PersonCard>
+          <FeaturedPersonItem {person} />
+        </PersonCard>
+      {/snippet}
+    </SectionList>
+  </div>
+
+  {#if isDrawerOpen}
+    <FeaturedPeopleDrawer {people} onClose={close} />
+  {/if}
+{/if}
+
+<style>
+  .trakt-featured-people-list {
+    padding-block-start: var(--gap-xxl);
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
@@ -4,6 +4,7 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
+  import FeaturedPeopleList from "./FeaturedPeopleList.svelte";
   import SortValue from "./_internal/SortValue.svelte";
   import UserListItem from "./_internal/UserListItem.svelte";
   import type { ListSortProps } from "./models/ListSortProps";
@@ -67,6 +68,8 @@
     />
   {/snippet}
 </DrilledMediaList>
+
+<FeaturedPeopleList listId={list.id} />
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;

--- a/projects/client/src/lib/sections/lists/user/_internal/FeaturedPeopleDrawer.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/FeaturedPeopleDrawer.spec.ts
@@ -1,0 +1,60 @@
+import { PersonFergusonMappedMock } from '$mocks/data/people/mapped/PersonFergusonMappedMock.ts';
+import { mapToPersonSummary } from '$lib/requests/_internal/mapToPersonSummary.ts';
+import { PersonGrantResponseMock } from '$mocks/data/people/response/PersonGrantResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import { http, HttpResponse } from 'msw';
+import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import FeaturedPeopleDrawer from './FeaturedPeopleDrawer.svelte';
+
+beforeAll(() => {
+  Element.prototype.scrollTo = vi.fn();
+});
+
+describe('FeaturedPeopleDrawer', () => {
+  it('should show all featured people, search names, and restore the list', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get(
+        `http://localhost/people/${PersonGrantResponseMock.ids.slug}`,
+        () => HttpResponse.json(PersonGrantResponseMock),
+      ),
+    );
+    renderComponent(FeaturedPeopleDrawer, {
+      props: {
+        people: [
+          PersonFergusonMappedMock,
+          mapToPersonSummary(PersonGrantResponseMock),
+        ],
+        onClose: vi.fn(),
+      },
+    });
+
+    const search = await screen.findByRole('searchbox', {
+      name: 'Search people',
+    });
+    expect(screen.getByText('Featured People')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Rebecca Ferguson/ }))
+      .toBeInTheDocument();
+    expect(screen.getByText('Hugh Grant')).toBeInTheDocument();
+
+    await user.type(search, '  REBECCA  ');
+    await waitFor(() =>
+      expect(screen.queryByText('Hugh Grant')).not.toBeInTheDocument()
+    );
+    expect(screen.getByText('Rebecca Ferguson')).toBeInTheDocument();
+
+    await user.clear(search);
+    await user.type(search, 'no matching person');
+    await waitFor(() =>
+      expect(screen.queryByRole('listitem')).not.toBeInTheDocument()
+    );
+
+    await user.clear(search);
+    await waitFor(() =>
+      expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    );
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/FeaturedPeopleDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/FeaturedPeopleDrawer.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import DrawerSearchInput from "$lib/components/drawer/DrawerSearchInput.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary.ts";
+  import FeaturedPersonItem from "./FeaturedPersonItem.svelte";
+
+  const { people, onClose }: {
+    people: PersonSummary[];
+    onClose: () => void;
+  } = $props();
+
+  let isOpen = $state(false);
+  let searchTerm = $state("");
+  const normalizedSearchTerm = $derived(searchTerm.trim().toLocaleLowerCase());
+  const visiblePeople = $derived(
+    people.filter(({ name }) => name.toLocaleLowerCase().includes(normalizedSearchTerm)),
+  );
+</script>
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.list_title_featured_people()}
+  size="large"
+  headerVariant="overlay"
+>
+  {#if isOpen}
+    <div class="trakt-featured-people-drawer">
+      <DrawerSearchInput
+        bind:value={searchTerm}
+        label={m.input_label_search_credit_members()}
+        placeholder={m.input_placeholder_search_credit_members()}
+      />
+      {#if visiblePeople.length > 0}
+        <div class="people-list" role="list">
+          {#each visiblePeople as person (person.key)}
+            <FeaturedPersonItem {person} variant="summary" />
+          {/each}
+        </div>
+      {:else}
+        <p class="secondary">{m.list_placeholder_no_filter_results()}</p>
+      {/if}
+    </div>
+  {/if}
+</Drawer>
+
+<style>
+  .trakt-featured-people-drawer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+
+    .people-list {
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-s);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/user/_internal/FeaturedPersonItem.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/FeaturedPersonItem.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import CardCover from "$lib/components/card/CardCover.svelte";
+  import CardFooter from "$lib/components/card/CardFooter.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useQuery } from "$lib/features/query/useQuery.ts";
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary.ts";
+  import { peopleSummaryQuery } from "$lib/requests/queries/people/peopleSummaryQuery.ts";
+  import CreditMemberItem from "$lib/sections/lists/components/CreditMemberItem.svelte";
+  import { whenInViewport } from "$lib/utils/actions/whenInViewport.ts";
+  import { toTranslatedPosition } from "$lib/utils/formatting/string/toTranslatedPosition";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { map } from "rxjs";
+
+  const { person, variant = "card" }: {
+    person: PersonSummary;
+    variant?: "card" | "summary";
+  } = $props();
+
+  let isVisible = $state(false);
+  const query = useQuery(
+    fromRune(() => ({ slug: person.slug, isVisible })).pipe(
+      map(({ slug, isVisible }) => ({
+        ...peopleSummaryQuery({ slug }),
+        enabled: isVisible,
+      })),
+    ),
+  );
+  const profile = $derived($query.data ?? person);
+  const description = $derived(
+    profile.knownFor ? toTranslatedPosition(profile.knownFor) : "",
+  );
+</script>
+
+<div
+  class="trakt-featured-person-item"
+  use:whenInViewport={() => (isVisible = true)}
+>
+  {#if variant === "summary"}
+    <CreditMemberItem
+      member={{
+        key: person.slug,
+        name: person.name,
+        headshot: profile.headshot,
+        description,
+      }}
+    />
+  {:else}
+    <Link focusable={false} href={UrlBuilder.people(person.slug)}>
+      <CardCover
+        title={person.name}
+        src={profile.headshot.url.thumb}
+        alt={m.image_alt_person_headshot({ person: person.name })}
+      />
+    </Link>
+    <CardFooter>
+      <p class="trakt-card-title ellipsis" title={person.name}>{person.name}</p>
+      {#if description}
+        <p class="trakt-card-subtitle ellipsis" title={description}>{description}</p>
+      {/if}
+    </CardFooter>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary

Adds Featured People below the items on personal and official lists, following the cast row on media detail pages. This draft is for validating whether the feature feels useful and whether its placement, cards, and drilldown feel right.

Built on https://github.com/trakt/trakt-workers/pull/1525.

## Changes

- Treat featured people as bonus content with a generous gap after the list.
- Reuse portrait people cards and the cast row's drilldown behavior, with a searchable drawer containing all featured people.
- Preserve the API's ranking and hide the section when no featured people are available.
- Load cached person summaries as entries become visible to fill in portraits and the known-for department.

## Why this must remain a draft

The current `GET /lists/{id}?extended=featured` response contains only names and IDs for each featured person. The UI therefore makes an additional list-summary request, then a person-summary request for each visible person. Viewport gating limits the initial burst, but does not eliminate the extra requests or the delay before portraits appear.

Before this is ready to merge:

- [ ] Return compact person records with headshot URLs and relevant roles directly from the featured-people request, so the row and drawer do not need per-person summary requests. Prefer roles relevant to this list over a person's general known-for department; full biographies and credits are unnecessary.
- [ ] Consider a dedicated `GET /lists/{id}/people` endpoint for this computed collection, with independent caching and invalidation, instead of attaching it to the list summary.
- [ ] Consider exposing the appearance counts already used by the backend to rank people.
- [ ] Adapt the client to the agreed API contract and remove the temporary per-person hydration.
- [ ] Validate desktop/mobile placement, card presentation, and the view-all/search interaction; check request volume and portrait loading with the improved API.

Please keep this PR in draft while we validate the experience and resolve the API/performance work above.

## Validation

- Targeted query, list-summary, featured-people drawer, and existing cast-drawer tests: passed (8 tests).
- Svelte/TypeScript check: passed with 0 errors and 0 warnings (Node with an 8 GB heap; the initial Deno run exceeded its default heap limit).
- ESLint and formatting checks on changed code: passed; staged diff whitespace check passed.
- Live public API inspection confirmed that featured entries contain names and IDs only.
- Desktop/mobile visual verification remains pending: the local preview hit an app-wide Svelte hydration error before the list rendered. No screenshots are attached.
- Full coverage, production build, and E2E checks were not run locally. The repository's main CI and preview pipeline skips draft PRs.

## Pull Request Checklist

Before you dim the lights and raise the curtain on your cinematic masterpiece,
make sure your pull request has passed these critical checks:

- [ ] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [ ] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [ ] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action?
- [ ] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [ ] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [ ] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [ ] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [ ] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?
