### PR TITLE
refactor(query): delegate mutations to TanStack query-core

### DIFF
--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -306,8 +306,10 @@ export function useUser() {
   context or shared section
 - Hooks that fire user tracking mutations (history, watchlist, ratings,
   favorites) route writes through `executeOrEnqueue` and overlay reads with
-  `findPendingOverride` so actions work offline - see "Pattern 5" in
+  `findPendingOverride` so actions work offline - see "Pattern 6" in
   `requests.md`
+- Every other write hook uses `defineMutation` + `useMutation` for its pending
+  state and invalidation - see "Pattern 5" in `requests.md`
 
 ### Hooks that drive `useQuery` take `Observable<T>`, never a bare value
 

--- a/.agents/rules/requests.md
+++ b/.agents/rules/requests.md
@@ -217,7 +217,69 @@ validate with Zod if response body matters.
 
 ---
 
-## Pattern 5 - Offline-Aware Tracking Mutation
+## Pattern 5 - Mutation Hook (`defineMutation` + `useMutation`)
+
+Hooks never hand-roll a pending flag or call `invalidate` after a write. Wrap
+the `*Request` function with `defineMutation` and drive it with `useMutation`:
+query-core owns the pending state, the error state and the invalidation.
+
+```ts
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
+
+export function useLikeList(list: MediaListSummary) {
+  const like = useMutation(defineMutation({
+    key: 'list:like',
+    request: likeListRequest,
+    invalidations: [InvalidateAction.List.Like],
+  }));
+
+  const likeList = async () => {
+    track({ action: 'like' });
+    await like.mutate({ listId: list.id });
+  };
+
+  return { likeList, isUpdating: like.isPending };
+}
+```
+
+`useMutation` returns:
+
+| Field       | Shape                                     |
+| ----------- | ----------------------------------------- |
+| `mutate`    | `(variables) => Promise<TData>`           |
+| `isPending` | `Observable<boolean>`                     |
+| `result`    | `Observable<MutationObserverResult<...>>` |
+| `reset`     | `() => void`                              |
+
+### Key rules
+
+- `key` is a stable `{domain}:{action}` string (`'list:like'`).
+- `request` is the existing `*Request` function - do not create a `*Mutation.ts`
+  file for it. Variables are the request params.
+- `invalidations` replaces every `await invalidate(...)` in the hook. They run
+  in the shared `MutationCache` (`createMutationCache.ts`), and query-core
+  awaits them before the mutation settles, so `isPending` still covers the
+  invalidation window.
+- `mutate` rejects when the request throws - callers keep whatever error
+  handling they had around `await someRequest(...)`.
+- Expose the pending state under whatever name the components already use
+  (`isUpdating`, `isSaving`); combine several with
+  `combineLatest([a.isPending, b.isPending])`.
+- Never pass per-call callbacks to `mutate`: query-core only runs those while
+  the observer has listeners. Side effects go in `invalidations`, in the
+  mutation options, or in the caller after `await`.
+- The mutation cache is shared with the test bed (`TestProvider.svelte`), so a
+  hook spec exercises the real invalidation path. Assert invalidations with
+  `captureInvalidations` from `$test/beds/query/` - module mocks do not reach
+  modules loaded through the Svelte provider tree.
+- `useInvalidator` survives only for invalidations that are not tied to one
+  request, such as the auth teardown in `useAuth`. A write hook should not
+  import it.
+
+---
+
+## Pattern 6 - Offline-Aware Tracking Mutation
 
 User tracking mutations (history, watchlist, ratings, favorites) must survive a
 dead connection: they queue in IndexedDB and replay when connectivity returns.
@@ -402,5 +464,7 @@ Before submitting a new query or request, verify:
 - [ ] `invalidations` lists relevant `InvalidateAction.*` tokens
 - [ ] Mapper is pure function - no side effects
 - [ ] `ttl` is appropriate for data's freshness requirements
-- [ ] Tracking mutation: hook routes through `executeOrEnqueue` (Pattern 5),
+- [ ] Write hook: `defineMutation` + `useMutation` (Pattern 5), no hand-rolled
+      pending flag and no `await invalidate(...)`
+- [ ] Tracking mutation: hook routes through `executeOrEnqueue` (Pattern 6),
       read store overlays the pending queue via `findPendingOverride`

--- a/.agents/rules/requests.md
+++ b/.agents/rules/requests.md
@@ -287,20 +287,33 @@ The infrastructure lives in `lib/features/offline/`.
 
 **Hooks never call these request functions directly.** They go through
 `executeOrEnqueue`, which runs the request when online and queues it (deduped by
-media key set, latest intent wins) on network failure:
+media key set, latest intent wins) on network failure. It is the mutation's
+`request` (Pattern 5), and `whenExecuted` keeps the invalidation off the queued
+path - a queued action carries its own tokens and invalidates when it replays:
 
 ```ts
 import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { whenExecuted } from '$lib/features/offline/whenExecuted.ts';
 
-await executeOrEnqueue({
-  endpoint: 'watchlist:add',
-  keys: media.map((item) => toMediaKey(type, item.id)),
-  body,
-  invalidations: [InvalidateAction.Watchlisted(type)],
-});
-await invalidate(InvalidateAction.Watchlisted(type));
+const invalidations = [InvalidateAction.Watchlisted(type)];
+
+const addition = useMutation(defineMutation({
+  key: 'watchlist:add',
+  request: () =>
+    executeOrEnqueue({
+      endpoint: 'watchlist:add',
+      keys: media.map((item) => toMediaKey(type, item.id)),
+      body,
+      invalidations,
+    }),
+  invalidations: whenExecuted(invalidations),
+}));
 ```
+
+State the hook reads before the write - an orphaned rating, a history snapshot
+an undo needs - belongs inside `request` and comes back as the mutation data, so
+`isPending` covers the read too.
 
 The matching read store overlays the pending queue so the UI reflects the action
 while offline (see `useIsWatched` / `useIsWatchlisted`):
@@ -318,8 +331,9 @@ if (pending) return isAddEndpoint(pending.endpoint);
 2. Map its body type in `offline/models/OfflineActionBody.ts`.
 3. Register the executor in `offline/_internal/executeOfflineAction.ts`
    (endpoint -> existing `*Request` function).
-4. Route the hook's write through `executeOrEnqueue` with `toMediaKey` keys and
-   the same `InvalidateAction` tokens the hook already fires.
+4. Route the hook's write through `executeOrEnqueue` inside a `defineMutation`
+   `request`, with `toMediaKey` keys and the same `InvalidateAction` tokens on
+   both the action and `whenExecuted`.
 5. Overlay the read store with `findPendingOverride` + `isAddEndpoint`.
 6. If replaying the action can duplicate server-side effects (like extra history
    plays), extend the reconcile step

--- a/.agents/rules/utils.md
+++ b/.agents/rules/utils.md
@@ -179,6 +179,7 @@ invariants only.
 | `resolve(stream, timeout)` | Await first defined value from RxJS `Observable`                                 |
 | `fromRune(accessor)`       | Bridge a Svelte 5 rune-driven accessor into an `Observable<T>` via `$effect.pre` |
 | `multicast(graceMs?)`      | `share + ReplaySubject(1) + timer` operator for multi-subscriber Observables     |
+| `anyTrue(sources)`         | `true` while any boolean Observable is `true` (combined pending / loading flags) |
 
 ---
 

--- a/projects/client/src/lib/features/notes/_internal/useDeleteNote.ts
+++ b/projects/client/src/lib/features/notes/_internal/useDeleteNote.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { NoteType } from '$lib/requests/models/NoteType.ts';
 import { deleteNoteRequest } from '$lib/requests/queries/users/deleteNoteRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 type DeleteNoteProps = {
   id: number;
@@ -17,22 +17,25 @@ type DeleteNoteProps = {
 };
 
 export function useDeleteNote() {
-  const isDeleting = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.DeleteNote);
 
+  const deletion = useMutation(defineMutation({
+    key: 'note:delete',
+    request: ({ id, type }: DeleteNoteProps) =>
+      deleteNoteRequest({ id, body: { type } }),
+    invalidations: (
+      { variables },
+    ) => [InvalidateAction.Note.Delete(variables.media.type)],
+  }));
+
   const deleteNote = async ({ id, media, type }: DeleteNoteProps) => {
-    isDeleting.next(true);
-
     track({ type });
-    await deleteNoteRequest({ id, body: { type } });
-    await invalidate(InvalidateAction.Note.Delete(media.type));
 
-    isDeleting.next(false);
+    await deletion.mutate({ id, media, type });
   };
 
   return {
     deleteNote,
-    isDeleting: isDeleting.asObservable(),
+    isDeleting: deletion.isPending,
   };
 }

--- a/projects/client/src/lib/features/notes/_internal/useEditNote.ts
+++ b/projects/client/src/lib/features/notes/_internal/useEditNote.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { NoteType } from '$lib/requests/models/NoteType.ts';
 import { editNoteRequest } from '$lib/requests/queries/users/editNoteRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 type EditNoteProps = {
   id: number;
@@ -18,33 +18,30 @@ type EditNoteProps = {
 };
 
 export function useEditNote() {
-  const isEditing = new BehaviorSubject(false);
-
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.EditNote);
 
-  const editNote = async ({ id, notes, media, type }: EditNoteProps) => {
-    isEditing.next(true);
+  const edit = useMutation(defineMutation({
+    key: 'note:edit',
+    request: ({ id, notes, type }: EditNoteProps) =>
+      editNoteRequest({ id, body: { type, notes } }),
+    invalidations: (
+      { variables },
+    ) => [InvalidateAction.Note.Edit(variables.media.type)],
+  }));
 
+  const editNote = async ({ id, notes, media, type }: EditNoteProps) => {
     const trimmed = notes.trim();
     if (!trimmed) {
-      isEditing.next(false);
       return;
     }
 
     track({ type });
-    const result = await editNoteRequest({
-      id,
-      body: { type, notes: trimmed },
-    });
-    await invalidate(InvalidateAction.Note.Edit(media.type));
 
-    isEditing.next(false);
-    return result;
+    return await edit.mutate({ id, notes: trimmed, media, type });
   };
 
   return {
     editNote,
-    isEditing: isEditing.asObservable(),
+    isEditing: edit.isPending,
   };
 }

--- a/projects/client/src/lib/features/notes/_internal/usePostNote.ts
+++ b/projects/client/src/lib/features/notes/_internal/usePostNote.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { NoteType } from '$lib/requests/models/NoteType.ts';
 import { postNoteRequest } from '$lib/requests/queries/users/postNoteRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 type PostNoteProps = {
   media: {
@@ -17,35 +17,29 @@ type PostNoteProps = {
 };
 
 export function usePostNote() {
-  const isPosting = new BehaviorSubject(false);
-
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.AddNote);
 
-  const postNote = async (props: PostNoteProps) => {
-    isPosting.next(true);
+  const post = useMutation(defineMutation({
+    key: 'note:post',
+    request: (body: PostNoteProps) => postNoteRequest({ body }),
+    invalidations: (
+      { variables },
+    ) => [InvalidateAction.Note.Add(variables.media.type)],
+  }));
 
+  const postNote = async (props: PostNoteProps) => {
     const notes = props.notes.trim();
     if (!notes) {
-      isPosting.next(false);
       return;
     }
 
-    const payload = {
-      ...props,
-      notes,
-    };
-
     track({ type: props.type });
-    const result = await postNoteRequest({ body: payload });
-    await invalidate(InvalidateAction.Note.Add(props.media.type));
 
-    isPosting.next(false);
-    return result;
+    return await post.mutate({ ...props, notes });
   };
 
   return {
     postNote,
-    isPosting: isPosting.asObservable(),
+    isPosting: post.isPending,
   };
 }

--- a/projects/client/src/lib/features/offline/_internal/onlineStatusStore.spec.ts
+++ b/projects/client/src/lib/features/offline/_internal/onlineStatusStore.spec.ts
@@ -1,0 +1,30 @@
+import { onlineManager } from '@tanstack/query-core';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { onlineStatusStore } from './onlineStatusStore.ts';
+
+describe('store: onlineStatusStore', () => {
+  afterEach(() => {
+    onlineManager.setOnline(true);
+  });
+
+  it('should report the current online state on subscribe', async () => {
+    onlineManager.setOnline(false);
+
+    expect(onlineStatusStore.isOnline()).toBe(false);
+    expect(await firstValueFrom(onlineStatusStore.isOnline$)).toBe(false);
+  });
+
+  it('should emit when connectivity comes back', () => {
+    onlineManager.setOnline(false);
+
+    const states: boolean[] = [];
+    const subscription = onlineStatusStore.isOnline$
+      .subscribe((isOnline) => states.push(isOnline));
+
+    onlineManager.setOnline(true);
+    subscription.unsubscribe();
+
+    expect(states).to.deep.equal([false, true]);
+  });
+});

--- a/projects/client/src/lib/features/offline/_internal/onlineStatusStore.ts
+++ b/projects/client/src/lib/features/offline/_internal/onlineStatusStore.ts
@@ -1,19 +1,16 @@
-import { browser } from '$app/environment';
-import { BehaviorSubject, type Observable } from 'rxjs';
+import { onlineManager } from '@tanstack/query-core';
+import { Observable, type Observer } from 'rxjs';
 
-const isOnlineSubject = new BehaviorSubject<boolean>(
-  browser ? navigator.onLine : true,
-);
+const isOnline$ = new Observable<boolean>((subscriber: Observer<boolean>) => {
+  subscriber.next(onlineManager.isOnline());
 
-if (browser) {
-  globalThis.addEventListener('online', () => isOnlineSubject.next(true));
-  globalThis.addEventListener('offline', () => isOnlineSubject.next(false));
-}
+  return onlineManager.subscribe((isOnline) => subscriber.next(isOnline));
+});
 
 export const onlineStatusStore: {
   isOnline$: Observable<boolean>;
   isOnline: () => boolean;
 } = {
-  isOnline$: isOnlineSubject.asObservable(),
-  isOnline: () => isOnlineSubject.getValue(),
+  isOnline$,
+  isOnline: () => onlineManager.isOnline(),
 };

--- a/projects/client/src/lib/features/offline/executeOrEnqueue.ts
+++ b/projects/client/src/lib/features/offline/executeOrEnqueue.ts
@@ -7,6 +7,8 @@ import type { OfflineAction } from './models/OfflineAction.ts';
 import type { OfflineActionBody } from './models/OfflineActionBody.ts';
 import type { OfflineActionEndpoint } from './models/OfflineActionEndpoint.ts';
 
+export type ExecuteOrEnqueueOutcome = 'executed' | 'queued';
+
 type ExecuteOrEnqueueParams<TEndpoint extends OfflineActionEndpoint> = {
   endpoint: TEndpoint;
   keys: string[];
@@ -22,7 +24,7 @@ export async function executeOrEnqueue<
   TEndpoint extends OfflineActionEndpoint,
 >(
   { endpoint, keys, body, invalidations }: ExecuteOrEnqueueParams<TEndpoint>,
-): Promise<'executed' | 'queued'> {
+): Promise<ExecuteOrEnqueueOutcome> {
   const action: OfflineAction = {
     id: crypto.randomUUID(),
     endpoint,

--- a/projects/client/src/lib/features/offline/whenExecuted.ts
+++ b/projects/client/src/lib/features/offline/whenExecuted.ts
@@ -1,0 +1,12 @@
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+import type { ExecuteOrEnqueueOutcome } from './executeOrEnqueue.ts';
+
+/**
+ * Invalidations for a write that may have been queued instead of sent. A
+ * queued action carries its own tokens and invalidates when it replays.
+ */
+export function whenExecuted(actions: InvalidateActionOptions[]) {
+  return (
+    { data }: { data: ExecuteOrEnqueueOutcome },
+  ): InvalidateActionOptions[] => data === 'executed' ? actions : [];
+}

--- a/projects/client/src/lib/features/query/QueryClientProvider.svelte
+++ b/projects/client/src/lib/features/query/QueryClientProvider.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
   import { iffy } from "$lib/utils/function/iffy";
   import type { QueryClient } from "@tanstack/query-core";
+  import { onMount } from "svelte";
   import { setQueryClient } from "./_internal/queryClientContext";
 
   const { children, client }: ChildrenProps & { client: QueryClient } =
     $props();
 
   setQueryClient(iffy(() => client));
+
+  // `mount` is what subscribes the client to the focus and online managers.
+  // Without it `refetchOnWindowFocus` never fires and paused mutations never
+  // resume - query-core leaves that wiring to the framework adapter.
+  onMount(() => {
+    client.mount();
+
+    return () => client.unmount();
+  });
 </script>
 
 {@render children()}

--- a/projects/client/src/lib/features/query/_internal/mutationBridge.spec.ts
+++ b/projects/client/src/lib/features/query/_internal/mutationBridge.spec.ts
@@ -1,0 +1,126 @@
+import type { CreateMutationOptions } from '$lib/features/query/types.ts';
+import { MutationCache, QueryClient } from '@tanstack/query-core';
+import type { Subscription } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mutationBridge } from './mutationBridge.ts';
+
+type Variables = { value: string };
+
+function buildOptions(
+  mutationFn: (variables: Variables) => Promise<string>,
+): CreateMutationOptions<string, Error, Variables> {
+  return { mutationKey: ['mutationBridge'], mutationFn };
+}
+
+describe('mutationBridge', () => {
+  const teardown: Array<() => void> = [];
+
+  afterEach(() => {
+    teardown.splice(0).forEach((fn) => fn());
+  });
+
+  function createClient(mutationCache?: MutationCache) {
+    const client = new QueryClient({ mutationCache });
+    teardown.push(() => client.clear());
+    return client;
+  }
+
+  function collect<T>(
+    subscription: (push: (value: T) => void) => Subscription,
+  ) {
+    const values: Array<T> = [];
+    const sub = subscription((value) => values.push(value));
+    teardown.push(() => sub.unsubscribe());
+    return values;
+  }
+
+  it('should emit the idle result synchronously, then pending and success', async () => {
+    const bridge = mutationBridge(
+      buildOptions(({ value }) => Promise.resolve(value)),
+      createClient(),
+    );
+
+    const statuses = collect<string>((push) =>
+      bridge.result$.subscribe(({ status }) => push(status))
+    );
+
+    expect(statuses).to.deep.equal(['idle']);
+
+    await bridge.mutate({ value: 'done' });
+
+    await vi.waitFor(() => expect(statuses.at(-1)).to.equal('success'));
+    expect(statuses).to.deep.equal(['idle', 'pending', 'success']);
+  });
+
+  it('should run the mutation and its cache callbacks without any subscriber', async () => {
+    const onSuccess = vi.fn();
+    const client = createClient(new MutationCache({ onSuccess }));
+
+    const bridge = mutationBridge(
+      buildOptions(({ value }) => Promise.resolve(value)),
+      client,
+    );
+
+    await expect(bridge.mutate({ value: 'done' })).resolves.to.equal('done');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject the caller when the mutation fails', async () => {
+    const bridge = mutationBridge(
+      buildOptions(() => Promise.reject(new Error('nope'))),
+      createClient(),
+    );
+
+    const statuses = collect<string>((push) =>
+      bridge.result$.subscribe(({ status }) => push(status))
+    );
+
+    await expect(bridge.mutate({ value: 'boom' })).rejects.toThrow('nope');
+    expect(statuses.at(-1)).to.equal('error');
+  });
+
+  it('should keep the result pending until cache invalidation settles', async () => {
+    let releaseInvalidation = () => {};
+    const invalidation = new Promise<void>((resolve) => {
+      releaseInvalidation = resolve;
+    });
+
+    const client = createClient(
+      new MutationCache({ onSuccess: () => invalidation }),
+    );
+
+    const bridge = mutationBridge(
+      buildOptions(({ value }) => Promise.resolve(value)),
+      client,
+    );
+
+    const pending = collect<boolean>((push) =>
+      bridge.result$.subscribe(({ isPending }) => push(isPending))
+    );
+
+    const mutated = bridge.mutate({ value: 'done' });
+
+    await vi.waitFor(() => expect(pending.at(-1)).to.equal(true));
+
+    releaseInvalidation();
+    await mutated;
+
+    await vi.waitFor(() => expect(pending.at(-1)).to.equal(false));
+  });
+
+  it('should stop emitting to a subscriber that unsubscribed', async () => {
+    const bridge = mutationBridge(
+      buildOptions(({ value }) => Promise.resolve(value)),
+      createClient(),
+    );
+
+    const statuses: Array<string> = [];
+    bridge.result$
+      .subscribe(({ status }) => statuses.push(status))
+      .unsubscribe();
+
+    await bridge.mutate({ value: 'done' });
+
+    expect(statuses).to.deep.equal(['idle']);
+  });
+});

--- a/projects/client/src/lib/features/query/_internal/mutationBridge.ts
+++ b/projects/client/src/lib/features/query/_internal/mutationBridge.ts
@@ -1,0 +1,44 @@
+import type { CreateMutationOptions } from '$lib/features/query/types.ts';
+import {
+  MutationObserver,
+  type MutationObserverResult,
+  type QueryClient,
+} from '@tanstack/query-core';
+import { Observable } from 'rxjs';
+import { untrack } from 'svelte';
+
+// query-core only runs `mutate`'s per-call callbacks while the observer has
+// listeners, so the bridge drops that argument: side effects belong on the
+// observer options or the MutationCache.
+export type MutationBridge<TData, TError extends Error, TVariables> = {
+  mutate: (variables: TVariables) => Promise<TData>;
+  reset: () => void;
+  result$: Observable<MutationObserverResult<TData, TError, TVariables>>;
+};
+
+export function mutationBridge<TData, TError extends Error, TVariables>(
+  options: CreateMutationOptions<TData, TError, TVariables>,
+  client: QueryClient,
+): MutationBridge<TData, TError, TVariables> {
+  const observer = new MutationObserver<TData, TError, TVariables>(
+    client,
+    options,
+  );
+
+  const result$ = new Observable<
+    MutationObserverResult<TData, TError, TVariables>
+  >((subscriber) => {
+    const emit = (result: MutationObserverResult<TData, TError, TVariables>) =>
+      untrack(() => subscriber.next(result));
+
+    emit(observer.getCurrentResult());
+
+    return observer.subscribe(emit);
+  });
+
+  return {
+    mutate: observer.mutate,
+    reset: observer.reset,
+    result$,
+  };
+}

--- a/projects/client/src/lib/features/query/createMutationCache.ts
+++ b/projects/client/src/lib/features/query/createMutationCache.ts
@@ -1,0 +1,12 @@
+import { invalidateActions } from '$lib/features/query/invalidateActions.ts';
+import { MutationCache } from '@tanstack/query-core';
+
+export function createMutationCache(): MutationCache {
+  return new MutationCache({
+    onSuccess: (_data, _variables, _onMutateResult, mutation, context) =>
+      invalidateActions({
+        client: context.client,
+        actions: mutation.options.meta?.invalidations ?? [],
+      }),
+  });
+}

--- a/projects/client/src/lib/features/query/createMutationCache.ts
+++ b/projects/client/src/lib/features/query/createMutationCache.ts
@@ -3,10 +3,13 @@ import { MutationCache } from '@tanstack/query-core';
 
 export function createMutationCache(): MutationCache {
   return new MutationCache({
-    onSuccess: (_data, _variables, _onMutateResult, mutation, context) =>
+    onSuccess: (data, variables, _onMutateResult, mutation, context) =>
       invalidateActions({
         client: context.client,
-        actions: mutation.options.meta?.invalidations ?? [],
+        actions: mutation.options.meta?.resolveInvalidations?.({
+          data,
+          variables,
+        }) ?? [],
       }),
   });
 }

--- a/projects/client/src/lib/features/query/defineMutation.ts
+++ b/projects/client/src/lib/features/query/defineMutation.ts
@@ -1,0 +1,15 @@
+import type { CreateMutationOptions } from '$lib/features/query/types.ts';
+import type { DefineMutationProps } from './models/DefineMutationProps.ts';
+import type { MutationMeta } from './models/MutationMeta.ts';
+
+export function defineMutation<TData, TVariables = void>(
+  { key, request, invalidations }: DefineMutationProps<TData, TVariables>,
+): CreateMutationOptions<TData, Error, TVariables> {
+  const meta: MutationMeta = { invalidations };
+
+  return {
+    mutationKey: [key],
+    mutationFn: (variables: TVariables) => request(variables),
+    meta,
+  };
+}

--- a/projects/client/src/lib/features/query/defineMutation.ts
+++ b/projects/client/src/lib/features/query/defineMutation.ts
@@ -5,7 +5,15 @@ import type { MutationMeta } from './models/MutationMeta.ts';
 export function defineMutation<TData, TVariables = void>(
   { key, request, invalidations }: DefineMutationProps<TData, TVariables>,
 ): CreateMutationOptions<TData, Error, TVariables> {
-  const meta: MutationMeta = { invalidations };
+  const meta: MutationMeta = {
+    resolveInvalidations: ({ data, variables }) =>
+      typeof invalidations === 'function'
+        ? invalidations({
+          data: data as TData,
+          variables: variables as TVariables,
+        })
+        : invalidations,
+  };
 
   return {
     mutationKey: [key],

--- a/projects/client/src/lib/features/query/invalidateActions.ts
+++ b/projects/client/src/lib/features/query/invalidateActions.ts
@@ -1,0 +1,32 @@
+import {
+  InvalidateAction,
+  type InvalidateActionOptions,
+} from '$lib/requests/models/InvalidateAction.ts';
+import { setMarker } from '$lib/utils/date/Marker.ts';
+import type { QueryClient } from '@tanstack/query-core';
+
+type InvalidateActionsParams = {
+  client: QueryClient | Nil;
+  actions: InvalidateActionOptions[];
+};
+
+export async function invalidateActions(
+  { client, actions }: InvalidateActionsParams,
+): Promise<void> {
+  if (actions.length === 0) {
+    return;
+  }
+
+  actions.forEach(setMarker);
+
+  const hasAuth = actions.includes(InvalidateAction.Auth);
+
+  if (hasAuth) {
+    await client?.removeQueries();
+  }
+
+  await client?.invalidateQueries({
+    predicate: (query) =>
+      hasAuth || actions.some((action) => query.queryKey.includes(action)),
+  });
+}

--- a/projects/client/src/lib/features/query/models/DefineMutationProps.ts
+++ b/projects/client/src/lib/features/query/models/DefineMutationProps.ts
@@ -1,7 +1,16 @@
 import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
 
+type InvalidationProps<TData, TVariables> = {
+  data: TData;
+  variables: TVariables;
+};
+
 export type DefineMutationProps<TData, TVariables = void> = {
   key: string;
   request: (variables: TVariables) => Promise<TData>;
-  invalidations: InvalidateActionOptions[];
+  invalidations:
+    | InvalidateActionOptions[]
+    | ((
+      props: InvalidationProps<TData, TVariables>,
+    ) => InvalidateActionOptions[]);
 };

--- a/projects/client/src/lib/features/query/models/DefineMutationProps.ts
+++ b/projects/client/src/lib/features/query/models/DefineMutationProps.ts
@@ -1,0 +1,7 @@
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+
+export type DefineMutationProps<TData, TVariables = void> = {
+  key: string;
+  request: (variables: TVariables) => Promise<TData>;
+  invalidations: InvalidateActionOptions[];
+};

--- a/projects/client/src/lib/features/query/models/MutationMeta.ts
+++ b/projects/client/src/lib/features/query/models/MutationMeta.ts
@@ -1,7 +1,14 @@
 import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
 
+type ResolveInvalidationsProps = {
+  data: unknown;
+  variables: unknown;
+};
+
 export type MutationMeta = {
-  invalidations?: InvalidateActionOptions[];
+  resolveInvalidations?: (
+    props: ResolveInvalidationsProps,
+  ) => InvalidateActionOptions[];
 };
 
 declare module '@tanstack/query-core' {

--- a/projects/client/src/lib/features/query/models/MutationMeta.ts
+++ b/projects/client/src/lib/features/query/models/MutationMeta.ts
@@ -1,0 +1,11 @@
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+
+export type MutationMeta = {
+  invalidations?: InvalidateActionOptions[];
+};
+
+declare module '@tanstack/query-core' {
+  interface Register {
+    mutationMeta: MutationMeta;
+  }
+}

--- a/projects/client/src/lib/features/query/types.ts
+++ b/projects/client/src/lib/features/query/types.ts
@@ -1,12 +1,13 @@
 import type {
   DefaultError,
   InfiniteQueryObserverOptions,
+  MutationObserverOptions,
   QueryKey,
   QueryObserverOptions,
 } from '@tanstack/query-core';
 
 /**
- * Local aliases for the QueryObserver option shapes. Plain re-exports of the
+ * Local aliases for the observer option shapes. Plain re-exports of the
  * query-core option types, kept here so call sites stay agnostic of the
  * underlying TanStack package.
  */
@@ -35,4 +36,15 @@ export type CreateInfiniteQueryOptions<
   TData,
   TQueryKey,
   TPageParam
+>;
+
+export type CreateMutationOptions<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+> = MutationObserverOptions<
+  TData,
+  TError,
+  TVariables,
+  unknown
 >;

--- a/projects/client/src/lib/features/query/useMutation.ts
+++ b/projects/client/src/lib/features/query/useMutation.ts
@@ -1,0 +1,35 @@
+import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
+import type { CreateMutationOptions } from '$lib/features/query/types.ts';
+import { multicast } from '$lib/utils/store/multicast.ts';
+import type { MutationObserverResult } from '@tanstack/query-core';
+import { distinctUntilChanged, map, type Observable } from 'rxjs';
+import { mutationBridge } from './_internal/mutationBridge.ts';
+
+type Mutation<TData, TError extends Error, TVariables> = {
+  mutate: (variables: TVariables) => Promise<TData>;
+  reset: () => void;
+  result: Observable<MutationObserverResult<TData, TError, TVariables>>;
+  isPending: Observable<boolean>;
+};
+
+export function useMutation<
+  TData,
+  TVariables = void,
+  TError extends Error = Error,
+>(
+  options: CreateMutationOptions<TData, TError, TVariables>,
+): Mutation<TData, TError, TVariables> {
+  const { mutate, reset, result$ } = mutationBridge(options, useQueryClient());
+
+  const result = result$.pipe(multicast());
+
+  return {
+    mutate,
+    reset,
+    result,
+    isPending: result.pipe(
+      map(({ isPending }) => isPending),
+      distinctUntilChanged(),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/components/lists-drawer/useList.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/useList.ts
@@ -1,44 +1,55 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { addToListRequest } from '$lib/requests/queries/users/addToListRequest.ts';
 import { removeFromListRequest } from '$lib/requests/queries/users/removeFromListRequest.ts';
 import type { UserList } from '$lib/requests/queries/users/userListsQuery.ts';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 import {
   toBulkPayload,
 } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
-
 type UseListProps = { list: UserList } & MediaStoreProps;
 
 export function useList(props: UseListProps) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
-  const isListUpdating = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
 
   const { track } = useTrack(AnalyticsEvent.List);
   const ids = media.map(({ id }) => id);
   const body = toBulkPayload(type, ids);
+
+  const target = {
+    listId: props.list.id,
+    userId: props.list.ownerId,
+    body,
+  };
+  const invalidations = type === 'episode'
+    ? []
+    : [InvalidateAction.Listed(type)];
+
+  const addition = useMutation(defineMutation({
+    key: 'list:add',
+    request: () => addToListRequest(target),
+    invalidations,
+  }));
+
+  const removal = useMutation(defineMutation({
+    key: 'list:remove',
+    request: () => removeFromListRequest(target),
+    invalidations,
+  }));
 
   const addToList = async () => {
     if (type === 'episode') {
       return;
     }
 
-    isListUpdating.next(true);
     track({ action: 'add' });
 
-    await addToListRequest({
-      listId: props.list.id,
-      userId: props.list.ownerId,
-      body,
-    });
-    await invalidate(InvalidateAction.Listed(type));
-
-    isListUpdating.next(false);
+    await addition.mutate();
   };
 
   const removeFromList = async () => {
@@ -46,18 +57,12 @@ export function useList(props: UseListProps) {
       return;
     }
 
-    isListUpdating.next(true);
     track({ action: 'remove' });
 
-    await removeFromListRequest({
-      listId: props.list.id,
-      userId: props.list.ownerId,
-      body,
-    });
-    await invalidate(InvalidateAction.Listed(type));
-
-    isListUpdating.next(false);
+    await removal.mutate();
   };
+
+  const isListUpdating = anyTrue([addition.isPending, removal.isPending]);
 
   return {
     addToList,

--- a/projects/client/src/lib/sections/lists/smart/_internal/useDeleteSmartList.ts
+++ b/projects/client/src/lib/sections/lists/smart/_internal/useDeleteSmartList.ts
@@ -1,7 +1,7 @@
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { deleteSmartListRequest } from '$lib/requests/queries/users/deleteSmartListRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 import { AnalyticsEvent } from '../../../../features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '../../../../features/analytics/useTrack.ts';
 
@@ -10,28 +10,22 @@ type DeleteListProps = {
 };
 
 export function useDeleteSmartList() {
-  const isDeleting = new BehaviorSubject(false);
-
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.SmartListDelete);
 
-  const deleteList = async (
-    { slug }: DeleteListProps,
-  ) => {
-    isDeleting.next(true);
+  const deletion = useMutation(defineMutation({
+    key: 'smart-list:delete',
+    request: ({ slug }: DeleteListProps) => deleteSmartListRequest({ slug }),
+    invalidations: [InvalidateAction.SmartList.Deleted],
+  }));
+
+  const deleteList = async ({ slug }: DeleteListProps) => {
     track();
 
-    await deleteSmartListRequest({
-      slug,
-    });
-
-    await invalidate(InvalidateAction.SmartList.Deleted);
-
-    isDeleting.next(false);
+    await deletion.mutate({ slug });
   };
 
   return {
     deleteList,
-    isDeleting: isDeleting.asObservable(),
+    isDeleting: deletion.isPending,
   };
 }

--- a/projects/client/src/lib/sections/lists/user/_internal/useDeleteList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useDeleteList.ts
@@ -1,39 +1,37 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 import { deleteListRequest } from '$lib/requests/queries/users/deleteListRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import { BehaviorSubject } from 'rxjs';
+import { map } from 'rxjs';
 
 export function useDeleteList(list: MediaListSummary) {
-  const isDeleting = new BehaviorSubject(false);
-  const isDeleted = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.ListDelete);
 
+  const deletion = useMutation(defineMutation({
+    key: 'list:delete',
+    request: () =>
+      deleteListRequest({
+        userId: assertDefined(
+          list.user.slug,
+          'Expected user list to have a user slug',
+        ),
+        listId: list.slug,
+      }),
+    invalidations: [InvalidateAction.List.Deleted],
+  }));
+
   const deleteList = async () => {
-    isDeleting.next(true);
     track();
-
-    const result = await deleteListRequest({
-      userId: assertDefined(
-        list.user.slug,
-        'Expected user list to have a user slug',
-      ),
-      listId: list.slug,
-    });
-
-    await invalidate(InvalidateAction.List.Deleted);
-
-    isDeleted.next(result);
-    isDeleting.next(false);
+    await deletion.mutate();
   };
 
   return {
-    isDeleting: isDeleting.asObservable(),
-    isDeleted: isDeleted.asObservable(),
+    isDeleting: deletion.isPending,
+    isDeleted: deletion.result.pipe(map(({ data }) => data ?? false)),
     deleteList,
   };
 }

--- a/projects/client/src/lib/sections/lists/user/_internal/useLikeList.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useLikeList.spec.ts
@@ -1,0 +1,51 @@
+import { SiloListsMappedMock } from '$mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts';
+import { captureRequests } from '$test/beds/request/captureRequests.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useLikeList } from './useLikeList.ts';
+
+const list = assertDefined(SiloListsMappedMock.at(0));
+
+describe('store: useLikeList', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+  });
+
+  it('should NOT be updating when first requested', async () => {
+    const { isUpdating } = await renderStore(() => useLikeList(list));
+
+    expect(await firstValueFrom(isUpdating)).toBe(false);
+  });
+
+  it('should be updating while the like is in flight', async () => {
+    const { isUpdating, likeList } = await renderStore(() => useLikeList(list));
+
+    likeList();
+
+    expect(await firstValueFrom(isUpdating)).toBe(true);
+  });
+
+  it('should stop updating once the like resolves', async () => {
+    const { isUpdating, likeList } = await renderStore(() => useLikeList(list));
+
+    await likeList();
+
+    expect(await firstValueFrom(isUpdating)).toBe(false);
+  });
+
+  it('should like and unlike through the list endpoint', async () => {
+    const { likeList, unlikeList } = await renderStore(() => useLikeList(list));
+
+    const requests = await captureRequests(async () => {
+      await likeList();
+      await unlikeList();
+    });
+
+    expect(requests).to.include.members([
+      `POST /lists/${list.id}/like`,
+      `DELETE /lists/${list.id}/like`,
+    ]);
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/useLikeList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useLikeList.ts
@@ -1,18 +1,30 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 import { likeListRequest } from '$lib/requests/queries/lists/likeListRequest.ts';
 import { unlikeListRequest } from '$lib/requests/queries/lists/unlikeListRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, map } from 'rxjs';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
+import { map } from 'rxjs';
 
 export function useLikeList(list: MediaListSummary) {
-  const isUpdating = new BehaviorSubject<boolean>(false);
   const { track } = useTrack(AnalyticsEvent.ListLike);
-  const { invalidate } = useInvalidator();
   const { likes } = useUser();
+
+  const like = useMutation(defineMutation({
+    key: 'list:like',
+    request: likeListRequest,
+    invalidations: [InvalidateAction.List.Like],
+  }));
+
+  const unlike = useMutation(defineMutation({
+    key: 'list:unlike',
+    request: unlikeListRequest,
+    invalidations: [InvalidateAction.List.Like],
+  }));
 
   const isLiked = likes.pipe(
     map(($likes) => {
@@ -24,28 +36,16 @@ export function useLikeList(list: MediaListSummary) {
     }),
   );
 
+  const isUpdating = anyTrue([like.isPending, unlike.isPending]);
+
   const likeList = async () => {
-    isUpdating.next(true);
-
     track({ action: 'like' });
-    await likeListRequest({
-      listId: list.id,
-    });
-    await invalidate(InvalidateAction.List.Like);
-
-    isUpdating.next(false);
+    await like.mutate({ listId: list.id });
   };
 
   const unlikeList = async () => {
-    isUpdating.next(true);
-
     track({ action: 'unlike' });
-    await unlikeListRequest({
-      listId: list.id,
-    });
-    await invalidate(InvalidateAction.List.Like);
-
-    isUpdating.next(false);
+    await unlike.mutate({ listId: list.id });
   };
 
   return {

--- a/projects/client/src/lib/sections/lists/user/_internal/useRemoveFromList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useRemoveFromList.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { ExtendedMediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { removeFromListRequest } from '$lib/requests/queries/users/removeFromListRequest.ts';
 import { toBulkPayload } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 /*
   FIXME: this is here temporarily
   Will move to a more generic useList
@@ -18,33 +18,30 @@ type UseRemoveFromListProps = {
 export function useRemoveFromList(props: UseRemoveFromListProps) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
-  const isListUpdating = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.List);
 
   const ids = media.map(({ id }) => id);
 
   const body = toBulkPayload(type, ids);
 
+  const invalidationType = type === 'episode' || type === 'season'
+    ? 'show'
+    : type;
+
+  const removal = useMutation(defineMutation({
+    key: 'list:remove',
+    request: () => removeFromListRequest({ body, listId: props.listId }),
+    invalidations: [InvalidateAction.Listed(invalidationType)],
+  }));
+
   const removeFromList = async () => {
-    isListUpdating.next(true);
     track({ action: 'remove' });
 
-    await removeFromListRequest({
-      body,
-      listId: props.listId,
-    });
-
-    const invalidationType = type === 'episode' || type === 'season'
-      ? 'show'
-      : type;
-    await invalidate(InvalidateAction.Listed(invalidationType));
-
-    isListUpdating.next(false);
+    await removal.mutate();
   };
 
   return {
-    isListUpdating,
+    isListUpdating: removal.isPending,
     removeFromList,
   };
 }

--- a/projects/client/src/lib/sections/lists/user/_internal/useSaveList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useSaveList.ts
@@ -1,10 +1,10 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { ListPrivacy } from '$lib/requests/models/ListPrivacy.ts';
 import { createListRequest } from '$lib/requests/queries/users/createListRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 import { updateListRequest } from '../../../../requests/queries/users/updateListRequest.ts';
 
 type SaveListProps = {
@@ -46,16 +46,20 @@ function saveRequest(props: UseSaveListProps & SaveListProps) {
 }
 
 export function useSaveList(props: UseSaveListProps) {
-  const isSaving = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
+  const isCreating = props.type === 'create';
 
-  const invalidateAction = props.type === 'create'
-    ? InvalidateAction.List.Created
-    : InvalidateAction.List.Edited;
-  const analyticsEvent = props.type === 'create'
-    ? AnalyticsEvent.ListCreate
-    : AnalyticsEvent.ListEdit;
-  const { track } = useTrack(analyticsEvent);
+  const { track } = useTrack(
+    isCreating ? AnalyticsEvent.ListCreate : AnalyticsEvent.ListEdit,
+  );
+
+  const save = useMutation(defineMutation({
+    key: `list:${props.type}`,
+    request: (variables: SaveListProps) =>
+      saveRequest({ ...props, ...variables }),
+    invalidations: [
+      isCreating ? InvalidateAction.List.Created : InvalidateAction.List.Edited,
+    ],
+  }));
 
   const saveList = async (
     { name, description, privacy }: SaveListProps,
@@ -65,23 +69,13 @@ export function useSaveList(props: UseSaveListProps) {
       return;
     }
 
-    isSaving.next(true);
     track();
 
-    await saveRequest({
-      ...props,
-      name: newName,
-      description,
-      privacy,
-    });
-
-    await invalidate(invalidateAction);
-
-    isSaving.next(false);
+    await save.mutate({ name: newName, description, privacy });
   };
 
   return {
-    isSaving: isSaving.asObservable(),
+    isSaving: save.isPending,
     saveList,
   };
 }

--- a/projects/client/src/lib/sections/media-actions/check-in/useCheckIn.ts
+++ b/projects/client/src/lib/sections/media-actions/check-in/useCheckIn.ts
@@ -1,13 +1,14 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { useNowPlaying } from '$lib/features/toast/useNowPlaying.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { checkinEpisodeRequest } from '$lib/requests/queries/checkin/checkinEpisodeRequest.ts';
 import { checkinMovieRequest } from '$lib/requests/queries/checkin/checkinMovieRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { hasAired } from '$lib/utils/media/hasAired.ts';
 import type { MovieCheckinRequest, ShowCheckinRequest } from '@trakt/api';
-import { BehaviorSubject, map } from 'rxjs';
+import { map } from 'rxjs';
 import type { MarkAsWatchedStoreProps } from '../mark-as-watched/useMarkAsWatched.ts';
 
 export type UseCheckInProps = MarkAsWatchedStoreProps;
@@ -49,8 +50,6 @@ function mapToMoviePayload(media: MovieProps): MovieCheckinRequest {
 
 export function useCheckIn(props: UseCheckInProps) {
   const { type } = props;
-  const isCheckingIn = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.CheckIn);
 
   const { nowPlaying } = useNowPlaying();
@@ -59,34 +58,39 @@ export function useCheckIn(props: UseCheckInProps) {
     throw new Error('Cannot check in multiple media items at once.');
   }
 
+  const checkingIn = useMutation(defineMutation({
+    key: 'media:check-in',
+    request: async () => {
+      if (Array.isArray(props.media)) return;
+
+      switch (type) {
+        case 'episode': {
+          await checkinEpisodeRequest({
+            body: mapToEpisodePayload({
+              episode: props.media,
+              show: props.show,
+            }),
+          });
+          return;
+        }
+        case 'movie': {
+          await checkinMovieRequest({ body: mapToMoviePayload(props.media) });
+          return;
+        }
+      }
+    },
+    invalidations: [InvalidateAction.CheckIn],
+  }));
+
   const checkin = async () => {
     if (Array.isArray(props.media)) return;
     if (type === 'show') {
       throw new Error('Cannot check in a show directly.');
     }
 
-    isCheckingIn.next(true);
     track({ type, action: 'start' });
 
-    switch (type) {
-      case 'episode': {
-        const payload = mapToEpisodePayload({
-          episode: props.media,
-          show: props.show,
-        });
-        await checkinEpisodeRequest({ body: payload });
-        break;
-      }
-      case 'movie': {
-        const payload = mapToMoviePayload(props.media);
-        await checkinMovieRequest({ body: payload });
-        break;
-      }
-    }
-
-    await invalidate(InvalidateAction.CheckIn);
-
-    isCheckingIn.next(false);
+    await checkingIn.mutate();
   };
 
   const isWatchable = hasAired({
@@ -96,7 +100,7 @@ export function useCheckIn(props: UseCheckInProps) {
 
   return {
     checkin,
-    isCheckingIn,
+    isCheckingIn: checkingIn.isPending,
     /*
       FIXME: when we can cancel a checkin, only return true if the
       now playing item is the same as the one we are checking in

--- a/projects/client/src/lib/sections/media-actions/cover-image/useCoverImage.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/useCoverImage.ts
@@ -2,11 +2,11 @@ import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
 import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { setCoverImageRequest } from '$lib/requests/queries/users/setCoverImageRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 type UseCoverImageProps = {
   type: ExtendedMediaType;
@@ -18,29 +18,28 @@ type UseCoverImageProps = {
 export function useCoverImage(
   { type, id, title, coverUrl }: UseCoverImageProps,
 ) {
-  const isSettingCoverImage = new BehaviorSubject(false);
-
-  const { invalidate } = useInvalidator();
   const { confirm } = useConfirm();
   const { track } = useTrack(AnalyticsEvent.CoverImage);
+
+  const setting = useMutation(defineMutation({
+    key: 'user:set-cover-image',
+    request: () => setCoverImageRequest({ type, id }),
+    invalidations: [InvalidateAction.User.CoverImage],
+  }));
 
   const setCoverImage = confirm({
     type: ConfirmationType.SetCoverImage,
     title,
     previewUrl: coverUrl,
     onConfirm: async () => {
-      isSettingCoverImage.next(true);
-
       track({ type });
-      await setCoverImageRequest({ type, id });
-      await invalidate(InvalidateAction.User.CoverImage);
 
-      isSettingCoverImage.next(false);
+      await setting.mutate();
     },
   });
 
   return {
     setCoverImage,
-    isSettingCoverImage: isSettingCoverImage.asObservable(),
+    isSettingCoverImage: setting.isPending,
   };
 }

--- a/projects/client/src/lib/sections/media-actions/drop/useDrop.ts
+++ b/projects/client/src/lib/sections/media-actions/drop/useDrop.ts
@@ -1,15 +1,15 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { dropMovieRequest } from '$lib/requests/queries/users/dropMovieRequest.ts';
 import { dropShowRequest } from '$lib/requests/queries/users/dropShowRequest.ts';
 import { hideShowCalendarRequest } from '$lib/requests/queries/users/hideShowCalendarRequest.ts';
 import { toBulkPayload } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
-import { BehaviorSubject } from 'rxjs';
 import { useDropNotePrompt } from './_internal/useDropNotePrompt.ts';
 
 type DropProps = {
@@ -43,12 +43,18 @@ export function useDrop(
   props: DropStoreProps,
 ) {
   const { title, context = 'drop', ...target } = props;
-  const isDropping = new BehaviorSubject(false);
   const { user } = useUser();
-  const { invalidate } = useInvalidator();
   const dropNote = useDropNotePrompt();
 
   const { track } = useTrack(AnalyticsEvent.Drop);
+
+  const dropping = useMutation(defineMutation({
+    key: 'media:drop',
+    request: async () => {
+      await requestDrop(target);
+    },
+    invalidations: [InvalidateAction.Drop(target.type)],
+  }));
 
   const drop = async () => {
     const current = await resolve(user);
@@ -57,22 +63,17 @@ export function useDrop(
       return;
     }
 
-    isDropping.next(true);
     track({ type: target.type });
 
-    await requestDrop(target);
+    await dropping.mutate();
 
     if (context === 'drop') {
       dropNote?.show({ title, type: target.type, id: target.id });
     }
-
-    await invalidate(InvalidateAction.Drop(target.type));
-
-    isDropping.next(false);
   };
 
   return {
-    isDropping,
+    isDropping: dropping.isPending,
     drop,
   };
 }

--- a/projects/client/src/lib/sections/media-actions/favorite/useFavorites.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/favorite/useFavorites.spec.ts
@@ -1,11 +1,11 @@
 import { useAddNoteDrawer } from '$lib/features/notes/useAddNoteDrawer.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts';
 import { ShowDevsMappedMock } from '$mocks/data/summary/shows/devs/ShowDevsMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { lastActionToast } from '$test/beds/action-toast/lastActionToast.ts';
+import { captureInvalidations } from '$test/beds/query/captureInvalidations.ts';
 import { captureRequests } from '$test/beds/request/captureRequests.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
@@ -13,7 +13,6 @@ import { firstValueFrom } from 'rxjs';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { type FavoritesStoreProps, useFavorites } from './useFavorites.ts';
 
-vi.mock('$lib/stores/useInvalidator.ts');
 vi.mock('$lib/features/notes/useAddNoteDrawer.ts');
 
 const { notify } = vi.hoisted(() => ({ notify: vi.fn() }));
@@ -22,16 +21,9 @@ vi.mock('$lib/features/action-toast/useActionToast.ts', () => ({
 }));
 
 describe('useFavorites', () => {
-  const invalidate = vi.fn(function () {});
-
   beforeEach(() => {
     setAuthorization(true);
-    invalidate.mockReset();
-    notify.mockReset();
-
-    (useInvalidator as Mock)
-      .mockReturnValueOnce({ invalidate }) // 1: useFavorites
-      .mockReturnValueOnce({ invalidate }); // 2: useFavorites -> useUser
+    notify.mockReset(); // 2: useFavorites -> useUser
 
     (useAddNoteDrawer as Mock).mockReturnValue({ open: vi.fn() });
   });
@@ -84,8 +76,9 @@ describe('useFavorites', () => {
     it('should call invalidate after adding to favorites', async () => {
       const { addToFavorites } = await renderStore(() => useFavorites(props));
 
-      await addToFavorites();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(addToFavorites);
+
+      expect(invalidations).toContain(invalidation);
     });
 
     it('should call invalidate after removing from favorites', async () => {
@@ -93,8 +86,9 @@ describe('useFavorites', () => {
         useFavorites(props)
       );
 
-      await removeFromFavorites();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(removeFromFavorites);
+
+      expect(invalidations).toContain(invalidation);
     });
 
     it('should NOT be favorited', async () => {

--- a/projects/client/src/lib/sections/media-actions/favorite/useFavorites.ts
+++ b/projects/client/src/lib/sections/media-actions/favorite/useFavorites.ts
@@ -9,10 +9,12 @@ import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
 import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
+import { whenExecuted } from '$lib/features/offline/whenExecuted.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, combineLatest, map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 
 export type FavoritesStoreProps = {
   type: MediaType;
@@ -35,9 +37,7 @@ function getFavoritesPayload(
 export function useFavorites(
   { type, id, title, isToastEnabled = true }: FavoritesStoreProps,
 ) {
-  const isUpdatingFavorite = new BehaviorSubject(false);
   const { favorites } = useUser();
-  const { invalidate } = useInvalidator();
   const notify = toGatedNotify(useActionToast().notify, isToastEnabled);
 
   const { actions } = useOfflineActions();
@@ -71,21 +71,20 @@ export function useFavorites(
     }),
   );
 
+  const favoriting = useMutation(defineMutation({
+    key: 'favorites:write',
+    request: (action: 'add' | 'remove') =>
+      executeOrEnqueue({
+        endpoint: action === 'add' ? 'favorites:add' : 'favorites:remove',
+        keys: [toMediaKey(type, id)],
+        body: getFavoritesPayload({ type, id }),
+        invalidations: [InvalidateAction.Favorited(type)],
+      }),
+    invalidations: whenExecuted([InvalidateAction.Favorited(type)]),
+  }));
+
   const addOrRemoveFavorite = async (action: 'add' | 'remove') => {
-    isUpdatingFavorite.next(true);
-
-    const payload = getFavoritesPayload({ type, id });
-
-    const result = await executeOrEnqueue({
-      endpoint: action === 'add' ? 'favorites:add' : 'favorites:remove',
-      keys: [toMediaKey(type, id)],
-      body: payload,
-      invalidations: [InvalidateAction.Favorited(type)],
-    });
-
-    if (result === 'executed') {
-      await invalidate(InvalidateAction.Favorited(type));
-    }
+    await favoriting.mutate(action);
 
     notify({
       message: action === 'add'
@@ -95,14 +94,10 @@ export function useFavorites(
         addOrRemoveFavorite(action === 'add' ? 'remove' : 'add')
       ),
     });
-
-    // Always clear: a queued action stays flagged via isQueued, and leaving
-    // this pinned would re-disable the button once it syncs and dequeues.
-    isUpdatingFavorite.next(false);
   };
 
   return {
-    isUpdatingFavorite,
+    isUpdatingFavorite: favoriting.isPending,
     isFavorited,
     isQueued,
     addToFavorites: async () => await addOrRemoveFavorite('add'),

--- a/projects/client/src/lib/sections/media-actions/hide-recommendation/useHideRecommendation.ts
+++ b/projects/client/src/lib/sections/media-actions/hide-recommendation/useHideRecommendation.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { hideRecommendedMovieRequest } from '$lib/requests/queries/recommendations/hideRecommendedMovieRequest.ts';
 import { hideRecommendedShowRequest } from '$lib/requests/queries/recommendations/hideRecommendedShowRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 export type HideRecommendationParams = {
   slug: string;
@@ -22,25 +22,25 @@ function typeToRequest(type: MediaType) {
 }
 
 export function useHideRecommendation() {
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.HideRecommendation);
 
-  const isHiding = new BehaviorSubject(false);
+  const hiding = useMutation(defineMutation({
+    key: 'recommendation:hide',
+    request: ({ slug, type }: HideRecommendationParams) =>
+      typeToRequest(type)({ slug }),
+    invalidations: ({ variables }) => [
+      InvalidateAction.HideRecommended(variables.type),
+    ],
+  }));
 
-  const hide = async ({ slug, type }: HideRecommendationParams) => {
-    track({ type });
-    isHiding.next(true);
+  const hide = async (params: HideRecommendationParams) => {
+    track({ type: params.type });
 
-    const request = typeToRequest(type);
-
-    await request({ slug });
-    await invalidate(InvalidateAction.HideRecommended(type));
-
-    isHiding.next(false);
+    await hiding.mutate(params);
   };
 
   return {
-    isHiding,
+    isHiding: hiding.isPending,
     hide,
   };
 }

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
@@ -1,20 +1,18 @@
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { ShowDevsMappedMock } from '$mocks/data/summary/shows/devs/ShowDevsMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { lastActionToast } from '$test/beds/action-toast/lastActionToast.ts';
+import { captureInvalidations } from '$test/beds/query/captureInvalidations.ts';
 import { captureRequests } from '$test/beds/request/captureRequests.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
 import { firstValueFrom } from 'rxjs';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type MarkAsWatchedStoreProps,
   useMarkAsWatched,
 } from './useMarkAsWatched.ts';
-
-vi.mock('$lib/stores/useInvalidator.ts');
 
 const removeRatingSpy = vi.fn((_body?: unknown) => Promise.resolve(true));
 vi.mock('$lib/requests/sync/removeRatingRequest.ts', () => ({
@@ -35,20 +33,11 @@ vi.mock('$lib/features/action-toast/useActionToast.ts', () => ({
 }));
 
 describe('useMarkAsWatched', () => {
-  const invalidate = vi.fn(function () {});
-
   beforeEach(() => {
     setAuthorization(true);
-    invalidate.mockReset();
     removeRatingSpy.mockClear();
     addWatchedSpy.mockClear();
-    notify.mockReset();
-
-    (useInvalidator as Mock)
-      .mockReturnValueOnce({ invalidate }) // 1: useMarkAsWatched
-      .mockReturnValueOnce({ invalidate }) // 2: useMarkAsWatched -> useUser
-      .mockReturnValueOnce({ invalidate }) // 3: useMarkAsWatched -> useTrack -> useUser
-      .mockReturnValueOnce({ invalidate }); // 4: useMarkAsWatched -> useIsWatched -> useUser
+    notify.mockReset(); // 4: useMarkAsWatched -> useIsWatched -> useUser
   });
 
   const runCommonTests = (
@@ -104,8 +93,9 @@ describe('useMarkAsWatched', () => {
         useMarkAsWatched(props)
       );
 
-      await removeWatched();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(removeWatched);
+
+      expect(invalidations).toContain(invalidation);
     });
 
     it('should call invalidate after removing watched', async () => {
@@ -113,8 +103,9 @@ describe('useMarkAsWatched', () => {
         useMarkAsWatched(props)
       );
 
-      await removeWatched();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(removeWatched);
+
+      expect(invalidations).toContain(invalidation);
     });
 
     it('should NOT be watched', async () => {

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
@@ -12,6 +12,9 @@ import { m } from '$lib/features/i18n/messages.ts';
 import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
+import { whenExecuted } from '$lib/features/offline/whenExecuted.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
@@ -20,10 +23,10 @@ import {
   toAddRatingsPayload,
 } from '$lib/requests/sync/toAddRatingsPayload.ts';
 import { toRemoveRatingsPayload } from '$lib/requests/sync/toRemoveRatingsPayload.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { hasAired } from '$lib/utils/media/hasAired.ts';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
-import { BehaviorSubject, filter } from 'rxjs';
+import { filter } from 'rxjs';
 import type { MarkAsWatchedAt } from '../../../models/MarkAsWatchedAt.ts';
 import { toMarkAsWatchedPayload } from './toMarkAsWatchedPayload.ts';
 import { useIsWatched } from './useIsWatched.ts';
@@ -68,9 +71,7 @@ export function useMarkAsWatched(
   const { type, isToastEnabled = true } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
   const mediaKeys = media.map((item) => toMediaKey(type, item.id));
-  const isMarkingAsWatched = new BehaviorSubject(false);
   const { user, history, ratings } = useUser();
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.MarkAsWatched);
   const notify = toGatedNotify(useActionToast().notify, isToastEnabled);
 
@@ -79,6 +80,72 @@ export function useMarkAsWatched(
 
   const { isWatched } = useIsWatched(props);
   const { isQueued } = useIsQueued({ domain: 'history', keys: mediaKeys });
+
+  const watchedInvalidations = [InvalidateAction.MarkAsWatched(type)];
+  const ratedInvalidations = [InvalidateAction.Rated(type)];
+
+  const watchedAdd = useMutation(defineMutation({
+    key: 'history:add',
+    request: (watchedAt: MarkAsWatchedAt | ReadonlyMap<number, Date>) =>
+      executeOrEnqueue({
+        endpoint: 'history:add',
+        keys: mediaKeys,
+        body: toMarkAsWatchedPayload(props, watchedAt),
+        invalidations: watchedInvalidations,
+      }),
+    invalidations: whenExecuted(watchedInvalidations),
+  }));
+
+  // The snapshot has to be read before the request, and the submitted state
+  // has to cover that read, so it happens inside the write.
+  const watchedRemove = useMutation(defineMutation({
+    key: 'history:remove',
+    request: async () => {
+      const snapshot = await getRemovalSnapshot();
+
+      const outcome = await executeOrEnqueue({
+        endpoint: 'history:remove',
+        keys: mediaKeys,
+        body: toMarkAsWatchedPayload(props),
+        invalidations: watchedInvalidations,
+      });
+
+      return { snapshot, outcome };
+    },
+    invalidations: ({ data }) =>
+      whenExecuted(watchedInvalidations)({ data: data.outcome }),
+  }));
+
+  const ratingAdd = useMutation(defineMutation({
+    key: 'rating:add',
+    request: (targets: ReadonlyArray<RatedTarget>) =>
+      executeOrEnqueue({
+        endpoint: 'rating:add',
+        keys: targets.map(({ id }) => toMediaKey(type, id)),
+        body: toAddRatingsPayload(type, targets),
+        invalidations: ratedInvalidations,
+      }),
+    invalidations: whenExecuted(ratedInvalidations),
+  }));
+
+  const ratingRemove = useMutation(defineMutation({
+    key: 'rating:remove',
+    request: (targets: ReadonlyArray<RatedTarget>) =>
+      executeOrEnqueue({
+        endpoint: 'rating:remove',
+        keys: targets.map(({ id }) => toMediaKey(type, id)),
+        body: toRemoveRatingsPayload(type, targets.map(({ id }) => id)),
+        invalidations: ratedInvalidations,
+      }),
+    invalidations: whenExecuted(ratedInvalidations),
+  }));
+
+  const isMarkingAsWatched = anyTrue([
+    watchedAdd.isPending,
+    watchedRemove.isPending,
+    ratingAdd.isPending,
+    ratingRemove.isPending,
+  ]);
 
   const markAsWatched = async (
     watchedAt?: MarkAsWatchedAt | ReadonlyMap<number, Date>,
@@ -89,25 +156,9 @@ export function useMarkAsWatched(
       return;
     }
 
-    const watchedAtDate = watchedAt ?? 'now';
-
-    isMarkingAsWatched.next(true);
     track({ action: 'add' });
 
-    const result = await executeOrEnqueue({
-      endpoint: 'history:add',
-      keys: mediaKeys,
-      body: toMarkAsWatchedPayload(props, watchedAtDate),
-      invalidations: [InvalidateAction.MarkAsWatched(type)],
-    });
-
-    if (result === 'executed') {
-      await invalidate(InvalidateAction.MarkAsWatched(type));
-    }
-
-    // Always clear: a queued action stays flagged via isQueued, and leaving
-    // this pinned would re-disable the button once it syncs and dequeues.
-    isMarkingAsWatched.next(false);
+    await watchedAdd.mutate(watchedAt ?? 'now');
   };
 
   // A removal wipes every play of the target, so a rated item that is
@@ -174,48 +225,16 @@ export function useMarkAsWatched(
       return;
     }
 
-    const result = await executeOrEnqueue({
-      endpoint: 'rating:add',
-      keys: snapshot.ratings.map(({ id }) => toMediaKey(type, id)),
-      body: toAddRatingsPayload(type, snapshot.ratings),
-      invalidations: [InvalidateAction.Rated(type)],
-    });
-
-    if (result === 'executed') {
-      await invalidate(InvalidateAction.Rated(type));
-    }
+    await ratingAdd.mutate(snapshot.ratings);
   };
 
   const removeWatched = async () => {
-    isMarkingAsWatched.next(true);
     track({ action: 'remove' });
 
-    const snapshot = await getRemovalSnapshot();
-
-    const removeResult = await executeOrEnqueue({
-      endpoint: 'history:remove',
-      keys: mediaKeys,
-      body: toMarkAsWatchedPayload(props),
-      invalidations: [InvalidateAction.MarkAsWatched(type)],
-    });
+    const { snapshot } = await watchedRemove.mutate();
 
     if (snapshot.ratings.length > 0) {
-      const ratingResult = await executeOrEnqueue({
-        endpoint: 'rating:remove',
-        keys: snapshot.ratings.map(({ id }) => toMediaKey(type, id)),
-        body: toRemoveRatingsPayload(
-          type,
-          snapshot.ratings.map(({ id }) => id),
-        ),
-        invalidations: [InvalidateAction.Rated(type)],
-      });
-      if (ratingResult === 'executed') {
-        await invalidate(InvalidateAction.Rated(type));
-      }
-    }
-
-    if (removeResult === 'executed') {
-      await invalidate(InvalidateAction.MarkAsWatched(type));
+      await ratingRemove.mutate(snapshot.ratings);
     }
 
     // A show-wide removal captures no dates, so it gets no undo.
@@ -229,8 +248,6 @@ export function useMarkAsWatched(
         ? undoToastAction(() => restoreWatched(snapshot))
         : undefined,
     });
-
-    isMarkingAsWatched.next(false);
   };
 
   const isWatchable = media.every((item) => {

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.spec.ts
@@ -3,16 +3,14 @@ import {
   useRemoveFromHistory,
   type UseRemoveFromHistoryProps,
 } from '$lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { lastActionToast } from '$test/beds/action-toast/lastActionToast.ts';
+import { captureInvalidations } from '$test/beds/query/captureInvalidations.ts';
 import { captureRequests } from '$test/beds/request/captureRequests.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { server } from '$mocks/server.ts';
 import { http, HttpResponse } from 'msw';
 import { firstValueFrom } from 'rxjs';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-
-vi.mock('$lib/stores/useInvalidator.ts');
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { notify } = vi.hoisted(() => ({ notify: vi.fn() }));
 vi.mock('$lib/features/action-toast/useActionToast.ts', () => ({
@@ -28,15 +26,10 @@ vi.mock('$lib/requests/sync/removeWatchedRequest.ts', () => ({
 }));
 
 describe('useRemoveFromHistory', () => {
-  const invalidate = vi.fn(function () {});
-
   beforeEach(() => {
     setAuthorization(true);
-    invalidate.mockReset();
     removeRatingSpy.mockClear();
     notify.mockReset();
-
-    (useInvalidator as Mock).mockReturnValue({ invalidate });
   });
 
   const runCommonTests = (
@@ -65,8 +58,9 @@ describe('useRemoveFromHistory', () => {
         useRemoveFromHistory(props)
       );
 
-      await removeFromHistory();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(removeFromHistory);
+
+      expect(invalidations).toContain(invalidation);
     });
   };
 

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts
@@ -5,6 +5,8 @@ import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { m } from '$lib/features/i18n/messages.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { addRatingRequest } from '$lib/requests/sync/addRatingRequest.ts';
 import { markAsWatchedRequest } from '$lib/requests/sync/markAsWatchedRequest.ts';
@@ -12,10 +14,10 @@ import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
 import { toAddRatingsPayload } from '$lib/requests/sync/toAddRatingsPayload.ts';
 import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
 import { toRemoveRatingsPayload } from '$lib/requests/sync/toRemoveRatingsPayload.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
 import type { HistoryAddRequest } from '@trakt/api';
-import { BehaviorSubject, filter } from 'rxjs';
+import { filter } from 'rxjs';
 
 type RemovedMediaType = 'movie' | 'episode';
 
@@ -36,6 +38,8 @@ function toHistoryAddPayload(
   return type === 'movie' ? { movies: entries } : { episodes: entries };
 }
 
+type OrphanedRating = number | undefined;
+
 export type UseRemoveFromHistoryProps =
   & { watchedAt: Date; title?: string; isToastEnabled?: boolean }
   & (
@@ -53,9 +57,7 @@ export function useRemoveFromHistory(props: UseRemoveFromHistoryProps) {
   // Trakt id of the media itself; `id` above is the history entry (play) id.
   const traktId = props.type === 'movie' ? props.movie.id : props.episode.id;
 
-  const isRemoving = new BehaviorSubject(false);
   const { history, ratings } = useUser();
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.RemoveFromHistory);
   const notify = toGatedNotify(useActionToast().notify, isToastEnabled);
 
@@ -88,10 +90,32 @@ export function useRemoveFromHistory(props: UseRemoveFromHistoryProps) {
     }
   };
 
-  const restoreToHistory = async (orphanedRating: number | undefined) => {
-    isRemoving.next(true);
+  const historyInvalidations = (orphanedRating: OrphanedRating) =>
+    orphanedRating == null
+      ? [InvalidateAction.MarkAsWatched(type)]
+      : [InvalidateAction.Rated(type), InvalidateAction.MarkAsWatched(type)];
 
-    try {
+  const removal = useMutation(defineMutation({
+    key: 'history:remove',
+    request: async (): Promise<OrphanedRating> => {
+      const orphanedRating = await getOrphanedRating();
+
+      await removeWatchedRequest({ body: { ids: [id] } });
+
+      if (orphanedRating != null) {
+        await removeRatingRequest({
+          body: toRemoveRatingsPayload(type, [traktId]),
+        });
+      }
+
+      return orphanedRating;
+    },
+    invalidations: ({ data }) => historyInvalidations(data),
+  }));
+
+  const restoration = useMutation(defineMutation({
+    key: 'history:restore',
+    request: async (orphanedRating: OrphanedRating) => {
       await markAsWatchedRequest({
         body: toHistoryAddPayload({ type, traktId, watchedAt }),
       });
@@ -103,41 +127,25 @@ export function useRemoveFromHistory(props: UseRemoveFromHistoryProps) {
             rating: orphanedRating,
           }]),
         });
-        await invalidate(InvalidateAction.Rated(type));
       }
-
-      await invalidate(InvalidateAction.MarkAsWatched(type));
-    } finally {
-      isRemoving.next(false);
-    }
-  };
+    },
+    invalidations: ({ variables }) => historyInvalidations(variables),
+  }));
 
   const removeFromHistory = async () => {
-    isRemoving.next(true);
     track();
 
-    const orphanedRating = await getOrphanedRating();
-
-    await removeWatchedRequest({ body: { ids: [id] } });
-
-    if (orphanedRating != null) {
-      await removeRatingRequest({
-        body: toRemoveRatingsPayload(type, [traktId]),
-      });
-      await invalidate(InvalidateAction.Rated(type));
-    }
-
-    await invalidate(InvalidateAction.MarkAsWatched(type));
+    const orphanedRating = await removal.mutate();
 
     notify({
       message: title
         ? m.action_toast_removed_from_history({ title })
         : m.action_toast_removed_from_history_generic(),
-      action: undoToastAction(() => restoreToHistory(orphanedRating)),
+      action: undoToastAction(() => restoration.mutate(orphanedRating)),
     });
-
-    isRemoving.next(false);
   };
+
+  const isRemoving = anyTrue([removal.isPending, restoration.isPending]);
 
   return {
     isRemoving,

--- a/projects/client/src/lib/sections/media-actions/restore/useRestore.ts
+++ b/projects/client/src/lib/sections/media-actions/restore/useRestore.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { restoreShowCalendarRequest } from '$lib/requests/queries/users/restoreShowCalendarRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
-import { BehaviorSubject } from 'rxjs';
 import { restoreShowProgressRequest } from '../../../requests/queries/users/restoreShowProgressRequest.ts';
 import { toBulkPayload } from '../_internal/toBulkPayload.ts';
 
@@ -17,10 +17,23 @@ export function useRestore(
   props: RestoreStoreProps,
 ) {
   const { ids } = props;
-  const isRestoring = new BehaviorSubject(false);
   const { user } = useUser();
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Restore);
+
+  const restoration = useMutation(defineMutation({
+    key: 'show:restore',
+    request: () => {
+      const payload = {
+        body: toBulkPayload('show', ids),
+      };
+
+      return Promise.all([
+        restoreShowProgressRequest(payload),
+        restoreShowCalendarRequest(payload),
+      ]);
+    },
+    invalidations: [InvalidateAction.Restore],
+  }));
 
   const restore = async () => {
     const current = await resolve(user);
@@ -29,25 +42,13 @@ export function useRestore(
       return;
     }
 
-    isRestoring.next(true);
     track();
 
-    const payload = {
-      body: toBulkPayload('show', ids),
-    };
-
-    await Promise.all([
-      restoreShowProgressRequest(payload),
-      restoreShowCalendarRequest(payload),
-    ]);
-
-    await invalidate(InvalidateAction.Restore);
-
-    isRestoring.next(false);
+    await restoration.mutate();
   };
 
   return {
-    isRestoring,
+    isRestoring: restoration.isPending,
     restore,
   };
 }

--- a/projects/client/src/lib/sections/media-actions/rewatching/useRewatching.ts
+++ b/projects/client/src/lib/sections/media-actions/rewatching/useRewatching.ts
@@ -1,10 +1,12 @@
 import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
 import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { startShowRewatchingRequest } from '$lib/requests/queries/shows/startShowRewatchingRequest.ts';
 import { stopShowRewatchingRequest } from '$lib/requests/queries/shows/stopShowRewatchingRequest.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
+import { firstValueFrom } from 'rxjs';
 import { useIsRewatching } from './useIsRewatching.ts';
 
 type UseRewatchingProps = {
@@ -14,8 +16,6 @@ type UseRewatchingProps = {
 };
 
 export function useRewatching({ show }: UseRewatchingProps) {
-  const isUpdatingRewatching = new BehaviorSubject(false);
-  const { invalidateAll } = useInvalidator();
   const { isEnabled } = useFeatureFlag();
   const isRewatchingFeatureEnabled = isEnabled(FeatureFlag.Rewatching);
   const { isRewatching } = useIsRewatching({
@@ -23,29 +23,32 @@ export function useRewatching({ show }: UseRewatchingProps) {
     media: show,
   });
 
-  const invalidateRewatching = () =>
-    invalidateAll([
-      InvalidateAction.Rewatching('show'),
-      InvalidateAction.MarkAsWatched('show'),
-    ]);
+  const rewatchingInvalidations = ({ data }: { data: boolean }) =>
+    data
+      ? [
+        InvalidateAction.Rewatching('show'),
+        InvalidateAction.MarkAsWatched('show'),
+      ]
+      : [];
+
+  const start = useMutation(defineMutation({
+    key: 'show:start-rewatching',
+    request: () => startShowRewatchingRequest({ id: show.id }),
+    invalidations: rewatchingInvalidations,
+  }));
+
+  const stop = useMutation(defineMutation({
+    key: 'show:stop-rewatching',
+    request: () => stopShowRewatchingRequest({ id: show.id }),
+    invalidations: rewatchingInvalidations,
+  }));
 
   const startRewatching = async () => {
     if (!(await firstValueFrom(isRewatchingFeatureEnabled))) {
       return false;
     }
 
-    isUpdatingRewatching.next(true);
-
-    try {
-      const didStart = await startShowRewatchingRequest({ id: show.id });
-      if (didStart) {
-        await invalidateRewatching();
-      }
-
-      return didStart;
-    } finally {
-      isUpdatingRewatching.next(false);
-    }
+    return await start.mutate();
   };
 
   const stopRewatching = async () => {
@@ -53,19 +56,10 @@ export function useRewatching({ show }: UseRewatchingProps) {
       return false;
     }
 
-    isUpdatingRewatching.next(true);
-
-    try {
-      const didStop = await stopShowRewatchingRequest({ id: show.id });
-      if (didStop) {
-        await invalidateRewatching();
-      }
-
-      return didStop;
-    } finally {
-      isUpdatingRewatching.next(false);
-    }
+    return await stop.mutate();
   };
+
+  const isUpdatingRewatching = anyTrue([start.isPending, stop.isPending]);
 
   return {
     isRewatching,

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.spec.ts
@@ -1,18 +1,16 @@
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts';
 import { ShowDevsMappedMock } from '$mocks/data/summary/shows/devs/ShowDevsMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { lastActionToast } from '$test/beds/action-toast/lastActionToast.ts';
+import { captureInvalidations } from '$test/beds/query/captureInvalidations.ts';
 import { captureRequests } from '$test/beds/request/captureRequests.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
 import { firstValueFrom } from 'rxjs';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useWatchlist } from './useWatchlist.ts';
-
-vi.mock('$lib/stores/useInvalidator.ts');
 
 const { notify } = vi.hoisted(() => ({ notify: vi.fn() }));
 vi.mock('$lib/features/action-toast/useActionToast.ts', () => ({
@@ -20,17 +18,9 @@ vi.mock('$lib/features/action-toast/useActionToast.ts', () => ({
 }));
 
 describe('useWatchlist', () => {
-  const invalidate = vi.fn(function () {});
-
   beforeEach(() => {
     setAuthorization(true);
-    invalidate.mockReset();
-    notify.mockReset();
-
-    (useInvalidator as Mock)
-      .mockReturnValueOnce({ invalidate }) // 1: in useWatchlist
-      .mockReturnValueOnce({ invalidate }) // 2: in useWatchlist -> useTrack -> useUser
-      .mockReturnValueOnce({ invalidate }); // 3: in useWatchlist -> useIsWatchlisted -> useUser
+    notify.mockReset(); // 3: in useWatchlist -> useIsWatchlisted -> useUser
   });
 
   const runCommonTests = (props: MediaStoreProps, invalidation: string) => {
@@ -81,8 +71,9 @@ describe('useWatchlist', () => {
     it('should call invalidate after adding to watchlist', async () => {
       const { addToWatchlist } = await renderStore(() => useWatchlist(props));
 
-      await addToWatchlist();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(addToWatchlist);
+
+      expect(invalidations).toContain(invalidation);
     });
 
     it('should call invalidate after removing from watchlist', async () => {
@@ -90,8 +81,9 @@ describe('useWatchlist', () => {
         useWatchlist(props)
       );
 
-      await removeFromWatchlist();
-      expect(invalidate).toHaveBeenCalledWith(invalidation);
+      const invalidations = await captureInvalidations(removeFromWatchlist);
+
+      expect(invalidations).toContain(invalidation);
     });
 
     it('should NOT be watchlisted', async () => {

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
@@ -7,15 +7,16 @@ import { m } from '$lib/features/i18n/messages.ts';
 import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
+import { whenExecuted } from '$lib/features/offline/whenExecuted.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
 import { manageListsDrawerStore } from '$lib/sections/components/lists-drawer/manageListsDrawerStore.ts';
 import { toBulkPayload } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { useIsWatchlisted } from '$lib/stores/useIsWatchlisted.ts';
-import { BehaviorSubject } from 'rxjs';
-
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 // The "change list" drawer needs a full entry; bulk mutations may only carry
 // an `{ id }`.
 function isListableEntry(item: { id: number }): item is MediaEntry {
@@ -33,8 +34,6 @@ type UseWatchlistProps = MediaStoreProps & {
 export function useWatchlist(props: UseWatchlistProps) {
   const { type, isToastEnabled = true } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
-  const isWatchlistUpdating = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Watchlist);
   const notify = toGatedNotify(useActionToast().notify, isToastEnabled);
 
@@ -52,24 +51,44 @@ export function useWatchlist(props: UseWatchlistProps) {
   });
   const body = toBulkPayload(type, ids);
 
+  const watchlistInvalidations = type === 'episode'
+    ? []
+    : [InvalidateAction.Watchlisted(type)];
+
+  const addition = useMutation(defineMutation({
+    key: 'watchlist:add',
+    request: () =>
+      executeOrEnqueue({
+        endpoint: 'watchlist:add',
+        keys: ids.map((id) => toMediaKey(type, id)),
+        body,
+        invalidations: watchlistInvalidations,
+      }),
+    invalidations: whenExecuted(watchlistInvalidations),
+  }));
+
+  const removal = useMutation(defineMutation({
+    key: 'watchlist:remove',
+    request: () =>
+      executeOrEnqueue({
+        endpoint: 'watchlist:remove',
+        keys: ids.map((id) => toMediaKey(type, id)),
+        body,
+        invalidations: watchlistInvalidations,
+      }),
+    invalidations: whenExecuted(watchlistInvalidations),
+  }));
+
+  const isWatchlistUpdating = anyTrue([addition.isPending, removal.isPending]);
+
   const addToWatchlist = async () => {
     if (type === 'episode') {
       return;
     }
 
-    isWatchlistUpdating.next(true);
     track({ action: 'add' });
 
-    const addResult = await executeOrEnqueue({
-      endpoint: 'watchlist:add',
-      keys: ids.map((id) => toMediaKey(type, id)),
-      body,
-      invalidations: [InvalidateAction.Watchlisted(type)],
-    });
-
-    if (addResult === 'executed') {
-      await invalidate(InvalidateAction.Watchlisted(type));
-    }
+    await addition.mutate();
 
     notify({
       message: singleEntry
@@ -87,10 +106,6 @@ export function useWatchlist(props: UseWatchlistProps) {
         }
         : undefined,
     });
-
-    // Always clear: a queued action stays flagged via isQueued, and leaving
-    // this pinned would re-disable the button once it syncs and dequeues.
-    isWatchlistUpdating.next(false);
   };
 
   const removeFromWatchlist = async () => {
@@ -98,19 +113,9 @@ export function useWatchlist(props: UseWatchlistProps) {
       return;
     }
 
-    isWatchlistUpdating.next(true);
     track({ action: 'remove' });
 
-    const removeResult = await executeOrEnqueue({
-      endpoint: 'watchlist:remove',
-      keys: ids.map((id) => toMediaKey(type, id)),
-      body,
-      invalidations: [InvalidateAction.Watchlisted(type)],
-    });
-
-    if (removeResult === 'executed') {
-      await invalidate(InvalidateAction.Watchlisted(type));
-    }
+    await removal.mutate();
 
     notify({
       message: singleEntry
@@ -118,8 +123,6 @@ export function useWatchlist(props: UseWatchlistProps) {
         : m.action_toast_removed_from_watchlist_generic(),
       action: undoToastAction(addToWatchlist),
     });
-
-    isWatchlistUpdating.next(false);
   };
 
   return {

--- a/projects/client/src/lib/sections/profile-banner/_internal/useBlockUser.ts
+++ b/projects/client/src/lib/sections/profile-banner/_internal/useBlockUser.ts
@@ -1,42 +1,39 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { blockUserRequest } from '$lib/requests/queries/users/blockUserRequest.ts';
 import { unblockUserRequest } from '$lib/requests/queries/users/unblockUserRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
-
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 export function useBlockUser() {
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Block);
-  const isRequestingBlock = new BehaviorSubject(false);
+
+  const block = useMutation(defineMutation({
+    key: 'user:block',
+    request: (slug: string) => blockUserRequest({ slug }),
+    invalidations: [InvalidateAction.User.Block, InvalidateAction.User.Follow],
+  }));
+
+  const unblock = useMutation(defineMutation({
+    key: 'user:unblock',
+    request: (slug: string) => unblockUserRequest({ slug }),
+    invalidations: [InvalidateAction.User.Block],
+  }));
 
   const blockUser = async (slug: string) => {
-    isRequestingBlock.next(true);
+    track({ action: 'block' });
 
-    try {
-      track({ action: 'block' });
-      await blockUserRequest({ slug });
-      await Promise.all([
-        invalidate(InvalidateAction.User.Block),
-        invalidate(InvalidateAction.User.Follow),
-      ]);
-    } finally {
-      isRequestingBlock.next(false);
-    }
+    await block.mutate(slug);
   };
 
   const unblockUser = async (slug: string) => {
-    isRequestingBlock.next(true);
+    track({ action: 'unblock' });
 
-    try {
-      track({ action: 'unblock' });
-      await unblockUserRequest({ slug });
-      await invalidate(InvalidateAction.User.Block);
-    } finally {
-      isRequestingBlock.next(false);
-    }
+    await unblock.mutate(slug);
   };
+
+  const isRequestingBlock = anyTrue([block.isPending, unblock.isPending]);
 
   return {
     isRequestingBlock,

--- a/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
+++ b/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
@@ -7,6 +7,8 @@ import {
 import { currentUserPendingFollowsQuery } from '$lib/features/auth/queries/currentUserPendingFollowsQuery.ts';
 import { useAuth } from '$lib/features/auth/stores/useAuth.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { UserProfile } from '$lib/requests/models/UserProfile.ts';
@@ -14,19 +16,43 @@ import { approveFollowRequest } from '$lib/requests/queries/users/approveFollowR
 import { denyFollowRequest } from '$lib/requests/queries/users/denyFollowRequest.ts';
 import { followUserRequest } from '$lib/requests/queries/users/followUserRequest.ts';
 import { unfollowUserRequest } from '$lib/requests/queries/users/unfollowUserRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, combineLatest, map, of, switchMap, tap } from 'rxjs';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
+import { combineLatest, map, of, startWith, switchMap } from 'rxjs';
 
 export type FollowStatus = 'none' | 'pending' | 'following';
 
+const followInvalidations = [InvalidateAction.User.Follow];
+
 export function useFollowUserRequest(slug: string) {
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Follow);
   const { isAuthorized } = useAuth();
   const { network } = useUser();
   const pendingFollowsQuerySignal = useQuery(currentUserPendingFollowsQuery());
   const followRequestsQuerySignal = useQuery(currentUserFollowRequestsQuery());
-  const isRequestingFollow = new BehaviorSubject(false);
+
+  const follow = useMutation(defineMutation({
+    key: 'user:follow',
+    request: () => followUserRequest({ slug }),
+    invalidations: followInvalidations,
+  }));
+
+  const unfollow = useMutation(defineMutation({
+    key: 'user:unfollow',
+    request: () => unfollowUserRequest({ slug }),
+    invalidations: followInvalidations,
+  }));
+
+  const approve = useMutation(defineMutation({
+    key: 'user:approve-follow-request',
+    request: (requestId: number) => approveFollowRequest({ requestId }),
+    invalidations: ({ data }) => data ? followInvalidations : [],
+  }));
+
+  const deny = useMutation(defineMutation({
+    key: 'user:deny-follow-request',
+    request: (requestId: number) => denyFollowRequest({ requestId }),
+    invalidations: ({ data }) => data ? followInvalidations : [],
+  }));
 
   const pendingFollows = isAuthorized.pipe(
     switchMap((authorized) =>
@@ -50,11 +76,9 @@ export function useFollowUserRequest(slug: string) {
     ),
   );
 
-  const followStatus = combineLatest([network, pendingFollows]).pipe(
-    tap(([$network, $pendingFollows]) => {
-      const isReady = $network != null && $pendingFollows != null;
-      isRequestingFollow.next(!isReady);
-    }),
+  const followState = combineLatest([network, pendingFollows]);
+
+  const followStatus = followState.pipe(
     map(([$network, $pendingFollows]): FollowStatus => {
       if ($network?.following.some((user) => user.slug === slug)) {
         return 'following';
@@ -68,63 +92,41 @@ export function useFollowUserRequest(slug: string) {
     }),
   );
 
+  const isFollowStateUnsettled = followState.pipe(
+    map(([$network, $pendingFollows]) =>
+      $network == null || $pendingFollows == null
+    ),
+  );
+
+  const isRequestingFollow = anyTrue([
+    isFollowStateUnsettled,
+    follow.isPending,
+    unfollow.isPending,
+    approve.isPending,
+    deny.isPending,
+  ]).pipe(startWith(false));
+
   const followUser = async () => {
-    isRequestingFollow.next(true);
-
     track({ action: 'follow' });
-    await followUserRequest({ slug });
-    await invalidate(InvalidateAction.User.Follow);
 
-    isRequestingFollow.next(false);
+    await follow.mutate();
   };
 
   const unfollowUser = async () => {
-    isRequestingFollow.next(true);
-
     track({ action: 'unfollow' });
-    await unfollowUserRequest({ slug });
-    await invalidate(InvalidateAction.User.Follow);
 
-    isRequestingFollow.next(false);
+    await unfollow.mutate();
   };
 
   const cancelFollowRequest = async () => {
-    isRequestingFollow.next(true);
-
     track({ action: 'cancel-follow-request' });
-    await unfollowUserRequest({ slug });
-    await invalidate(InvalidateAction.User.Follow);
 
-    isRequestingFollow.next(false);
+    await unfollow.mutate();
   };
-
-  const respondToFollowRequest = async (
-    action: (params: { requestId: number }) => Promise<boolean>,
-    requestId: number,
-  ): Promise<boolean> => {
-    isRequestingFollow.next(true);
-
-    try {
-      const succeeded = await action({ requestId });
-      if (succeeded) {
-        await invalidate(InvalidateAction.User.Follow);
-      }
-
-      return succeeded;
-    } finally {
-      isRequestingFollow.next(false);
-    }
-  };
-
-  const approveIncomingFollowRequest = (requestId: number) =>
-    respondToFollowRequest(approveFollowRequest, requestId);
-
-  const denyIncomingFollowRequest = (requestId: number) =>
-    respondToFollowRequest(denyFollowRequest, requestId);
 
   return {
-    approveIncomingFollowRequest,
-    denyIncomingFollowRequest,
+    approveIncomingFollowRequest: approve.mutate,
+    denyIncomingFollowRequest: deny.mutate,
     incomingFollowRequest,
     isRequestingFollow,
     followStatus,

--- a/projects/client/src/lib/sections/settings/_internal/apps/useCreateApiApplication.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useCreateApiApplication.ts
@@ -1,44 +1,45 @@
 import * as m from '$lib/features/i18n/messages.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import {
   createApiApplicationRequest,
   type CreateApiApplicationResult,
 } from '$lib/requests/queries/apps/createApiApplicationRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { BehaviorSubject } from 'rxjs';
 import type { ApiApplicationFormValues } from './ApiApplicationFormValues.ts';
 
 export function useCreateApiApplication() {
-  const isCreating = new BehaviorSubject(false);
   const error = new BehaviorSubject<string | null>(null);
-  const { invalidate } = useInvalidator();
+
+  const creation = useMutation(defineMutation({
+    key: 'app:create',
+    request: (input: ApiApplicationFormValues) =>
+      createApiApplicationRequest(input),
+    invalidations: ({ data }) => data.ok ? [InvalidateAction.App.Create] : [],
+  }));
 
   const createApplication = async (
     input: ApiApplicationFormValues,
   ): Promise<CreateApiApplicationResult> => {
-    isCreating.next(true);
     error.next(null);
 
     try {
-      const result = await createApiApplicationRequest(input);
+      const result = await creation.mutate(input);
 
       if (!result.ok) {
         error.next(m.error_text_app_save_failed());
-        return result;
       }
 
-      await invalidate(InvalidateAction.App.Create);
       return result;
     } catch {
       error.next(m.error_text_app_save_failed());
       return { ok: false };
-    } finally {
-      isCreating.next(false);
     }
   };
 
   return {
-    isCreating: isCreating.asObservable(),
+    isCreating: creation.isPending,
     error: error.asObservable(),
     dismissError: () => error.next(null),
     createApplication,

--- a/projects/client/src/lib/sections/settings/_internal/apps/useDeleteApiApplication.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useDeleteApiApplication.ts
@@ -1,8 +1,9 @@
 import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
 import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { deleteApiApplicationRequest } from '$lib/requests/queries/apps/deleteApiApplicationRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 
 type DeleteTarget = {
   id: number;
@@ -10,21 +11,25 @@ type DeleteTarget = {
 };
 
 export function useDeleteApiApplication() {
-  const { invalidate } = useInvalidator();
   const { confirm } = useConfirm();
+
+  const deletion = useMutation(defineMutation({
+    key: 'app:delete',
+    request: ({ id }: DeleteTarget) => deleteApiApplicationRequest({ id }),
+    invalidations: ({ data }) => data ? [InvalidateAction.App.Delete] : [],
+  }));
 
   const remove = (app: DeleteTarget, onDeleted?: () => void) =>
     confirm({
       type: ConfirmationType.DeleteApiApp,
       name: app.name,
       onConfirm: async () => {
-        const deleted = await deleteApiApplicationRequest({ id: app.id });
+        const deleted = await deletion.mutate(app);
 
         if (!deleted) {
           return;
         }
 
-        await invalidate(InvalidateAction.App.Delete);
         onDeleted?.();
       },
     });

--- a/projects/client/src/lib/sections/settings/_internal/apps/useRevokeConnectedApp.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useRevokeConnectedApp.ts
@@ -1,8 +1,9 @@
 import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
 import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { revokeConnectedAppRequest } from '$lib/requests/queries/apps/revokeConnectedAppRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 
 type RevokeTarget = {
   id: number;
@@ -10,17 +11,19 @@ type RevokeTarget = {
 };
 
 export function useRevokeConnectedApp() {
-  const { invalidate } = useInvalidator();
   const { confirm } = useConfirm();
+
+  const revocation = useMutation(defineMutation({
+    key: 'app:revoke',
+    request: ({ id }: RevokeTarget) => revokeConnectedAppRequest({ id }),
+    invalidations: [InvalidateAction.App.Revoke],
+  }));
 
   const revoke = (app: RevokeTarget) =>
     confirm({
       type: ConfirmationType.RevokeApp,
       name: app.name,
-      onConfirm: async () => {
-        await revokeConnectedAppRequest({ id: app.id });
-        await invalidate(InvalidateAction.App.Revoke);
-      },
+      onConfirm: () => revocation.mutate(app),
     });
 
   return { revoke };

--- a/projects/client/src/lib/sections/settings/_internal/apps/useUpdateApiApplication.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useUpdateApiApplication.ts
@@ -1,7 +1,8 @@
 import * as m from '$lib/features/i18n/messages.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { updateApiApplicationRequest } from '$lib/requests/queries/apps/updateApiApplicationRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { BehaviorSubject } from 'rxjs';
 import type { ApiApplicationFormValues } from './ApiApplicationFormValues.ts';
 
@@ -15,36 +16,37 @@ type UpdateApiApplicationError = {
 };
 
 export function useUpdateApiApplication() {
-  const isUpdating = new BehaviorSubject(false);
   const error = new BehaviorSubject<UpdateApiApplicationError | null>(null);
-  const { invalidate } = useInvalidator();
+
+  const update = useMutation(defineMutation({
+    key: 'app:update',
+    request: (input: UpdateApiApplicationInput) =>
+      updateApiApplicationRequest(input),
+    invalidations: ({ data }) => data.ok ? [InvalidateAction.App.Update] : [],
+  }));
 
   const updateApplication = async (
     input: UpdateApiApplicationInput,
   ): Promise<boolean> => {
-    isUpdating.next(true);
     error.next(null);
 
     try {
-      const result = await updateApiApplicationRequest(input);
+      const result = await update.mutate(input);
 
       if (!result.ok) {
         error.next({ id: input.id, message: m.error_text_app_save_failed() });
         return false;
       }
 
-      await invalidate(InvalidateAction.App.Update);
       return true;
     } catch {
       error.next({ id: input.id, message: m.error_text_app_save_failed() });
       return false;
-    } finally {
-      isUpdating.next(false);
     }
   };
 
   return {
-    isUpdating: isUpdating.asObservable(),
+    isUpdating: update.isPending,
     error: error.asObservable(),
     dismissError: () => error.next(null),
     updateApplication,

--- a/projects/client/src/lib/sections/settings/_internal/plex/usePlexServer.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/usePlexServer.ts
@@ -1,4 +1,6 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { PlexErrorCode } from '$lib/requests/plex/PlexErrorCode.ts';
 import { plexServerAccountsQuery } from '$lib/requests/plex/plexServerAccountsQuery.ts';
@@ -6,7 +8,6 @@ import { plexSettingsQuery } from '$lib/requests/plex/plexSettingsQuery.ts';
 import { plexUpdateSettingsRequest } from '$lib/requests/plex/plexUpdateSettingsRequest.ts';
 import { refetchQuery } from '$lib/features/query/refetchQuery.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import {
   BehaviorSubject,
@@ -30,7 +31,13 @@ const UNRECOVERABLE_ERROR_CODES = new Set<PlexErrorCode>([
 ]);
 
 export function usePlexServer({ serverId }: { serverId: string }) {
-  const { invalidate } = useInvalidator();
+  const selectionWrite = useMutation(defineMutation({
+    key: 'plex:write-selection',
+    request: (selection: PlexSelectionUpdate) =>
+      plexUpdateSettingsRequest({ settings: { sync: { selection } } })
+        .catch(() => false),
+    invalidations: ({ data }) => data ? [InvalidateAction.Plex.Settings] : [],
+  }));
   const { user } = useUser();
 
   const accountsQuery = useQuery(plexServerAccountsQuery({ serverId }));
@@ -143,16 +150,7 @@ export function usePlexServer({ serverId }: { serverId: string }) {
   async function writeSelection(
     selection: PlexSelectionUpdate,
   ): Promise<boolean> {
-    const success = await plexUpdateSettingsRequest({
-      settings: { sync: { selection } },
-    }).catch(() => false);
-
-    if (!success) {
-      return false;
-    }
-
-    await invalidate(InvalidateAction.Plex.Settings);
-    return true;
+    return await selectionWrite.mutate(selection);
   }
 
   async function saveChanges(): Promise<boolean> {

--- a/projects/client/src/lib/sections/settings/_internal/plex/usePlexSettingsToggle.ts
+++ b/projects/client/src/lib/sections/settings/_internal/plex/usePlexSettingsToggle.ts
@@ -1,19 +1,24 @@
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { plexUpdateSettingsRequest } from '$lib/requests/plex/plexUpdateSettingsRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import type { PlexToggleParams } from './PlexToggleParams.ts';
 
 type PlexSettingsSection = 'sync' | 'scrobbler';
 
 export function usePlexSettingsToggle(section: PlexSettingsSection) {
-  const { invalidate } = useInvalidator();
+  const toggle = useMutation(defineMutation({
+    key: `plex:toggle-${section}`,
+    request: ({ mediaKind, settingKey, current }: PlexToggleParams) =>
+      plexUpdateSettingsRequest({
+        settings: {
+          [section]: { toggles: { [mediaKind]: { [settingKey]: !current } } },
+        },
+      }),
+    invalidations: [InvalidateAction.Plex.Settings],
+  }));
 
-  return async ({ mediaKind, settingKey, current }: PlexToggleParams) => {
-    await plexUpdateSettingsRequest({
-      settings: {
-        [section]: { toggles: { [mediaKind]: { [settingKey]: !current } } },
-      },
-    });
-    await invalidate(InvalidateAction.Plex.Settings);
+  return async (params: PlexToggleParams) => {
+    await toggle.mutate(params);
   };
 }

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingServices.ts
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingServices.ts
@@ -1,15 +1,23 @@
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { saveStreamingPreferencesRequest } from '$lib/requests/queries/services/saveStreamingPreferencesRequest.ts';
 import { streamingSourcesQuery } from '$lib/requests/queries/services/streamingSourcesQuery.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { useStreamingPreferences } from '$lib/stores/useStreamingPreferences.ts';
 import { combineLatest, map } from 'rxjs';
 import { toFavoriteId } from './toFavoriteId.ts';
 
 export function useStreamingServices() {
   const { country, favorites } = useStreamingPreferences();
-  const { invalidate } = useInvalidator();
+
+  const savePreferences = useMutation(defineMutation({
+    key: 'streaming:save-preferences',
+    request: (
+      preferences: Parameters<typeof saveStreamingPreferencesRequest>[0],
+    ) => saveStreamingPreferencesRequest(preferences),
+    invalidations: [InvalidateAction.User.Settings],
+  }));
 
   const sources = useQuery(streamingSourcesQuery()).pipe(
     map((query) => query.data),
@@ -36,8 +44,7 @@ export function useStreamingServices() {
   );
 
   const setCountry = async (nextCountry: string) => {
-    await saveStreamingPreferencesRequest({ country: nextCountry });
-    await invalidate(InvalidateAction.User.Settings);
+    await savePreferences.mutate({ country: nextCountry });
   };
 
   const saveFavorites = async (forCountry: string, sourceSlugs: string[]) => {
@@ -45,8 +52,7 @@ export function useStreamingServices() {
     // payload fully replaces the stored list, so other countries are not sent.
     const next = sourceSlugs.map((slug) => toFavoriteId(forCountry, slug));
 
-    await saveStreamingPreferencesRequest({ favorites: next });
-    await invalidate(InvalidateAction.User.Settings);
+    await savePreferences.mutate({ favorites: next });
   };
 
   return {

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingServicesActions.ts
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/useStreamingServicesActions.ts
@@ -1,18 +1,38 @@
 import { page } from '$app/state';
 import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
 import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { connectStreamingRequest } from '$lib/requests/queries/streaming-sync/connectStreamingRequest.ts';
 import { disconnectStreamingRequest } from '$lib/requests/queries/streaming-sync/disconnectStreamingRequest.ts';
 import { refreshStreamingRequest } from '$lib/requests/queries/streaming-sync/refreshStreamingRequest.ts';
 import { undoSyncRequest } from '$lib/requests/queries/streaming-sync/undoSyncRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { streamingConnectionStatus } from './streamingConnectionStatus.ts';
 
 export function useStreamingServicesActions() {
-  const { invalidate } = useInvalidator();
   const { confirm } = useConfirm();
+
+  const refresh = useMutation(defineMutation({
+    key: 'streaming:refresh',
+    request: (
+      { serviceId, allData }: { serviceId: string; allData: boolean },
+    ) => refreshStreamingRequest({ serviceId, allData }),
+    invalidations: [InvalidateAction.StreamingSync.Connection],
+  }));
+
+  const disconnect = useMutation(defineMutation({
+    key: 'streaming:disconnect',
+    request: (serviceId: string) => disconnectStreamingRequest({ serviceId }),
+    invalidations: [InvalidateAction.StreamingSync.Connection],
+  }));
+
+  const undoSync = useMutation(defineMutation({
+    key: 'streaming:undo-sync',
+    request: (syncId: number) => undoSyncRequest({ syncId }),
+    invalidations: [InvalidateAction.StreamingSync.Sync],
+  }));
 
   // Younify returns to the dedicated callback route, which normalises its
   // result params before redirecting back to the settings page.
@@ -36,27 +56,20 @@ export function useStreamingServicesActions() {
   };
 
   const sync = async (serviceId: string, allData = false) => {
-    await refreshStreamingRequest({ serviceId, allData });
-    await invalidate(InvalidateAction.StreamingSync.Connection);
+    await refresh.mutate({ serviceId, allData });
   };
 
   const unlink = (service: { id: string; name: string }) =>
     confirm({
       type: ConfirmationType.UnlinkStreaming,
       service: service.name,
-      onConfirm: async () => {
-        await disconnectStreamingRequest({ serviceId: service.id });
-        await invalidate(InvalidateAction.StreamingSync.Connection);
-      },
+      onConfirm: () => disconnect.mutate(service.id),
     });
 
   const undo = (syncId: number) =>
     confirm({
       type: ConfirmationType.UndoSync,
-      onConfirm: async () => {
-        await undoSyncRequest({ syncId });
-        await invalidate(InvalidateAction.StreamingSync.Sync);
-      },
+      onConfirm: () => undoSync.mutate(syncId),
     });
 
   return { connect, sync, unlink, undo };

--- a/projects/client/src/lib/sections/settings/_internal/useResetCoverImage.ts
+++ b/projects/client/src/lib/sections/settings/_internal/useResetCoverImage.ts
@@ -3,37 +3,35 @@ import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
 import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { resetCoverImageRequest } from '$lib/requests/queries/users/resetCoverImageRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, map } from 'rxjs';
+import { map } from 'rxjs';
 
 export function useResetCoverImage() {
-  const isResettingCoverImage = new BehaviorSubject(false);
-
   const { user } = useUser();
-  const { invalidate } = useInvalidator();
   const { confirm } = useConfirm();
   const { track } = useTrack(AnalyticsEvent.Settings);
+
+  const reset = useMutation(defineMutation({
+    key: 'user:reset-cover-image',
+    request: () => resetCoverImageRequest({}),
+    invalidations: [InvalidateAction.User.CoverImage],
+  }));
 
   const resetCoverImage = confirm({
     type: ConfirmationType.ResetCoverImage,
     onConfirm: async () => {
-      isResettingCoverImage.next(true);
+      track({ settings: 'reset-cover-image' });
 
-      try {
-        track({ settings: 'reset-cover-image' });
-        await resetCoverImageRequest({});
-        await invalidate(InvalidateAction.User.CoverImage);
-      } finally {
-        isResettingCoverImage.next(false);
-      }
+      await reset.mutate();
     },
   });
 
   return {
     resetCoverImage,
     hasCoverImage: user.pipe(map(($user) => Boolean($user.cover.url))),
-    isResettingCoverImage: isResettingCoverImage.asObservable(),
+    isResettingCoverImage: reset.isPending,
   };
 }

--- a/projects/client/src/lib/sections/settings/_internal/useSettings.ts
+++ b/projects/client/src/lib/sections/settings/_internal/useSettings.ts
@@ -2,12 +2,13 @@ import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { Theme } from '$lib/features/theme/models/Theme.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { changeEmailRequest } from '$lib/requests/queries/users/changeEmailRequest.ts';
 import { saveSettingsRequest } from '$lib/requests/queries/users/saveSettingsRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import type { Genre, SettingsRequest } from '@trakt/api';
-import { BehaviorSubject, map } from 'rxjs';
+import { map } from 'rxjs';
 
 type HandleSettingsProps = {
   request: () => Promise<boolean>;
@@ -34,24 +35,24 @@ export function useSettings() {
   // direct `$user` bindings and these slices, so no local shareReplay wrapper
   // is needed anymore.
   const { user } = useUser();
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Settings);
-  const isSavingSettings = new BehaviorSubject(false);
+
+  const settingsChange = useMutation(defineMutation({
+    key: 'user:save-settings',
+    request: ({ request }: HandleSettingsProps) => request(),
+    invalidations: ({ data }) => data ? [InvalidateAction.User.Settings] : [],
+  }));
 
   const handleSettingsChange = async (
-    { request, action }: HandleSettingsProps,
+    props: HandleSettingsProps,
   ): Promise<boolean> => {
-    isSavingSettings.next(true);
+    const success = await settingsChange.mutate(props);
 
-    const success = await request();
     if (!success) {
-      isSavingSettings.next(false);
       return false;
     }
 
-    track({ settings: action });
-    await invalidate(InvalidateAction.User.Settings);
-    isSavingSettings.next(false);
+    track({ settings: props.action });
     return true;
   };
 
@@ -95,7 +96,7 @@ export function useSettings() {
   };
 
   return {
-    isSavingSettings: isSavingSettings.asObservable(),
+    isSavingSettings: settingsChange.isPending,
     spoilers: user.pipe(map(($user) => ({
       isHidden: Boolean($user.preferences.isSpoilerHidden),
       set: async (isEnabled: boolean) => {

--- a/projects/client/src/lib/sections/smart-lists/useCreateSmartList.ts
+++ b/projects/client/src/lib/sections/smart-lists/useCreateSmartList.ts
@@ -1,9 +1,9 @@
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { createSmartListRequest } from '$lib/requests/queries/users/createSmartListRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import type { SmartListWriteRequest } from '@trakt/api';
-import { BehaviorSubject } from 'rxjs';
 import { AnalyticsEvent } from '../../features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '../../features/analytics/useTrack.ts';
 import type { ListTarget } from './models/ListTarget.ts';
@@ -28,25 +28,23 @@ function toPayload(
 }
 
 export function useCreateSmartList() {
-  const isCreating = new BehaviorSubject(false);
-
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.SmartListCreate);
 
+  const creation = useMutation(defineMutation({
+    key: 'smart-list:create',
+    request: (props: CreateListProps) =>
+      createSmartListRequest({ body: toPayload(props) }),
+    invalidations: [InvalidateAction.SmartList.Created],
+  }));
+
   const createList = async (props: CreateListProps) => {
-    isCreating.next(true);
     track();
 
-    const body = toPayload(props);
-    await createSmartListRequest({ body });
-
-    await invalidate(InvalidateAction.SmartList.Created);
-
-    isCreating.next(false);
+    await creation.mutate(props);
   };
 
   return {
     createList,
-    isCreating: isCreating.asObservable(),
+    isCreating: creation.isPending,
   };
 }

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useCommentReaction.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useCommentReaction.ts
@@ -1,42 +1,48 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import {
   type Reaction,
 } from '$lib/requests/queries/comments/commentReactionsQuery.ts';
 import { reactCommentRequest } from '$lib/requests/queries/comments/reactCommentRequest.ts';
 import { removeReactionCommentRequest } from '$lib/requests/queries/comments/removeReactionCommentRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
-
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 type UseCommentReactionProps = {
   id: number;
 };
 
 export function useCommentReaction({ id }: UseCommentReactionProps) {
-  const isReacting = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.React);
 
+  const removal = useMutation(defineMutation({
+    key: 'comment:remove-reaction',
+    request: () => removeReactionCommentRequest({ id }),
+    invalidations: [InvalidateAction.React],
+  }));
+
+  const reaction = useMutation(defineMutation({
+    key: 'comment:react',
+    request: async (reaction: Reaction) => {
+      await removeReactionCommentRequest({ id });
+      return await reactCommentRequest({ id, reaction_type: reaction });
+    },
+    invalidations: [InvalidateAction.React],
+  }));
+
+  const isReacting = anyTrue([removal.isPending, reaction.isPending]);
+
   const remove = async () => {
-    isReacting.next(true);
     track({ action: 'remove', type: 'comment' });
 
-    await removeReactionCommentRequest({ id });
-    await invalidate(InvalidateAction.React);
-
-    isReacting.next(false);
+    await removal.mutate();
   };
 
-  const react = async (reaction: Reaction) => {
-    isReacting.next(true);
+  const react = async (type: Reaction) => {
     track({ action: 'add', type: 'comment' });
 
-    await removeReactionCommentRequest({ id });
-    await reactCommentRequest({ id, reaction_type: reaction });
-    await invalidate(InvalidateAction.React);
-
-    isReacting.next(false);
+    await reaction.mutate(type);
   };
 
   return {

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useDeleteComment.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useDeleteComment.ts
@@ -1,11 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { CommentableMediaType } from '$lib/requests/models/CommentableMediaType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaComment } from '$lib/requests/models/MediaComment.ts';
 import { deleteCommentRequest } from '$lib/requests/queries/comments/deleteCommentRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 type UseDeleteCommentProps = {
   comment: MediaComment;
@@ -15,26 +15,26 @@ type UseDeleteCommentProps = {
 export function useDeleteComment(
   { comment, type }: UseDeleteCommentProps,
 ) {
-  const isDeleting = new BehaviorSubject(false);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.DeleteComment);
 
-  const invalidateAction = comment.parentId > 0
-    ? InvalidateAction.Comment.Reply(type)
-    : InvalidateAction.Comment.Post(type);
+  const deletion = useMutation(defineMutation({
+    key: 'comment:delete',
+    request: () => deleteCommentRequest({ id: comment.id }),
+    invalidations: [
+      comment.parentId > 0
+        ? InvalidateAction.Comment.Reply(type)
+        : InvalidateAction.Comment.Post(type),
+    ],
+  }));
 
   const deleteComment = async () => {
-    isDeleting.next(true);
-
     track();
-    await deleteCommentRequest({ id: comment.id });
-    await invalidate(invalidateAction);
 
-    isDeleting.next(false);
+    await deletion.mutate();
   };
 
   return {
     deleteComment,
-    isDeleting: isDeleting.asObservable(),
+    isDeleting: deletion.isPending,
   };
 }

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/usePostComment.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/usePostComment.ts
@@ -1,13 +1,14 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import type { CommentableMediaType } from '$lib/requests/models/CommentableMediaType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { editCommentRequest } from '$lib/requests/queries/comments/editCommentRequest.ts';
 import { postCommentRequest } from '$lib/requests/queries/comments/postCommentRequest.ts';
 import { replyCommentRequest } from '$lib/requests/queries/comments/replyCommentRequest.ts';
 import { CommentError } from '$lib/sections/summary/components/comments/_internal/models/CommentError.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
 import { isHttpError } from '@sveltejs/kit';
 import type { CommentPostParams } from '@trakt/api';
@@ -101,10 +102,14 @@ function toInvalidations(props: PostCommentProps) {
 
 export function usePostComment() {
   const { user } = useUser();
-  const isCommenting = new BehaviorSubject(false);
   const error = new BehaviorSubject<CommentError | null>(null);
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.AddComment);
+
+  const comment = useMutation(defineMutation({
+    key: 'comment:post',
+    request: (props: PostCommentProps) => addCommentRequest(props),
+    invalidations: ({ variables }) => toInvalidations(variables),
+  }));
 
   const postComment = async (props: PostCommentProps) => {
     const current = await resolve(user);
@@ -112,10 +117,6 @@ export function usePostComment() {
     if (!current) {
       return null;
     }
-
-    const invalidateActions = toInvalidations(props);
-
-    isCommenting.next(true);
 
     /*
       FIXME: standardize errors we display in components.
@@ -127,14 +128,9 @@ export function usePostComment() {
       error.next(null);
 
       track({ action: props.commentType });
-      const result = await addCommentRequest(props);
-      await Promise.all(invalidateActions.map(invalidate));
 
-      isCommenting.next(false);
-      return result;
+      return await comment.mutate(props);
     } catch (commentError) {
-      isCommenting.next(false);
-
       if (!isHttpError(commentError)) {
         throw error;
       }
@@ -146,7 +142,7 @@ export function usePostComment() {
 
   return {
     postComment,
-    isCommenting,
+    isCommenting: comment.isPending,
     error,
   };
 }

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
@@ -1,29 +1,19 @@
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts';
 import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
+import { captureInvalidations } from '$test/beds/query/captureInvalidations.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
 import { waitForValue } from '$test/readable/waitForValue.ts';
 import { firstValueFrom } from 'rxjs';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useRatings } from './useRatings.ts';
 
-vi.mock('$lib/stores/useInvalidator.ts');
-
 describe('useRatings', () => {
-  const invalidate = vi.fn(function () {});
-
   beforeEach(() => {
-    setAuthorization(true);
-    invalidate.mockReset();
-
-    (useInvalidator as Mock)
-      .mockReturnValueOnce({ invalidate }) // 1: in useRatings
-      .mockReturnValueOnce({ invalidate }) // 2: in useRatings -> useUser
-      .mockReturnValueOnce({ invalidate }); // 3: in useRatings -> useTrack -> useUser
+    setAuthorization(true); // 3: in useRatings -> useTrack -> useUser
   });
 
   it('should indicate while rating is in progress', async () => {
@@ -101,15 +91,15 @@ describe('useRatings', () => {
       })
     );
 
-    vi.useFakeTimers();
-    addRating(2);
-    await vi.advanceTimersByTimeAsync(500);
-    vi.useRealTimers();
+    const invalidations = await captureInvalidations(async () => {
+      vi.useFakeTimers();
+      addRating(2);
+      await vi.advanceTimersByTimeAsync(500);
+      vi.useRealTimers();
+    });
 
-    expect(invalidate)
-      .toHaveBeenCalledWith(InvalidateAction.Rated('movie'));
-    expect(invalidate)
-      .not.toHaveBeenNthCalledWith(2, InvalidateAction.Favorited('movie'));
+    expect(invalidations).toContain(InvalidateAction.Rated('movie'));
+    expect(invalidations).not.toContain(InvalidateAction.Favorited('movie'));
   });
 
   it('should call invalidate after rating a season', async () => {
@@ -122,12 +112,13 @@ describe('useRatings', () => {
       })
     );
 
-    vi.useFakeTimers();
-    addRating(6);
-    await vi.advanceTimersByTimeAsync(500);
-    vi.useRealTimers();
+    const invalidations = await captureInvalidations(async () => {
+      vi.useFakeTimers();
+      addRating(6);
+      await vi.advanceTimersByTimeAsync(500);
+      vi.useRealTimers();
+    });
 
-    expect(invalidate)
-      .toHaveBeenCalledWith(InvalidateAction.Rated('season'));
+    expect(invalidations).toContain(InvalidateAction.Rated('season'));
   });
 });

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
@@ -9,12 +9,14 @@ import type { OfflineAction } from '$lib/features/offline/models/OfflineAction.t
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
 import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
+import { whenExecuted } from '$lib/features/offline/whenExecuted.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { useLastWatched } from '$lib/features/toast/useLastWatched.ts';
 import {
   InvalidateAction,
   type RatedMediaType,
 } from '$lib/requests/models/InvalidateAction.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { RatingsSyncRequest, RemoveRatingsParams } from '@trakt/api';
 import {
@@ -77,7 +79,6 @@ function toPendingRatedEntry(
 export function useRatings({ type, id }: WatchlistStoreProps) {
   const pendingRating = new BehaviorSubject<null | number>(null);
   const { ratings, favorites } = useUser();
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Rate);
   const { dismiss } = useLastWatched();
 
@@ -150,53 +151,75 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
     }),
   );
 
-  const isSubmitting = new BehaviorSubject<boolean>(false);
+  const ratedInvalidations = [InvalidateAction.Rated(type)];
+
+  const hasRating = async () => {
+    const currentRatings = await firstValueFrom(ratings);
+
+    if (!currentRatings) {
+      return false;
+    }
+
+    switch (type) {
+      case 'movie':
+        return currentRatings.movies.has(id);
+      case 'show':
+        return currentRatings.shows.has(id);
+      case 'season':
+        return currentRatings.seasons.has(id);
+      case 'episode':
+        return currentRatings.episodes.has(id);
+    }
+  };
+
+  // Tracking rides inside the write: the "changed vs added" dimension reads
+  // the pre-write rating, which the submitted state has to cover too.
+  const ratingAdd = useMutation(defineMutation({
+    key: 'rating:add',
+    request: async (newRating: number) => {
+      track({
+        action: await hasRating() ? 'changed' : 'added',
+        rating: newRating,
+      });
+
+      return await executeOrEnqueue({
+        endpoint: 'rating:add',
+        keys: [toMediaKey(type, id)],
+        body: toAddPayload(type, id, newRating),
+        invalidations: ratedInvalidations,
+      });
+    },
+    invalidations: whenExecuted(ratedInvalidations),
+  }));
+
+  const ratingRemove = useMutation(defineMutation({
+    key: 'rating:remove',
+    request: () =>
+      executeOrEnqueue({
+        endpoint: 'rating:remove',
+        keys: [toMediaKey(type, id)],
+        body: toRemovePayload(type, id),
+        invalidations: ratedInvalidations,
+      }),
+    invalidations: whenExecuted(ratedInvalidations),
+  }));
+
+  const isSubmitting = ratingAdd.isPending;
   const ratingSubject = new Subject<number | null>();
 
   ratingSubject.pipe(
     debounceTime(postDelay),
     filter((v): v is number => v !== null),
   ).subscribe(async (newRating) => {
-    isSubmitting.next(true);
+    const outcome = await ratingAdd.mutate(newRating);
 
-    let hasRating = false;
-    const currentRatings = await firstValueFrom(ratings);
-    if (currentRatings) {
-      switch (type) {
-        case 'movie':
-          hasRating = currentRatings.movies.has(id);
-          break;
-        case 'show':
-          hasRating = currentRatings.shows.has(id);
-          break;
-        case 'season':
-          hasRating = currentRatings.seasons.has(id);
-          break;
-        case 'episode':
-          hasRating = currentRatings.episodes.has(id);
-          break;
-      }
-    }
-
-    track({ action: hasRating ? 'changed' : 'added', rating: newRating });
-
-    const addResult = await executeOrEnqueue({
-      endpoint: 'rating:add',
-      keys: [toMediaKey(type, id)],
-      body: toAddPayload(type, id, newRating),
-      invalidations: [InvalidateAction.Rated(type)],
-    });
-    if (addResult === 'executed') {
-      await invalidate(InvalidateAction.Rated(type));
-      if (type !== 'season') {
-        dismiss(id, type, 'rating');
-      }
+    if (outcome === 'executed' && type !== 'season') {
+      dismiss(id, type, 'rating');
     }
 
     // Always clear: a queued rating stays flagged via isQueued, and leaving
     // these pinned would re-disable the stars once it syncs and dequeues.
     pendingRating.next(null);
-    isSubmitting.next(false);
   });
 
   const addRating = (newRating: number) => {
@@ -209,14 +232,10 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
     pendingRating.next(0);
 
     track({ action: 'removed' });
-    const removeResult = await executeOrEnqueue({
-      endpoint: 'rating:remove',
-      keys: [toMediaKey(type, id)],
-      body: toRemovePayload(type, id),
-      invalidations: [InvalidateAction.Rated(type)],
-    });
-    if (removeResult === 'executed') {
-      await invalidate(InvalidateAction.Rated(type));
+
+    const outcome = await ratingRemove.mutate();
+
+    if (outcome === 'executed') {
       pendingRating.next(null);
     }
   };

--- a/projects/client/src/lib/sections/toast/_internal/useStopNowPlaying.ts
+++ b/projects/client/src/lib/sections/toast/_internal/useStopNowPlaying.ts
@@ -1,34 +1,34 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { NowPlayingItem } from '$lib/requests/models/NowPlayingItem.ts';
 import { deleteCheckinRequest } from '$lib/requests/queries/checkin/deleteCheckinRequest.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
 
 export function useStopNowPlaying(nowPlaying: NowPlayingItem) {
-  const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.CheckIn);
 
-  const isStopping = new BehaviorSubject(false);
   const isStoppable = nowPlaying.action === 'checkin';
+
+  const stopping = useMutation(defineMutation({
+    key: 'check-in:stop',
+    request: () => deleteCheckinRequest({}),
+    invalidations: [InvalidateAction.CheckIn],
+  }));
 
   const deleteCheckin = async () => {
     if (!isStoppable) {
       return;
     }
 
-    isStopping.next(true);
-
     track({ type: nowPlaying.type, action: 'stop' });
-    await deleteCheckinRequest({});
-    await invalidate(InvalidateAction.CheckIn);
 
-    isStopping.next(false);
+    await stopping.mutate();
   };
 
   return {
-    isStopping: isStopping.asObservable(),
+    isStopping: stopping.isPending,
     stop: deleteCheckin,
     isStoppable,
   };

--- a/projects/client/src/lib/sections/vip/_internal/useVip.ts
+++ b/projects/client/src/lib/sections/vip/_internal/useVip.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { defineMutation } from '$lib/features/query/defineMutation.ts';
+import { useMutation } from '$lib/features/query/useMutation.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { cancelSubscriptionQuery } from '$lib/requests/vip/cancelSubscriptionQuery.ts';
@@ -8,13 +10,13 @@ import { manageSubscriptionQuery } from '$lib/requests/vip/manageSubscriptionQue
 import { startCheckoutQuery } from '$lib/requests/vip/startCheckoutQuery.ts';
 import { vipPlansQuery } from '$lib/requests/vip/vipPlansQuery.ts';
 import { vipSubscriptionQuery } from '$lib/requests/vip/vipSubscriptionQuery.ts';
-import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { setCacheBuster } from '$lib/utils/url/setCacheBuster.ts';
 import { BehaviorSubject, map } from 'rxjs';
 import type { VipPlan } from './models/VipPlan.ts';
 import type { VipPlanDuration } from '$lib/requests/models/VipPlanDuration.ts';
+import { anyTrue } from '$lib/utils/store/anyTrue.ts';
 
 const elevatedPlanType = new BehaviorSubject<VipPlanDuration>('yearly');
 
@@ -28,61 +30,65 @@ export function useVip() {
   const { track: trackManage } = useTrack(AnalyticsEvent.VipManage);
   const { track: trackCancel } = useTrack(AnalyticsEvent.VipCancel);
 
-  const { invalidate, invalidateAll } = useInvalidator();
-
-  const isFetching = new BehaviorSubject(false);
-
   const subscription = useQuery(vipSubscriptionQuery());
   const plansResult = useQuery(vipPlansQuery());
+
+  const checkout = useMutation(defineMutation({
+    key: 'vip:start-checkout',
+    request: (plan: VipPlan) =>
+      startCheckoutQuery({
+        duration: plan.type,
+        returnUrl: getReturnUrl(),
+      }),
+    invalidations: [],
+  }));
+
+  const management = useMutation(defineMutation({
+    key: 'vip:manage-subscription',
+    request: () => manageSubscriptionQuery({ returnUrl: getReturnUrl() }),
+    invalidations: [],
+  }));
+
+  const cancellation = useMutation(defineMutation({
+    key: 'vip:cancel-subscription',
+    request: () => cancelSubscriptionQuery(),
+    invalidations: [InvalidateAction.Vip.Canceled],
+  }));
+
+  const confirmation = useMutation(defineMutation({
+    key: 'vip:confirm-checkout',
+    request: (sessionId: string) => confirmCheckoutQuery({ sessionId }),
+    invalidations: [
+      InvalidateAction.Vip.Updated,
+      InvalidateAction.User.Settings,
+    ],
+  }));
+
+  const isFetching = anyTrue([
+    checkout.isPending,
+    management.isPending,
+    cancellation.isPending,
+  ]);
 
   return {
     plans: plansResult.pipe(map(($plans) => $plans.data ?? [])),
     startCheckout: async (plan: VipPlan) => {
       trackUpgrade({ plan: plan.type });
 
-      isFetching.next(true);
-      try {
-        return await startCheckoutQuery({
-          duration: plan.type,
-          returnUrl: getReturnUrl(),
-        });
-      } finally {
-        isFetching.next(false);
-      }
+      return await checkout.mutate(plan);
     },
     manageSubscription: async () => {
       trackManage();
 
-      isFetching.next(true);
-      try {
-        return await manageSubscriptionQuery({
-          returnUrl: getReturnUrl(),
-        });
-      } finally {
-        isFetching.next(false);
-      }
+      return await management.mutate();
     },
     cancelSubscription: async () => {
       trackCancel();
 
-      isFetching.next(true);
-      try {
-        const isCancelled = await cancelSubscriptionQuery();
-        await invalidate(InvalidateAction.Vip.Canceled);
-        return isCancelled;
-      } finally {
-        isFetching.next(false);
-      }
+      return await cancellation.mutate();
     },
-    confirmCheckout: async (sessionId: string) => {
-      const success = await confirmCheckoutQuery({ sessionId });
-      await invalidateAll([
-        InvalidateAction.Vip.Updated,
-        InvalidateAction.User.Settings,
-      ]);
-      return success;
-    },
-    isFetching: isFetching.asObservable(),
+    confirmCheckout: (sessionId: string) => confirmation.mutate(sessionId),
+    isFetching,
     subscription: subscription.pipe(map(($details) => $details.data)),
     isLoading: subscription.pipe(map(toLoadingState)),
     elevatedPlanType: elevatedPlanType.asObservable(),

--- a/projects/client/src/lib/stores/useInvalidator.ts
+++ b/projects/client/src/lib/stores/useInvalidator.ts
@@ -1,30 +1,13 @@
 import { browser } from '$app/environment';
-import {
-  InvalidateAction,
-  type InvalidateActionOptions,
-} from '$lib/requests/models/InvalidateAction.ts';
 import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
-import { setMarker } from '../utils/date/Marker.ts';
+import { invalidateActions } from '$lib/features/query/invalidateActions.ts';
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
 
 export function useInvalidator() {
   const client = browser ? useQueryClient() : undefined;
 
-  const invalidateAll = async (actions: InvalidateActionOptions[]) => {
-    actions.forEach(setMarker);
-
-    const hasAuth = actions.includes(InvalidateAction.Auth);
-
-    if (hasAuth) {
-      await client?.removeQueries();
-    }
-
-    await client?.invalidateQueries({
-      predicate: (query) => {
-        return hasAuth ||
-          actions.some((action) => query.queryKey.includes(action));
-      },
-    });
-  };
+  const invalidateAll = (actions: InvalidateActionOptions[]) =>
+    invalidateActions({ client, actions });
 
   const invalidate = (action: InvalidateActionOptions) =>
     invalidateAll([action]);

--- a/projects/client/src/lib/utils/store/anyTrue.spec.ts
+++ b/projects/client/src/lib/utils/store/anyTrue.spec.ts
@@ -1,0 +1,33 @@
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { anyTrue } from './anyTrue.ts';
+
+describe('util: anyTrue', () => {
+  it('should be false without sources', async () => {
+    expect(await firstValueFrom(anyTrue([]))).toBe(false);
+  });
+
+  it('should be false while every source is false', async () => {
+    const sources = [new BehaviorSubject(false), new BehaviorSubject(false)];
+
+    expect(await firstValueFrom(anyTrue(sources))).toBe(false);
+  });
+
+  it('should be true while any source is true', async () => {
+    const sources = [new BehaviorSubject(false), new BehaviorSubject(true)];
+
+    expect(await firstValueFrom(anyTrue(sources))).toBe(true);
+  });
+
+  it('should follow a source flipping back to false', () => {
+    const source = new BehaviorSubject(true);
+    const states: boolean[] = [];
+
+    const subscription = anyTrue([source, new BehaviorSubject(false)])
+      .subscribe((value) => states.push(value));
+    source.next(false);
+    subscription.unsubscribe();
+
+    expect(states).to.deep.equal([true, false]);
+  });
+});

--- a/projects/client/src/lib/utils/store/anyTrue.ts
+++ b/projects/client/src/lib/utils/store/anyTrue.ts
@@ -1,0 +1,11 @@
+import { combineLatest, map, type Observable, of } from 'rxjs';
+
+export function anyTrue(
+  sources: ReadonlyArray<Observable<boolean>>,
+): Observable<boolean> {
+  if (sources.length === 0) {
+    return of(false);
+  }
+
+  return combineLatest(sources).pipe(map((states) => states.some(Boolean)));
+}

--- a/projects/client/src/mocks/handlers/lists.ts
+++ b/projects/client/src/mocks/handlers/lists.ts
@@ -41,4 +41,20 @@ export const lists = [
       return HttpResponse.json(ListedMoviesResponseMock);
     },
   ),
+  http.post(
+    `http://localhost/lists/${
+      assertDefined(SiloListsResponseMock.at(0)).ids.trakt
+    }/like`,
+    () => {
+      return new HttpResponse(null, { status: 204 });
+    },
+  ),
+  http.delete(
+    `http://localhost/lists/${
+      assertDefined(SiloListsResponseMock.at(0)).ids.trakt
+    }/like`,
+    () => {
+      return new HttpResponse(null, { status: 204 });
+    },
+  ),
 ];

--- a/projects/client/src/routes/+layout.ts
+++ b/projects/client/src/routes/+layout.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { setToken } from '$lib/features/auth/token/index.ts';
 import { createIdbPersister } from '$lib/features/query/_internal/createIdbPersister.ts';
+import { createMutationCache } from '$lib/features/query/createMutationCache.ts';
 import { retryDelay } from '$lib/utils/retry/retryDelay.ts';
 import type { LayoutLoad } from '$types/$types.d.ts';
 import { QueryClient } from '@tanstack/query-core';
@@ -15,7 +16,13 @@ const persister = canPersist ? createIdbPersister() : undefined;
 
 export const load: LayoutLoad = ({ data }) => {
   const queryClient = new QueryClient({
+    mutationCache: createMutationCache(),
     defaultOptions: {
+      mutations: {
+        // query-core pauses an offline mutation instead of rejecting it.
+        // Queueing is the offline feature's job, so writes stay eager.
+        networkMode: 'always',
+      },
       queries: {
         enabled: browser,
         retry: 3,

--- a/projects/client/src/routes/+layout.ts
+++ b/projects/client/src/routes/+layout.ts
@@ -28,6 +28,8 @@ export const load: LayoutLoad = ({ data }) => {
         retry: 3,
         retryDelay,
         refetchOnWindowFocus: false,
+        // Mounting the client turns on reconnect refetching for every query.
+        refetchOnReconnect: false,
         persister: persister?.persisterFn,
       },
     },

--- a/projects/client/test/beds/_internal/TestProvider.svelte
+++ b/projects/client/test/beds/_internal/TestProvider.svelte
@@ -7,6 +7,7 @@
   import ToastProvider from "$lib/features/toast/ToastProvider.svelte";
   import { OidcUserMock } from "$mocks/data/auth/OidcUserMock.ts";
   import QueryClientProvider from "$lib/features/query/QueryClientProvider.svelte";
+  import { createMutationCache } from "$lib/features/query/createMutationCache.ts";
   import { QueryClient } from "@tanstack/query-core";
   import type { Snippet } from "svelte";
   import { isAuthorized } from "./isAuthorized.ts";
@@ -15,7 +16,9 @@
 </script>
 
 <!-- TODO: add more providers here as we expand test suite -->
-<QueryClientProvider client={new QueryClient()}>
+<QueryClientProvider
+  client={new QueryClient({ mutationCache: createMutationCache() })}
+>
   <AuthProvider
     isAuthorized={$isAuthorized}
     accessToken={OidcUserMock.access_token}

--- a/projects/client/test/beds/query/captureInvalidations.ts
+++ b/projects/client/test/beds/query/captureInvalidations.ts
@@ -1,0 +1,23 @@
+const MARKER_PREFIX = 'trakt-marker:';
+
+function markerKeys(): string[] {
+  const storage = globalThis.localStorage;
+
+  return Array.from(
+    { length: storage.length },
+    (_, index) => storage.key(index),
+  )
+    .filter((key): key is string => key?.startsWith(MARKER_PREFIX) ?? false);
+}
+
+// Two runs inside the same millisecond stamp the same marker value, so the
+// bed clears first and reports presence rather than diffing timestamps.
+export async function captureInvalidations(
+  run: () => Promise<unknown>,
+): Promise<string[]> {
+  markerKeys().forEach((key) => globalThis.localStorage.removeItem(key));
+
+  await run();
+
+  return markerKeys().map((key) => key.slice(MARKER_PREFIX.length));
+}


### PR DESCRIPTION
Writes were hand-rolled: a `BehaviorSubject` pending flag per hook, a manual `await invalidate(...)` after each request, no retry and no error state. We already ship `@tanstack/query-core`, and the version we pin exports `MutationObserver` / `MutationCache`, so this replaces the bespoke layer with an rxjs bridge over them.

38 write hooks migrated. Exported names stay (`isUpdating`, `isSaving`, `isMarkingAsWatched`, ...), so no component changes.

## The layer

| File | Role |
| --- | --- |
| `features/query/_internal/mutationBridge.ts` | drives `MutationObserver` from an Observable |
| `features/query/useMutation.ts` | `{ mutate, reset, result, isPending }` |
| `features/query/defineMutation.ts` | wraps an existing `*Request` fn, declares its `InvalidateAction` tokens |
| `features/query/createMutationCache.ts` | turns those tokens into invalidations, shared with the test bed |
| `features/query/invalidateActions.ts` | `useInvalidator`'s body as a free function, so the cache and the hook share one implementation |

```ts
const like = useMutation(defineMutation({
  key: 'list:like',
  request: likeListRequest,
  invalidations: [InvalidateAction.List.Like],
}));

const likeList = async () => {
  track({ action: 'like' });
  await like.mutate({ listId: list.id });
};
```

Two details that came out of reading query-core rather than the docs:

- Unlike `queryBridge`, the observer is eager and outlives every subscription. `mutate` is imperative and has to stay callable while nothing renders the result; building an observer touches no cache, the Mutation is only built inside `mutate`.
- `mutate`'s per-call callbacks only run while the observer has listeners, so the bridge drops that argument entirely. Side effects belong on the options or the cache.

Invalidation stays inside the pending window: `mutation.execute` awaits the cache's `onSuccess` before dispatching success, so `isPending` still covers it, exactly like the old `await invalidate(...)` before `isUpdating.next(false)`.

## Invalidations that depend on the write

`invalidations` takes a literal array or a resolver over `{ data, variables }`:

- notes invalidate against the media type carried by the write
- rewatching, settings, plex selection and the api-app writes only invalidate when the API reports success
- offline-aware writes use `whenExecuted`, which keeps the invalidation off the queued path: a queued action carries its own tokens and invalidates when it replays

## Offline writes

Favorites, watchlist, mark-as-watched and ratings keep `executeOrEnqueue` - queueing is still the offline feature's job - but it runs as the mutation's request, so pending state and invalidation come from query-core like every other write.

Reads a write depends on moved inside the request so the pending state covers them: the rating lookup that decides "added" vs "changed", and the removal snapshot an undo needs (`useMarkAsWatched` returns that snapshot as its mutation data). Previously `removeWatched()` left the button enabled during that lookup.

## `QueryClient.mount()`

Separate fix, found while wiring this up. `mount()` is the only thing that subscribes the client to the focus and online managers, and query-core leaves that call to the framework adapter - we have none, so nothing ever called it. Two live consequences:

- the five queries setting `refetchOnWindowFocus: true` have never refetched on focus
- paused mutations would never resume, so no offline-first design could work at all

The provider now mounts on mount and unmounts on destroy. Mounting also activates `refetchOnReconnect` for every query, which is much wider than this fix intends, so that default is pinned off - the focus opt-ins are the only queries whose behavior changes. Happy to flip reconnect on in a follow-up if we want it.

## Tests

Module mocks do not reach modules loaded through the Svelte provider tree, so the specs that asserted invalidation by mocking `useInvalidator` now read the markers `invalidateActions` stamps into storage. `captureInvalidations` mirrors `captureRequests`, and walks storage through `length`/`key` because the test double is Map-backed.

- `mutationBridge.spec.ts` pins: sync idle emission then pending then success, `mutate()` with zero subscribers still resolving and still firing the cache callback, rejection reaching the awaiting caller, `isPending` staying true until invalidation settles, and unsubscribe detaching the observer
- `useLikeList.spec.ts` covers the migrated surface end to end through MSW
- `onlineStatusStore.spec.ts` pins online state against `onlineManager`

## Verification

- `deno task check`: 7790 files, 0 errors, 0 warnings
- `deno task test:unit`: 3212 passed, 10 skipped, 1 failed
- `deno task lint`: no findings in any touched file

The one failure is pre-existing and unrelated: `toMeasurement > converts meters to feet for Myanmar` expects `5.74` and gets `၅.၇၄ ft` from local ICU. Reproduced on a clean tree before this branch.

## Docs

`.agents/rules/requests.md` gains Pattern 5 (mutation hooks) and rewrites Pattern 6 (offline) around it; the offline pattern renumbered from 5 to 6 and the one cross-reference in `components.md` follows.

## Deliberately not in scope

- `useAuth.logout` stays on `useInvalidator`: it is a teardown sequence, not a request paired with an invalidation. Documented as the surviving use.
- 10 `.svelte` components still call `invalidate` inline (profile image upload, plex home users, reorder drawers, raw import, clear data).
- Optimistic `onMutate` + rollback. The bridge supports it; each feature needs its own call on which cache entries to patch.
- Replacing the offline queue with persisted paused mutations. The mount fix unblocks it, but the swap has to build mutation persistence, the endpoint defaults registry, dedupe and the cache-backed pending overlay itself, so it is close to LOC-neutral and would rewrite the queue's tests in the same pass. Worth doing behind a flag with an offline e2e first, not in this PR.
